### PR TITLE
fix: route registration center brand to homepage

### DIFF
--- a/apps/web/app/components/FlowHeader.vue
+++ b/apps/web/app/components/FlowHeader.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import { useNuxtData } from '#app';
-import { publicEventHomePath, type PublicSiteConfiguration } from '@conference/contracts';
+import type { PublicSiteConfiguration } from '@conference/contracts';
 
-const route = useRoute();
 const api = useConferenceApi();
 const { data: siteConfiguration } = useNuxtData<PublicSiteConfiguration>(
   'public-site-configuration',
 );
-const eventSlug = computed(() => String(route.query.event ?? ''));
 const paymentSurface = computed(() => api.isPaymentSurface());
 
 /**
@@ -17,8 +15,7 @@ const paymentSurface = computed(() => api.isPaymentSurface());
  * @returns Home href for the brand link
  */
 const homeHref = computed(() => {
-  const path = eventSlug.value ? publicEventHomePath(eventSlug.value) : '/';
-  return api.resolveConferenceUrl(path);
+  return api.resolveConferenceUrl('/');
 });
 </script>
 


### PR DESCRIPTION
## 修改内容

- 将“大会议报名中心”品牌入口固定指向站点首页 `/`
- 保留支付域返回大会主域首页的现有处理

## 原因

公共页头此前会读取当前页面的 `event` 参数并生成 `/{eventSlug}`。当该大会专题页不可用时，点击品牌入口会进入 404 页面。

## 影响

报名、订单、票务及会员等共用 `FlowHeader` 的页面都会返回统一站点首页，不再依赖当前大会专题地址。

## 验证

- Web TypeScript 类型检查通过
- Web 测试 15 个文件、80 项测试全部通过
- ESLint 与差异格式检查通过
