### PR TITLE
ci: recognize merged test fixture fingerprints

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -3,3 +3,8 @@
 130efb86d03c5be7731e0a9bc6eeef5f343768ac:packages/contracts/src/auth-login.test.ts:generic-api-key:77
 130efb86d03c5be7731e0a9bc6eeef5f343768ac:packages/contracts/src/auth-login.test.ts:generic-api-key:82
 130efb86d03c5be7731e0a9bc6eeef5f343768ac:packages/contracts/src/auth-login.test.ts:generic-api-key:83
+423ed024b1f7b67d63e8ee9d44c8e5484166ba8f:apps/worker/src/notification-payload-secret.test.ts:generic-api-key:19
+423ed024b1f7b67d63e8ee9d44c8e5484166ba8f:packages/contracts/src/auth-login.test.ts:generic-api-key:75
+423ed024b1f7b67d63e8ee9d44c8e5484166ba8f:packages/contracts/src/auth-login.test.ts:generic-api-key:77
+423ed024b1f7b67d63e8ee9d44c8e5484166ba8f:packages/contracts/src/auth-login.test.ts:generic-api-key:82
+423ed024b1f7b67d63e8ee9d44c8e5484166ba8f:packages/contracts/src/auth-login.test.ts:generic-api-key:83


### PR DESCRIPTION
## Summary

- Add the squash-merge commit fingerprints for five known test-only credential fixtures.
- Keep the existing pre-merge fingerprints for branch-history scans.
- Restore the main-branch push workflow secret scan after PR #16.

## Verification

- Gitleaks passed against the exact merged main commit.
- Staged secret scan and diff formatting passed.