### PR TITLE
refactor: simplify cooperation page contact flow

### DIFF
--- a/apps/web/app/pages/apply/cooperation.vue
+++ b/apps/web/app/pages/apply/cooperation.vue
@@ -1,16 +1,46 @@
 <script setup lang="ts">
-import {
-  COOPERATION_TYPE_OPTIONS,
-  CreateCooperationRequestSchema,
-  publicEventHomePath,
-  type CooperationType,
-  type CreateCooperationRequest,
-  type PublicCooperationRequestResult,
-  type PublicEvent,
-  type PublicSiteConfiguration,
-} from '@conference/contracts';
+import { publicEventHomePath, type PublicEvent } from '@conference/contracts';
 import { createError, useAsyncData } from '#imports';
-import { nextTick } from 'vue';
+
+const cooperationDirections = [
+  {
+    no: '01',
+    title: '品牌赞助',
+    body: '联合权益、品牌露出与大会主题共建',
+  },
+  {
+    no: '02',
+    title: '展位展示',
+    body: '产品体验、现场演示与供需连接',
+  },
+  {
+    no: '03',
+    title: '媒体合作',
+    body: '内容报道、嘉宾访谈与传播联动',
+  },
+  {
+    no: '04',
+    title: '内容共创',
+    body: '主题演讲、案例发布与白皮书合作',
+  },
+  {
+    no: '05',
+    title: '社群渠道',
+    body: '定向邀约、联合招募与社群传播',
+  },
+  {
+    no: '06',
+    title: '团队购票',
+    body: '企业组团、席位安排与专属服务',
+  },
+] as const;
+
+const conversationGuide = [
+  { no: '01', label: '所在机构', detail: '简单介绍公司和业务' },
+  { no: '02', label: '合作方向', detail: '说明希望参与的方式' },
+  { no: '03', label: '可用资源', detail: '分享双方可以投入的资源' },
+  { no: '04', label: '合作目标', detail: '说清希望共同达成的结果' },
+] as const;
 
 const api = useConferenceApi();
 const route = useRoute();
@@ -23,11 +53,6 @@ const { data: event, error: eventError } = await useAsyncData<PublicEvent>(
   () => (eventSlug.value ? api.getEvent(eventSlug.value) : api.getHomepageEvent()),
   { deep: false, watch: [eventSlug] },
 );
-const { data: siteConfiguration } = await useAsyncData<PublicSiteConfiguration>(
-  'public-site-configuration',
-  () => api.getSiteConfiguration(),
-  { deep: false },
-);
 if (eventError.value || !event.value) {
   const failure = eventError.value as { statusCode?: number; status?: number } | null;
   throw createError({
@@ -35,102 +60,23 @@ if (eventError.value || !event.value) {
     statusMessage:
       (failure?.statusCode ?? failure?.status) === 404
         ? '大会不存在或尚未公开'
-        : '大会合作申请暂时不可用',
+        : '大会合作页面暂时不可用',
   });
 }
 
-useHead(() => ({ title: `合作申请 · ${event.value?.name ?? '大会'}` }));
+useHead(() => ({ title: `合作联系 · ${event.value?.name ?? '大会'}` }));
 
-const form = reactive({
-  cooperationTypes: [] as CooperationType[],
-  companyName: '',
-  contactName: '',
-  contactTitle: '',
-  mobile: '',
-  email: '',
-  wechatId: '',
-  message: '',
-  consentAccepted: false,
-});
-const fieldErrors = reactive<Record<string, string>>({});
-const submitError = ref('');
-const pending = ref(false);
-const result = ref<PublicCooperationRequestResult | null>(null);
-const requestKey = ref('');
 const homeHref = computed(() => publicEventHomePath(event.value!.slug));
-const privacyUrl = computed(() => siteConfiguration.value?.customerAccounts.privacyUrl ?? '');
-
-function clearField(field: string) {
-  delete fieldErrors[field];
-  submitError.value = '';
-}
-
-function toggleDirection(direction: CooperationType) {
-  const index = form.cooperationTypes.indexOf(direction);
-  if (index >= 0) form.cooperationTypes.splice(index, 1);
-  else if (form.cooperationTypes.length < 3) form.cooperationTypes.push(direction);
-  clearField('cooperationTypes');
-}
-
-function validate(): CreateCooperationRequest | null {
-  Object.keys(fieldErrors).forEach((key) => delete fieldErrors[key]);
-  const parsed = CreateCooperationRequestSchema.safeParse({
-    eventId: event.value!.id,
-    ...form,
-  });
-  if (parsed.success) return parsed.data;
-  for (const issue of parsed.error.issues) {
-    const field = String(issue.path[0] ?? 'form');
-    fieldErrors[field] ||= issue.message;
-  }
-  return null;
-}
-
-function failureMessage(error: unknown) {
-  const failure = error as {
-    status?: number;
-    statusCode?: number;
-    data?: { message?: string };
-  };
-  const status = failure.statusCode ?? failure.status;
-  if (status === 429) return '提交较频繁，请稍候一分钟再试。表单内容已为你保留。';
-  return failure.data?.message ?? '提交暂时失败，请检查网络后重试。表单内容已为你保留。';
-}
-
-async function submit() {
-  if (pending.value) return;
-  const input = validate();
-  if (!input) {
-    submitError.value = '请检查标注的内容后再提交。';
-    await nextTick();
-    document.querySelector<HTMLElement>('[aria-invalid="true"]')?.focus();
-    return;
-  }
-  pending.value = true;
-  submitError.value = '';
-  requestKey.value ||= `cooperation-${crypto.randomUUID()}`;
-  try {
-    result.value = await api.createCooperationRequest(input, requestKey.value);
-    window.scrollTo({
-      top: 0,
-      behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
-    });
-  } catch (error) {
-    submitError.value = failureMessage(error);
-  } finally {
-    pending.value = false;
-  }
-}
 </script>
 
 <template>
   <div class="conference-page cooperation-page">
-    <nav id="nav" class="scrolled cooperation-nav" aria-label="合作申请页导航">
+    <nav id="nav" class="scrolled cooperation-nav" aria-label="合作联系页导航">
       <div class="nav-inner">
         <NuxtLink :to="homeHref" class="logo" aria-label="返回大会首页">
           <span class="logo-mark">G</span>
           <span>{{ event?.shortName || event?.name || '大会官网' }}</span>
-          <span class="logo-sub">合作申请</span>
+          <span class="logo-sub">合作联系</span>
         </NuxtLink>
         <div class="nav-cta">
           <NuxtLink class="btn btn-outline cooperation-home-link" :to="homeHref">
@@ -142,235 +88,96 @@ async function submit() {
       </div>
     </nav>
 
-    <main
-      v-if="result"
-      id="main-content"
-      class="flow-shell cooperation-success"
-      aria-labelledby="success-title"
-    >
-      <section class="state-panel">
-        <div class="state-icon" aria-hidden="true">✓</div>
-        <p class="flow-eyebrow">REQUEST RECEIVED</p>
-        <h1 id="success-title">合作想法已收到</h1>
-        <p>{{ result.eventName }} 大会团队将根据你留下的联系方式推进沟通。请保留以下申请编号。</p>
-        <dl class="cooperation-receipt">
-          <div>
-            <dt>申请编号</dt>
-            <dd>{{ result.requestNo }}</dd>
-          </div>
-          <div>
-            <dt>提交时间</dt>
-            <dd>{{ new Date(result.submittedAt).toLocaleString('zh-CN') }}</dd>
-          </div>
-        </dl>
-        <NuxtLink class="flow-action" :to="homeHref">返回大会首页</NuxtLink>
-      </section>
-    </main>
-
-    <main v-else id="main-content" class="flow-shell cooperation-shell" tabindex="-1">
+    <main id="main-content" class="cooperation-shell" tabindex="-1">
       <header class="cooperation-intro">
-        <div>
+        <div class="cooperation-intro__copy">
           <p class="flow-eyebrow">PARTNERSHIP</p>
           <h1 class="flow-title">一起把好内容带到现场</h1>
           <p class="flow-lead">
-            申请与
+            围绕品牌、产品、媒体、内容、社群和团队参会，与
             {{ event?.name }}
-            展开品牌、媒体、内容、社群或团队购票合作。先告诉我们你的设想，大会团队会据此安排后续沟通。
+            一起创造更有价值的现场连接。
           </p>
         </div>
-        <div class="cooperation-brief" aria-label="申请说明">
-          <span>01</span>
-          <p><strong>选择方向</strong>最多选择 3 项</p>
-          <span>02</span>
-          <p><strong>留下设想</strong>说明资源与合作目标</p>
-          <span>03</span>
-          <p><strong>团队跟进</strong>提交后进入大会后台</p>
+        <div class="cooperation-intro__aside">
+          <span>PARTNER WITH US</span>
+          <strong>合作从一次清晰的对话开始。</strong>
+          <p>添加大会发起人微信，直接说明你的想法与资源。</p>
         </div>
       </header>
 
-      <form
-        id="cooperation-form"
-        class="flow-card cooperation-form"
-        novalidate
-        @submit.prevent="submit"
-      >
-        <div class="flow-card__head">
-          <h2>合作申请</h2>
-          <p><em>*</em> 为必填项。手机、邮箱、微信号至少填写一项。</p>
+      <section class="cooperation-layout" aria-label="合作方向与联系方式">
+        <div class="cooperation-scope">
+          <div class="cooperation-section-head">
+            <p class="flow-eyebrow">WHAT WE CAN BUILD</p>
+            <h2>可以一起做什么</h2>
+            <p>选择一个最接近的方向开启沟通，具体形式可以根据双方资源继续展开。</p>
+          </div>
+
+          <ol class="cooperation-scope__list">
+            <li v-for="direction in cooperationDirections" :key="direction.no">
+              <span>{{ direction.no }}</span>
+              <div>
+                <h3>{{ direction.title }}</h3>
+                <p>{{ direction.body }}</p>
+              </div>
+            </li>
+          </ol>
+
+          <p class="cooperation-scope__other">
+            有其他合作想法，也欢迎直接沟通。我们会结合大会内容和现场安排一起判断可行方式。
+          </p>
         </div>
-        <div class="flow-card__body">
-          <fieldset
-            class="direction-fieldset"
-            :aria-invalid="Boolean(fieldErrors.cooperationTypes)"
-            :aria-describedby="fieldErrors.cooperationTypes ? 'cooperation-types-error' : undefined"
+
+        <aside class="direct-contact" aria-labelledby="direct-contact-title">
+          <p class="direct-contact__eyebrow">DIRECT CONTACT</p>
+          <h2 id="direct-contact-title">加微信，聊合作</h2>
+          <p class="direct-contact__lead">微信沟通更直接，也方便后续发送合作资料。</p>
+
+          <div
+            class="direct-contact__qr"
+            role="img"
+            aria-label="姚金刚微信二维码待补充"
+            data-contact-qr-placeholder
           >
-            <legend>
-              合作方向 <em>*</em><small>已选 {{ form.cooperationTypes.length }} / 3</small>
-            </legend>
-            <div class="direction-options">
-              <label
-                v-for="option in COOPERATION_TYPE_OPTIONS"
-                :key="option.value"
-                class="direction-option"
-                :class="{ 'is-selected': form.cooperationTypes.includes(option.value) }"
-              >
-                <input
-                  type="checkbox"
-                  :checked="form.cooperationTypes.includes(option.value)"
-                  :disabled="
-                    !form.cooperationTypes.includes(option.value) &&
-                      form.cooperationTypes.length >= 3
-                  "
-                  @change="toggleDirection(option.value)"
-                />
-                <span>{{ option.label }}</span>
-              </label>
-            </div>
-            <p v-if="fieldErrors.cooperationTypes" id="cooperation-types-error" class="field-error">
-              {{ fieldErrors.cooperationTypes }}
-            </p>
-          </fieldset>
-
-          <h3 class="form-section-title">机构与联系人</h3>
-          <div class="form-grid">
-            <div class="form-field is-wide">
-              <label for="companyName">公司或机构名称 <em>*</em></label>
-              <input
-                id="companyName"
-                v-model="form.companyName"
-                class="form-input"
-                autocomplete="organization"
-                maxlength="160"
-                placeholder="例如：深圳湾数字商业中心"
-                :aria-invalid="Boolean(fieldErrors.companyName)"
-                @input="clearField('companyName')"
+            <svg viewBox="0 0 48 48" aria-hidden="true">
+              <path
+                d="M5 19V5h14v14H5Zm4-4h6V9H9v6Zm20 4V5h14v14H29Zm4-4h6V9h-6v6ZM5 43V29h14v14H5Zm4-4h6v-6H9v6Z"
               />
-              <p v-if="fieldErrors.companyName" class="field-error">
-                {{ fieldErrors.companyName }}
-              </p>
-            </div>
-            <div class="form-field">
-              <label for="contactName">联系人 <em>*</em></label>
-              <input
-                id="contactName"
-                v-model="form.contactName"
-                class="form-input"
-                autocomplete="name"
-                maxlength="80"
-                placeholder="请输入姓名"
-                :aria-invalid="Boolean(fieldErrors.contactName)"
-                @input="clearField('contactName')"
-              />
-              <p v-if="fieldErrors.contactName" class="field-error">
-                {{ fieldErrors.contactName }}
-              </p>
-            </div>
-            <div class="form-field">
-              <label for="contactTitle">职位</label>
-              <input
-                id="contactTitle"
-                v-model="form.contactTitle"
-                class="form-input"
-                autocomplete="organization-title"
-                maxlength="80"
-                placeholder="例如：品牌合作负责人"
-                @input="clearField('contactTitle')"
-              />
-            </div>
+              <path d="M29 29h5v5h-5v-5Zm9 0h5v5h-5v-5Zm-9 9h5v5h-5v-5Zm9 0h5v5h-5v-5Z" />
+            </svg>
+            <strong>微信二维码待补充</strong>
+            <span>收到原图后直接替换</span>
           </div>
 
-          <h3 class="form-section-title">联系方式</h3>
-          <div class="form-grid">
-            <div class="form-field">
-              <label for="mobile">手机</label>
-              <input
-                id="mobile"
-                v-model="form.mobile"
-                class="form-input"
-                type="tel"
-                autocomplete="tel"
-                inputmode="tel"
-                placeholder="中国大陆手机号"
-                :aria-invalid="Boolean(fieldErrors.mobile)"
-                @input="clearField('mobile')"
-              />
-              <p v-if="fieldErrors.mobile" class="field-error">{{ fieldErrors.mobile }}</p>
+          <dl class="direct-contact__details">
+            <div>
+              <dt>微信联系人</dt>
+              <dd>姚金刚</dd>
             </div>
-            <div class="form-field">
-              <label for="email">邮箱</label>
-              <input
-                id="email"
-                v-model="form.email"
-                class="form-input"
-                type="email"
-                autocomplete="email"
-                maxlength="255"
-                placeholder="name@company.com"
-                :aria-invalid="Boolean(fieldErrors.email)"
-                @input="
-                  clearField('email');
-                  clearField('mobile');
-                "
-              />
-              <p v-if="fieldErrors.email" class="field-error">{{ fieldErrors.email }}</p>
+            <div>
+              <dt>微信号</dt>
+              <dd>姚金刚</dd>
             </div>
-            <div class="form-field is-wide">
-              <label for="wechatId">微信号</label>
-              <input
-                id="wechatId"
-                v-model="form.wechatId"
-                class="form-input"
-                maxlength="80"
-                placeholder="便于大会团队添加联系"
-                :aria-invalid="Boolean(fieldErrors.wechatId)"
-                @input="
-                  clearField('wechatId');
-                  clearField('mobile');
-                "
-              />
-              <p v-if="fieldErrors.wechatId" class="field-error">{{ fieldErrors.wechatId }}</p>
-            </div>
-          </div>
+          </dl>
 
-          <h3 class="form-section-title">合作设想</h3>
-          <div class="form-field">
-            <label for="message">简单介绍你的资源、目标或初步想法 <em>*</em></label>
-            <textarea
-              id="message"
-              v-model="form.message"
-              class="form-input cooperation-message"
-              maxlength="1000"
-              placeholder="例如：希望联合发布行业白皮书，并在大会现场设置品牌体验区……"
-              :aria-invalid="Boolean(fieldErrors.message)"
-              @input="clearField('message')"
-            ></textarea>
-            <span class="character-count">{{ form.message.length }} / 1000</span>
-            <p v-if="fieldErrors.message" class="field-error">{{ fieldErrors.message }}</p>
-          </div>
+          <p class="direct-contact__note">添加时请备注「大会合作＋公司名」</p>
+        </aside>
+      </section>
 
-          <label class="cooperation-consent" :class="{ 'has-error': fieldErrors.consentAccepted }">
-            <input
-              v-model="form.consentAccepted"
-              type="checkbox"
-              :aria-invalid="Boolean(fieldErrors.consentAccepted)"
-              @change="clearField('consentAccepted')"
-            />
-            <span>
-              我同意大会团队为处理本次合作申请使用上述信息
-              <a v-if="privacyUrl" :href="privacyUrl" target="_blank" rel="noopener noreferrer">查看隐私说明</a>
-            </span>
-          </label>
-          <p v-if="fieldErrors.consentAccepted" class="field-error">请确认信息使用说明后提交</p>
-
-          <p v-if="submitError" class="form-error" role="alert">{{ submitError }}</p>
-          <div class="cooperation-actions">
-            <button class="flow-action" type="submit" :disabled="pending">
-              {{ pending ? '正在提交…' : '提交合作申请' }}
-            </button>
-            <NuxtLink class="cooperation-back" :to="homeHref">返回大会首页</NuxtLink>
-          </div>
+      <section class="conversation-guide" aria-labelledby="conversation-guide-title">
+        <div class="conversation-guide__head">
+          <p class="flow-eyebrow">LET'S TALK</p>
+          <h2 id="conversation-guide-title">沟通时带上这些信息</h2>
         </div>
-      </form>
+        <ol>
+          <li v-for="item in conversationGuide" :key="item.no">
+            <span>{{ item.no }}</span>
+            <strong>{{ item.label }}</strong>
+            <p>{{ item.detail }}</p>
+          </li>
+        </ol>
+      </section>
     </main>
   </div>
 </template>
@@ -393,16 +200,16 @@ async function submit() {
 .cooperation-shell {
   width: 100%;
   max-width: var(--max-w);
+  margin: 0 auto;
   padding: 132px var(--pad) 84px;
 }
 
 .cooperation-intro {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;
-  align-items: start;
-  gap: clamp(48px, 6vw, 80px);
-  margin-bottom: 42px;
-  padding-bottom: 42px;
+  align-items: end;
+  gap: clamp(48px, 6vw, 82px);
+  padding-bottom: 46px;
   border-bottom: 1px solid var(--line);
 }
 
@@ -417,258 +224,300 @@ async function submit() {
   margin-top: 20px;
   font-size: 16px;
   line-height: 1.8;
+  text-wrap: pretty;
 }
 
-.cooperation-brief {
+.cooperation-intro__aside {
   display: grid;
-  grid-template-columns: 34px 1fr;
-  gap: 18px 14px;
-  padding: 22px 0 0;
+  gap: 9px;
+  padding-top: 20px;
   border-top: 2px solid var(--accent);
 }
 
-.cooperation-brief > span {
+.cooperation-intro__aside > span {
   color: var(--accent);
   font-family: var(--conference-font-mono);
-  font-size: 12px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
 }
 
-.cooperation-brief p {
-  display: grid;
-  gap: 3px;
+.cooperation-intro__aside strong {
+  font-size: 17px;
+  line-height: 1.5;
+}
+
+.cooperation-intro__aside p {
   margin: 0;
   color: var(--ink-muted);
   font-size: 13px;
-  line-height: 1.55;
-}
-
-.cooperation-brief strong {
-  color: var(--ink);
-  font-size: 14px;
-}
-
-.cooperation-form {
-  width: 100%;
-  overflow: hidden;
-  border-color: var(--line);
-  border-radius: 0 0 var(--radius) var(--radius);
-  box-shadow: var(--shadow);
-}
-
-.cooperation-form .flow-card__head {
-  padding: 26px 32px 22px;
-}
-
-.cooperation-form .flow-card__body {
-  padding: 32px;
-}
-
-.flow-card__head em,
-.direction-fieldset em {
-  color: var(--conference-red);
-  font-style: normal;
-}
-
-.direction-fieldset {
-  min-width: 0;
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
-.direction-fieldset legend {
-  width: 100%;
-  margin-bottom: 12px;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.direction-fieldset legend small {
-  float: right;
-  color: var(--conference-ink-muted);
-  font-weight: 500;
-}
-
-.direction-options {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.direction-option {
-  position: relative;
-  min-height: 42px;
-  display: inline-flex;
-  align-items: center;
-  padding: 0 15px;
-  border: 1px solid #d4d4d8;
-  border-radius: 999px;
-  background: #fff;
-  color: var(--conference-ink-soft);
-  cursor: pointer;
-  font-size: 13px;
-  transition:
-    border-color 140ms ease,
-    background 140ms ease,
-    color 140ms ease,
-    transform 140ms ease;
-}
-
-.direction-option:active {
-  transform: scale(0.98);
-}
-
-.direction-option.is-selected {
-  border-color: var(--conference-primary);
-  background: var(--conference-primary-soft);
-  color: var(--conference-primary-dark);
-  font-weight: 700;
-}
-
-.direction-option:has(input:focus-visible) {
-  outline: 3px solid rgb(37 99 235 / 18%);
-  outline-offset: 2px;
-}
-
-.direction-option:has(input:disabled) {
-  cursor: not-allowed;
-  opacity: 0.45;
-}
-
-.direction-option input {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  opacity: 0;
-}
-
-.cooperation-message {
-  min-height: 150px;
-  resize: vertical;
   line-height: 1.7;
 }
 
-.character-count {
-  justify-self: end;
-  color: var(--conference-ink-muted);
+.cooperation-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  align-items: start;
+  gap: clamp(40px, 5vw, 64px);
+  padding: 52px 0 56px;
+}
+
+.cooperation-section-head {
+  max-width: 620px;
+  margin-bottom: 25px;
+}
+
+.cooperation-section-head h2,
+.conversation-guide__head h2 {
+  margin: 0;
+  font-size: clamp(26px, 3vw, 36px);
+  line-height: 1.18;
+  text-wrap: balance;
+}
+
+.cooperation-section-head > p:last-child {
+  margin: 12px 0 0;
+  color: var(--ink-soft);
+  font-size: 14px;
+  line-height: 1.75;
+  text-wrap: pretty;
+}
+
+.cooperation-scope__list {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.cooperation-scope__list li {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 12px;
+  min-width: 0;
+  padding: 21px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.cooperation-scope__list li:nth-child(odd) {
+  padding-right: 24px;
+  border-right: 1px solid var(--line);
+}
+
+.cooperation-scope__list li:nth-child(even) {
+  padding-left: 24px;
+}
+
+.cooperation-scope__list li > span {
+  padding-top: 3px;
+  color: var(--accent);
   font-family: var(--conference-font-mono);
   font-size: 11px;
 }
 
-.field-error {
-  margin: 0;
-  color: #b91c1c;
-  font-size: 12px;
+.cooperation-scope__list h3 {
+  margin: 0 0 4px;
+  font-size: 15px;
   line-height: 1.5;
 }
 
-.form-input[aria-invalid='true'] {
-  border-color: #ef4444;
-}
-
-.cooperation-consent {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  margin-top: 28px;
-  color: var(--conference-ink-soft);
-  font-size: 13px;
+.cooperation-scope__list p {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 12px;
   line-height: 1.65;
 }
 
-.cooperation-consent input {
-  width: 17px;
-  height: 17px;
-  flex: 0 0 auto;
-  margin-top: 2px;
-  accent-color: var(--conference-primary);
-}
-
-.cooperation-consent a {
-  margin-left: 5px;
-  color: var(--conference-primary);
-}
-
-.cooperation-actions {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  margin-top: 26px;
-}
-
-.cooperation-actions .flow-action:active {
-  transform: scale(0.98);
-}
-
-.cooperation-back {
-  color: var(--conference-ink-muted);
+.cooperation-scope__other {
+  margin: 22px 0 0;
+  color: var(--ink-soft);
   font-size: 13px;
-  text-underline-offset: 4px;
+  line-height: 1.75;
+  text-wrap: pretty;
 }
 
-.cooperation-success {
-  width: 100%;
-  max-width: var(--max-w);
-  padding: 148px var(--pad) 84px;
+.direct-contact {
+  padding: 34px 32px 32px;
+  border-radius: 0 0 18px 18px;
+  background: #1d4ed8;
+  color: #eff6ff;
 }
 
-.cooperation-success .flow-eyebrow {
-  justify-content: center;
-}
-
-.cooperation-receipt {
-  max-width: 540px;
-  margin: 0 auto 28px;
-  border-top: 1px solid var(--conference-line);
-  border-bottom: 1px solid var(--conference-line);
-}
-
-.cooperation-receipt > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 24px;
-  padding: 14px 0;
-}
-
-.cooperation-receipt > div + div {
-  border-top: 1px solid var(--conference-line);
-}
-
-.cooperation-receipt dt {
-  color: var(--conference-ink-muted);
-  font-size: 13px;
-}
-
-.cooperation-receipt dd {
-  margin: 0;
+.direct-contact__eyebrow {
+  margin: 0 0 9px;
+  color: #bfdbfe;
   font-family: var(--conference-font-mono);
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 700;
-  overflow-wrap: anywhere;
+  letter-spacing: 0.13em;
+}
+
+.direct-contact h2 {
+  margin: 0;
+  color: #f8fafc;
+  font-size: 28px;
+  line-height: 1.2;
+  text-wrap: balance;
+}
+
+.direct-contact__lead {
+  margin: 10px 0 24px;
+  color: rgb(239 246 255 / 76%);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.direct-contact__qr {
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+  width: 190px;
+  margin: 0 auto 25px;
+  padding: 24px 16px 17px;
+  border-radius: 8px;
+  outline: 1px solid rgb(23 23 23 / 10%);
+  outline-offset: -1px;
+  background: #f8fafc;
+  color: #1d4ed8;
+}
+
+.direct-contact__qr svg {
+  width: 80px;
+  height: 80px;
+  fill: currentColor;
+}
+
+.direct-contact__qr strong {
+  color: #334155;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.direct-contact__qr span {
+  color: #64748b;
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.direct-contact__details {
+  margin: 0;
+  border-top: 1px solid rgb(239 246 255 / 24%);
+  border-bottom: 1px solid rgb(239 246 255 / 24%);
+}
+
+.direct-contact__details > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 12px 0;
+}
+
+.direct-contact__details > div + div {
+  border-top: 1px solid rgb(239 246 255 / 18%);
+}
+
+.direct-contact__details dt {
+  color: rgb(239 246 255 / 58%);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+}
+
+.direct-contact__details dd {
+  margin: 0;
+  color: #f8fafc;
+  font-size: 15px;
+  font-weight: 750;
+}
+
+.direct-contact__note {
+  margin: 18px 0 0;
+  color: rgb(239 246 255 / 72%);
+  font-size: 12px;
+  line-height: 1.7;
+  text-align: center;
+}
+
+.conversation-guide {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.8fr) minmax(0, 2.2fr);
+  gap: clamp(40px, 6vw, 76px);
+  padding: 42px 0 0;
+  border-top: 1px solid var(--line);
+}
+
+.conversation-guide ol {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.conversation-guide li {
+  min-width: 0;
+  padding: 0 18px;
+}
+
+.conversation-guide li:first-child {
+  padding-left: 0;
+}
+
+.conversation-guide li + li {
+  border-left: 1px solid var(--line);
+}
+
+.conversation-guide li > span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--accent);
+  font-family: var(--conference-font-mono);
+  font-size: 11px;
+}
+
+.conversation-guide li strong {
+  font-size: 14px;
+}
+
+.conversation-guide li p {
+  margin: 5px 0 0;
+  color: var(--ink-muted);
+  font-size: 11px;
+  line-height: 1.65;
 }
 
 @media (max-width: 900px) {
   .cooperation-intro {
     grid-template-columns: 1fr;
+    align-items: start;
     gap: 30px;
   }
 
-  .cooperation-brief {
-    grid-template-columns: 34px minmax(0, 1fr) 34px minmax(0, 1fr) 34px minmax(0, 1fr);
-    column-gap: 10px;
+  .cooperation-layout {
+    grid-template-columns: minmax(0, 1fr) 310px;
+    gap: 32px;
+  }
+
+  .direct-contact {
+    padding-inline: 26px;
+  }
+
+  .conversation-guide {
+    grid-template-columns: 1fr;
+    gap: 28px;
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 700px) {
   .cooperation-shell {
     padding: 104px 20px 56px;
   }
 
   .cooperation-intro {
-    gap: 26px;
-    margin-bottom: 28px;
-    padding-bottom: 30px;
+    gap: 25px;
+    padding-bottom: 32px;
   }
 
   .cooperation-intro .flow-title {
@@ -683,52 +532,65 @@ async function submit() {
     line-height: 1.75;
   }
 
-  .cooperation-brief {
-    grid-template-columns: 30px 1fr;
-    gap: 14px 10px;
-    padding-top: 18px;
+  .cooperation-layout {
+    grid-template-columns: 1fr;
+    gap: 40px;
+    padding: 32px 0 46px;
   }
 
-  .cooperation-brief > span,
-  .cooperation-brief p {
-    grid-row: auto;
+  .direct-contact {
+    order: -1;
+    padding: 30px 22px 27px;
   }
 
-  .cooperation-form .flow-card__head,
-  .cooperation-form .flow-card__body {
-    padding: 22px 18px;
+  .direct-contact h2 {
+    font-size: 27px;
   }
 
-  .direction-options {
-    gap: 8px;
+  .direct-contact__qr {
+    width: 176px;
   }
 
-  .direction-option {
-    min-height: 40px;
-    padding-inline: 13px;
+  .cooperation-section-head {
+    margin-bottom: 20px;
   }
 
-  .cooperation-actions {
-    align-items: stretch;
-    flex-direction: column;
+  .cooperation-scope__list {
+    grid-template-columns: 1fr;
   }
 
-  .cooperation-actions .flow-action {
-    width: 100%;
+  .cooperation-scope__list li:nth-child(odd),
+  .cooperation-scope__list li:nth-child(even) {
+    padding: 18px 0;
+    border-right: 0;
   }
 
-  .cooperation-back {
-    text-align: center;
+  .conversation-guide {
+    padding-top: 34px;
   }
 
-  .cooperation-receipt > div {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 5px;
+  .conversation-guide ol {
+    grid-template-columns: 1fr 1fr;
   }
 
-  .cooperation-success {
-    padding: 120px 20px 56px;
+  .conversation-guide li,
+  .conversation-guide li:first-child {
+    padding: 17px 16px;
+    border-top: 1px solid var(--line);
+  }
+
+  .conversation-guide li:nth-child(odd) {
+    padding-left: 0;
+    border-left: 0;
+  }
+
+  .conversation-guide li:nth-child(even) {
+    padding-right: 0;
+    border-left: 1px solid var(--line);
+  }
+
+  .conversation-guide li > span {
+    margin-bottom: 8px;
   }
 }
 
@@ -739,13 +601,6 @@ async function submit() {
 
   .cooperation-home-link__mobile {
     display: inline;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .direction-option,
-  .cooperation-actions .flow-action {
-    transition: none;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- remove the cooperation application form and client-side submission flow
- present six cooperation directions in a concise editorial layout
- prioritize direct WeChat contact and QR placement, including mobile reordering
- add a short conversation checklist

## Why

The prior form created an operations review workflow for a page whose main purpose is to start a partnership conversation. This version sends visitors directly to the event initiator and keeps the page informational.

## Impact

The public cooperation page no longer submits new cooperation requests. Existing backend APIs and historical admin records remain unchanged. The QR slot is explicitly labeled as pending until the real asset is provided.

## Checks

- `pnpm check`
- browser verification at 1280px, 375px, and 320px
