### PR TITLE
feat: add guarded production deployment workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - 生产发布前必须阅读 `docs/production-deployment-runbook.md`。
 - 唯一上游仓库为 `https://github.com/yaojingang/TokEMS.git`，生产代码只允许来自已合并且 CI 通过的 `origin/main`。
 - 生产服务器源码目录为 `/www/wwwroot/TokEMS`。宝塔站点目录 `/www/dk_project/wwwroot/hui.ailingdaoli.com` 只承载站点和反向代理配置，禁止在该目录拉取代码、构建镜像或执行数据库迁移。
+- 生产环境文件固定为 `/etc/tokems/production.env`，目录权限为 `root:root 0700`，文件权限为 `root:root 0600`。生产 Compose 和发布脚本禁止读取 Git 工作区中的实时 `.env`。
 - 服务器分支 `production` 跟踪 `origin/main`。发布前确认工作区干净，并确认服务器 `HEAD` 与 `origin/main` 完全一致。
 - 每次生产变更都要先创建数据库备份、记录当前提交和容器状态，并为当前应用镜像添加 `rollback-<时间戳>` 标签。
 - Docker 构建和运行必须使用同一组 `BUILD_SHA`、`BUILD_TIME`、`BUILD_MIGRATION`、`BUILD_MIGRATION_HASH`。任何值为 `unknown` 时禁止切换生产流量。
@@ -16,6 +17,7 @@
 - 规范快照包含当前公开发布内容，以及大会基础设置、模板草稿、当前指针引用的发布版本、首页绑定、票种定义与容量、报名表、嘉宾、议程、FAQ、SEO、公开站点设置、蓝图、核销清单、通知模板、AI 文案提示、模板素材和所有被纳入模板定义引用的 HTML 文档。未被当前发布、绑定或默认设置引用的历史版本，以及销量、报名用户、会员资料、订单、支付、票证、发票和审计记录不得进入快照。
 - 管理员账号、姓名、邮箱、密码、权限身份，以及 API 地址、密钥、令牌、Cookie、第三方集成、支付、短信和对象存储凭据不得进入规范快照。管理员信息继续只从部署环境读取。
 - 禁止把 `git reset --hard`、`git clean`、`docker system prune`、`docker compose down -v`、删卷、清库或数据库覆盖恢复写入常规发布流程。
+- 解除生产写冻结前必须启动独立的 systemd 监督单元；恢复标记仍存在且部署控制器退出时，该单元持续停止 API 和 Worker，直至确认写容器已经停止。
 - 发布完成后必须同时验证容器健康、服务器本机 HTTP、公网 HTTP、构建版本、迁移哈希、公开大会内容和生产数据计数。
 - `.env`、数据库连接、密钥、令牌和第三方凭据不得写入 Git、日志、Issue、PR 或发布记录。检查环境时只输出允许公开的键。
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ CMD ["node", "dist/main.js"]
 FROM ${NODE_IMAGE} AS worker
 
 ENV NODE_ENV=production
+LABEL com.tokems.worker-ready-protocol="1"
 
 WORKDIR /app
 

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,6 +1,6 @@
 import { createHash, createHmac, randomBytes, randomUUID } from 'node:crypto';
 import { createReadStream } from 'node:fs';
-import { appendFile, stat, unlink, writeFile } from 'node:fs/promises';
+import { appendFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Queue, UnrecoverableError, Worker, type ConnectionOptions, type Job } from 'bullmq';
@@ -124,6 +124,8 @@ import {
 
 const queueName = 'conference-domain-events';
 const htmlImportQueueName = 'conference-html-template-imports';
+const workerReadyFile = join(tmpdir(), 'tokems-worker-ready.json');
+const workerReadyTempFile = join(tmpdir(), 'tokems-worker-ready.json.tmp');
 const notificationClaimLeaseMs = 25_000;
 const pollInterval = Number(process.env.OUTBOX_POLL_INTERVAL_MS ?? 2_000);
 const concurrency = Number(process.env.WORKER_CONCURRENCY ?? 5);
@@ -3855,6 +3857,8 @@ async function reconcileAliyunSmsDeliveries(db: ConferenceDatabase) {
 }
 
 async function start() {
+  await unlink(workerReadyFile).catch(() => undefined);
+  await unlink(workerReadyTempFile).catch(() => undefined);
   console.info(`[worker] build=${JSON.stringify(resolveBuildInfo('worker', process.env))}`);
   resolveDeploymentOrigins();
   notificationPayloadSecret();
@@ -3913,10 +3917,12 @@ async function start() {
   const worker = new Worker(queueName, (job) => processDomainEvent(job, db), {
     connection: workerConnection,
     concurrency,
+    autorun: false,
   });
   const htmlImportWorker = new Worker(htmlImportQueueName, (job) => processDomainEvent(job, db), {
     connection: workerConnection,
     concurrency: htmlImportConcurrency,
+    autorun: false,
   });
 
   const redriveDurableFailure = async (job: Job<Record<string, unknown>>) => {
@@ -4172,12 +4178,33 @@ async function start() {
     smsReceiptInterval,
   );
   const feishuDigestTimer = setInterval(() => void maintainFeishuDigests(), 60_000);
+  const workerRun = worker.run();
+  const htmlImportWorkerRun = htmlImportWorker.run();
+  void workerRun.catch((error) => {
+    console.error('[worker] domain event consumer stopped unexpectedly', error);
+    process.exit(1);
+  });
+  void htmlImportWorkerRun.catch((error) => {
+    console.error('[worker] HTML import consumer stopped unexpectedly', error);
+    process.exit(1);
+  });
+  await Promise.all([worker.waitUntilReady(), htmlImportWorker.waitUntilReady()]);
+  if (!worker.isRunning() || !htmlImportWorker.isRunning()) {
+    throw new Error('Worker consumers did not enter the running state');
+  }
+  await writeFile(workerReadyTempFile, `${JSON.stringify(resolveBuildInfo('worker', process.env))}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  await rename(workerReadyTempFile, workerReadyFile);
   console.info(
     `[worker] ready queue=${queueName} concurrency=${concurrency} htmlQueue=${htmlImportQueueName} htmlConcurrency=${htmlImportConcurrency}`,
   );
 
   const stop = async (signal: string) => {
     console.info(`[worker] stopping signal=${signal}`);
+    await unlink(workerReadyFile).catch(() => undefined);
+    await unlink(workerReadyTempFile).catch(() => undefined);
     clearInterval(timer);
     clearInterval(durableFailureTimer);
     clearInterval(inventoryTimer);

--- a/docs/generated/project-inventory.json
+++ b/docs/generated/project-inventory.json
@@ -7,5 +7,5 @@
   "databaseTables": 78,
   "apiControllers": 32,
   "apiOperations": 266,
-  "testFiles": 158
+  "testFiles": 159
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,6 +2,37 @@
 
 本文件说明通用运行、迁移和发布能力。`hui.ailingdaoli.com` 当前生产环境的固定目录、GitHub 推送规则、Docker 构建身份、备份、模板同步、验收和回滚流程见[生产推送与 Docker 发布规范](production-deployment-runbook.md)。每次正式发布的事实记录保存在 [`release-records/`](release-records/)。
 
+## 生产服务器单命令发布
+
+生产服务器源码与 Compose 固定在 `/www/wwwroot/TokEMS`，Git 分支 `production` 跟踪 `origin/main`。部署入口安装为 root 所有的 `/usr/local/sbin/tokems-deploy`；GitHub 主分支合并并完成 CI 后，在服务器运行：
+
+```bash
+sudo /usr/local/sbin/tokems-deploy check
+sudo /usr/local/sbin/tokems-deploy deploy
+```
+
+首次启用前，把现有生产环境文件一次性安装到 `/etc/tokems/production.env`，目录权限为 `root:root 0700`，文件权限为 `root:root 0600`。脚本会为每次运行固定 root-only 环境快照，并从目标 Git 提交创建 root-only 构建上下文；服务器工作区仍由 `ecs-user` 管理，运行与构建均不读取工作区中的实时 `.env`。
+
+历史失败发布导致 `.env` 构建身份与健康运行容器不一致时，先运行 `repair-identity`。该模式验证五类服务和数据库后备份并修正四项 `BUILD_*`，不会重启容器：
+
+```bash
+sudo /usr/local/sbin/tokems-deploy repair-identity
+```
+
+恢复标记存在时，使用已合并并通过 CI 的前向修复继续发布；独立人工恢复完成后可复核写权限、Worker ready、生产数据子集和首页投影并归档标记：
+
+```bash
+sudo /usr/local/sbin/tokems-deploy recover-interrupted
+sudo /usr/local/sbin/tokems-deploy deploy --resume-recovery
+sudo /usr/local/sbin/tokems-deploy resolve-recovery
+```
+
+脚本不依赖宿主机 Node.js 或 pnpm。它会验证目标提交来自已合并 PR 且官方 main push 的 `quality-and-flows` 成功，证明运行 API、目标 Compose 和备份操作使用同一个 PostgreSQL 实例，随后依次执行构建开始备份、镜像回滚标签、root-only 源码与环境快照、Fast-forward、串行镜像构建、写冻结后的最终数据库备份、迁移、按快照差异自动触发的规范模板同步、应用容器切换和完整验收。验收包含公开首页和生产数据库重新导出的脱敏完整后台模板快照。备份与日志保存在 `/www/backup/TokEMS/<时间戳>`，容量检查直接读取这个目录实际所在的文件系统。任何资源、Git、CI、Compose、Nginx、数据保护或健康门禁失败都会终止发布。首次修改源码、环境或镜像前会持久化 `RECOVERY_REQUIRED`；数据库写冻结后把阶段更新为 `write-freeze`，完整发布通过后才归档。`pre-write` 阶段的硬中断使用保存于发布备份中的精确恢复脚本离线恢复；受保护窗口由独立的 systemd 监督单元持续守护，部署控制器退出且恢复标记仍存在时反复停止 API/Worker，再由恢复流程收集数据库迁移证据并恢复应用。数据库不可用时继续保留标记并保持 API/Worker 停止。
+
+每次标准发布都使用短暂写冻结：镜像构建后停止 API/Worker，重新生成包含构建期间新增交易的最终 dump 和业务基线。稳定业务表按主键索引逐表流式取证；带保留期自动清理的数据在只读阶段单独比对，恢复 Worker 后允许既定清理策略运行。迁移与可选规范同步完成后，以只读 API 和暂停 Worker 的状态验收，随后恢复目标 API/Worker。Worker 完成启动维护后会在容器 tmpfs 写入带构建身份的持久 ready 文件，脚本核对该身份后再复核生产主键、计数和销量。窗口内报名、支付回调、后台保存和异步任务需要依赖调用方重试，正式操作安排在业务低峰。
+
+生产主机构建至少需要 10 GiB 的 `MemAvailable + SwapFree`，源码文件系统和 Docker 实际数据目录各需要 12 GiB 可用空间。备份盘预检按四倍当前数据库体积加 4 GiB 保留空间计算；构建开始的主键证据生成后，脚本会用实测文件大小重新预算最终备份、只读验收和恢复写入后的证据，并在每个大文件阶段前复核。数据库证明、查询、dump 和迁移均有超时上限。标准入口会拒绝 Compose 基础设施变更；此类发布使用单独维护窗口。资源不足时先扩容或改用外部预构建镜像。脚本保留历史备份与回滚镜像，清理策略由运维在恢复验证和观察期后单独执行。完整首次安装命令、手工等价步骤和数据库恢复边界见生产 Runbook。
+
 ## 本地 Docker 完整部署
 
 ```bash

--- a/docs/production-deployment-runbook.md
+++ b/docs/production-deployment-runbook.md
@@ -14,6 +14,7 @@
 | 服务器源码与 Compose 目录 | `/www/wwwroot/TokEMS`                         |
 | 宝塔站点与反向代理目录    | `/www/dk_project/wwwroot/hui.ailingdaoli.com` |
 | 生产备份根目录            | `/www/backup/TokEMS`                          |
+| 生产环境文件              | `/etc/tokems/production.env`                  |
 | Compose 项目名            | `tokems`                                      |
 | Gateway 宿主机入口        | `127.0.0.1:8088`                              |
 | 大会前台                  | `https://hui.ailingdaoli.com/`                |
@@ -22,7 +23,7 @@
 | 健康接口                  | `https://hui.ailingdaoli.com/api/v1/health`   |
 | 版本接口                  | `https://hui.ailingdaoli.com/version.json`    |
 
-`/www/wwwroot/TokEMS` 保存 Git 源码、`.env` 和 `docker-compose.yml`，所有迁移、构建和容器操作都从这里执行。
+`/www/wwwroot/TokEMS` 保存 Git 源码和 `docker-compose.yml`，所有迁移、构建和容器操作都从这里执行。生产环境文件独立保存在 `/etc/tokems/production.env`，仅允许 root 读取和原子更新。
 
 `/www/dk_project/wwwroot/hui.ailingdaoli.com` 属于宝塔和外部 Nginx 层。该目录不承载 TokEMS 源码，也不进入应用容器。修改其中的 Nginx 配置时，先运行 `nginx -t`，测试通过后再重载。
 
@@ -57,7 +58,7 @@ TokEMS 使用根目录多阶段 `Dockerfile` 构建以下应用镜像：
 | 应用发布     | 服务器拉取 `origin/main`，构建镜像，迁移并切换容器                 | GitHub 主分支需要进入生产运行时                    |
 | 规范模板同步 | 把仓库中的 `geo-conference`、`tokems26` 规范模板幂等写入生产数据库 | 仓库模板、前台文案、大会设置或规范发布快照发生变化 |
 
-代码变更进入 `main` 后不会自动出现在当前服务器。当前环境尚未配置 GitHub Actions 自动部署，正式上线仍需执行本手册的服务器流程。
+代码变更进入 `main` 后不会自动出现在当前服务器。当前环境使用仓库内 `tooling/production-deploy.sh` 作为服务器单命令发布入口，尚未配置 GitHub Actions 自动部署。
 
 后台直接修改默认大会时，保存操作会生成新的不可变发布快照并切换公开版本。修改完成后必须运行 `pnpm canonical:export` 回写仓库规范快照；最迟在下一次 GitHub 推送前完成。生产后台发生独立修改时，先同步回本地规范大会并确认公开页面，再更新仓库快照。
 
@@ -149,6 +150,196 @@ gh run list --repo yaojingang/TokEMS --branch main --limit 5
 
 以下命令以生产目录和当前 `ecs-user` Git 所有权为准。执行过程中出现非预期输出时停止发布，先定位当前层级。
 
+### 服务器单命令入口
+
+部署脚本在 GitHub 仓库中的固定位置是 `tooling/production-deploy.sh`。成功发布后，对应服务器文件为 `/www/wwwroot/TokEMS/tooling/production-deploy.sh`。`/www/dk_project/wwwroot/hui.ailingdaoli.com` 只保存站点和反向代理配置，不放置部署脚本、源码或构建产物。
+
+首次安装时不要把脚本直接复制到 `/www/wwwroot/TokEMS/tooling/`。服务器 `production` 仍停留在旧提交时，这样会产生未跟踪文件，Git 清洁门禁会拒绝继续。优先使用本节后面的“首次固定引导流程”，它直接从已经合并且 CI 成功的 `origin/main` 读取精确目标脚本。
+
+需要通过 SCP 上传时，先在本地从已合并的 `origin/main` 导出脚本，再上传到服务器 `/tmp`。将 `<生产服务器>` 替换为实际 SSH 主机：
+
+```bash
+cd /path/to/TokEMS
+git fetch origin main
+target_sha="$(git rev-parse origin/main)"
+git show "${target_sha}:tooling/production-deploy.sh" > /tmp/tokems-production-deploy.sh
+shasum -a 256 /tmp/tokems-production-deploy.sh
+scp /tmp/tokems-production-deploy.sh ecs-user@<生产服务器>:/tmp/tokems-production-deploy.sh
+```
+
+登录服务器后核对 SHA-256，把临时文件安装成 root 持有的稳定入口。服务器输出应与本地校验值完全一致：
+
+```bash
+sha256sum /tmp/tokems-production-deploy.sh
+sudo install -o root -g root -m 0755 \
+  /tmp/tokems-production-deploy.sh /usr/local/sbin/tokems-deploy
+sudo /usr/local/sbin/tokems-deploy --help
+```
+
+`/usr/local/sbin/tokems-deploy` 每次启动都会读取 `origin/main` 的目标脚本，并复核合并 PR、官方 main push CI 和 `quality-and-flows`。日常发布也使用这个 root 所有的入口，避免 root 直接执行由 `ecs-user` 管理的工作区文件。首次基线依次执行以下命令，每一步成功后再继续：
+
+```bash
+sudo install -d -o root -g root -m 0700 /etc/tokems
+sudo install -o root -g root -m 0600 \
+  /www/wwwroot/TokEMS/.env /etc/tokems/production.env
+sudo /usr/local/sbin/tokems-deploy repair-identity --target-sha <origin-main-full-sha>
+sudo /usr/local/sbin/tokems-deploy check --target-sha <origin-main-full-sha>
+sudo /usr/local/sbin/tokems-deploy deploy --target-sha <origin-main-full-sha>
+```
+
+`/etc/tokems` 必须保持 `root:root 0700`，`/etc/tokems/production.env` 必须保持 `root:root 0600`。脚本取得发布锁后立即创建 root-only 会话快照，后续 Compose 只读取受保护快照；发布成功或身份修复成功后再原子写回 `/etc/tokems/production.env`。不要把任何生产环境文件上传到 GitHub，也不要在终端输出其内容。确认新入口连续完成 `repair-identity`、`check` 和一次正式 `deploy` 后，可按既有凭据销毁流程处理工作区旧 `.env`。
+
+当前生产主机的历史内存与交换空间总可用量低于脚本要求的 10 GiB 构建门槛时，`check` 和 `deploy` 会在备份、迁移和容器切换前停止。先扩容，或完成外部预构建镜像改造，再执行正式发布。
+
+服务器已经首次安装 root 所有的稳定入口后，日常发布使用以下两个命令：
+
+```bash
+sudo /usr/local/sbin/tokems-deploy check
+sudo /usr/local/sbin/tokems-deploy deploy
+```
+
+`repair-identity` 是一次性、可审计的基线修复入口。它会同时读取 Gateway、Web、Admin、API、Worker 和数据库迁移身份，确认代码提交、构建时间和数据库健康一致后，先备份 `.env`，再只更新四项 `BUILD_*` 和兼容回滚标记，不重启容器：
+
+```bash
+sudo /usr/local/sbin/tokems-deploy repair-identity
+```
+
+出现 `/www/backup/TokEMS/RECOVERY_REQUIRED` 时，常规 `check` 和 `deploy` 会停止。已合并前向修复时运行：
+
+```bash
+sudo /usr/local/sbin/tokems-deploy deploy --resume-recovery
+```
+
+标记中的 `phase=pre-write` 表示中断发生在数据库操作前。这个阶段使用发布前回滚镜像和 `.env` 自动恢复应用，不执行数据库恢复：
+
+```bash
+sudo /usr/local/sbin/tokems-deploy recover-interrupted
+```
+
+每个恢复标记都固定协议版本、目标提交、目标镜像标签，并引用发布目录中 root-only 的精确恢复脚本及 SHA-256。`recover-interrupted` 可以在 GitHub 或外网不可用时从本机备份恢复；稳定入口会先校验并转交给该次发布保存的脚本。`write-freeze` 阶段恢复会等待遗留的 `db-init` 容器结束，验证当前迁移哈希属于备份基线到目标之间的有序链，再选择回滚镜像或目标镜像继续。
+
+人工恢复已经独立完成时，让脚本验证正常 API 写权限、标准 Worker 启动命令与持久 ready 身份，并把当前生产主键、计数、销量及首页投影重新对照恢复基线；全部通过后才归档恢复标记：
+
+```bash
+sudo /usr/local/sbin/tokems-deploy resolve-recovery
+```
+
+2026-08-24 的失败发布记录明确指出：线上容器已经回到 `01c7b490bb690e4e12695dba2996f7d2864566f4` / `0053_mute_vulcan.sql`，服务器 `.env` 仍留有失败目标的构建身份。首次使用本脚本时先执行 `repair-identity`，再执行 `check` 和 `deploy`。修复证据保存到 `/www/backup/TokEMS/identity-repair-<时间戳>`。
+
+`check` 只读检查当前运行版本、Git 工作区、官方远端、`production → origin/main`、GitHub 合并 PR、`quality-and-flows`、Compose、Nginx、容器、镜像标签、生产环境固定项、磁盘和构建内存。`deploy` 在相同门禁通过后自动完成以下流程：
+
+1. 创建构建开始时的 PostgreSQL custom dump、生产数据证据、旧 `.env`、旧 Compose 配置和运行状态证据。
+2. 给六个当前应用镜像添加 `rollback-<时间戳>` 标签。
+3. 以 Fast-forward 方式把服务器 `production` 更新到已经合并且 CI 成功的 `origin/main`。
+4. 从目标提交生成 root-only 源码快照和 Compose 构建上下文，生成并持久化四项构建身份，按服务串行构建镜像，固定 `COMPOSE_PARALLEL_LIMIT=1`。构建和容器切换全程使用 root-only `.env` 快照及清洁进程环境。
+5. 所有发布在数据库写入前先把 API/Worker 的 Docker 重启策略持久改为 `no`，启动持续重试的写阻断 guard，再落盘 `RECOVERY_REQUIRED` 并停止写服务。随后重新生成最终 PostgreSQL dump、生产主键、计数与销量基线，再以 `SEED_DEMO_DATA=false` 执行迁移；规范快照变化时继续执行受保护的 `geo-conference` / `tokems26` 同步。稳定业务表按主键索引流式取证，带自动保留期的数据在 Worker 暂停的阶段单独比对。
+6. 使用 `--no-build --no-deps --force-recreate --wait` 切换应用容器，不协调 PostgreSQL、Redis、MinIO 等基础设施。验收阶段以数据库只读模式启动 API，并暂停 Worker 任务。
+7. 在写冻结窗口验证容器、迁移、五类构建身份、本机与公网 HTTP、公开首页投影，以及从生产数据库重新导出的脱敏完整规范大会与后台设置；冻结期生产主键集合、计数和票种/配额销量必须精确一致。验证通过后以 `restart: no` 和正常数据库权限重建 API/Worker。Worker 的两类 BullMQ 消费者都完成 Redis ready 后才写入包含 SHA、构建时间和迁移身份的 `/tmp/tokems-worker-ready.json`；脚本核对并观察稳定后恢复 `unless-stopped`，再检查健康、数据库实例和允许正常新增的生产数据。
+8. 失败时先停止 API/Worker，再读取数据库迁移证据并恢复发布前镜像标签与 `.env`。迁移证据不可读取时，旧镜像和环境已经恢复，API/Worker 保持停止，`RECOVERY_REQUIRED` 继续阻止下一次普通发布。数据库 dump 始终保留，脚本不会自动覆盖恢复数据库。
+
+脚本会先验证 `origin/main` 对应的合并 PR 和 CI，再读取该提交中的最新脚本继续执行，因此后续仓库内的部署逻辑更新会随目标提交生效。服务器首次尚未取得该文件时，先用以下固定引导流程完成同样的外部校验，再授予目标脚本 root 权限。当前已知基线第一次把 `deploy_action` 设为 `repair-identity`；随后分别设为 `check` 和 `deploy` 重跑：
+
+```bash
+set -Eeuo pipefail
+
+app_dir=/www/wwwroot/TokEMS
+deploy_action=repair-identity
+sudo -u ecs-user git -C /www/wwwroot/TokEMS fetch --prune origin main
+target_sha="$(sudo -u ecs-user git -C "$app_dir" rev-parse origin/main)"
+bootstrap_dir="$(mktemp -d /tmp/tokems-deploy-bootstrap.XXXXXX)"
+trap 'rm -f -- "$bootstrap_dir/prs.json" "$bootstrap_dir/runs.json" "$bootstrap_dir/checks.json" "$bootstrap_dir/deploy.sh"; rmdir -- "$bootstrap_dir"' EXIT
+
+curl --fail --silent --show-error --location \
+  --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 --retry-connrefused \
+  -H 'Accept: application/vnd.github+json' \
+  -H 'X-GitHub-Api-Version: 2022-11-28' \
+  -H 'User-Agent: TokEMS-production-bootstrap' \
+  "https://api.github.com/repos/yaojingang/TokEMS/commits/${target_sha}/pulls?per_page=100" \
+  >"$bootstrap_dir/prs.json"
+curl --fail --silent --show-error --location \
+  --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 --retry-connrefused \
+  -H 'Accept: application/vnd.github+json' \
+  -H 'X-GitHub-Api-Version: 2022-11-28' \
+  -H 'User-Agent: TokEMS-production-bootstrap' \
+  "https://api.github.com/repos/yaojingang/TokEMS/actions/workflows/ci.yml/runs?branch=main&event=push&per_page=100" \
+  >"$bootstrap_dir/runs.json"
+curl --fail --silent --show-error --location \
+  --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 --retry-connrefused \
+  -H 'Accept: application/vnd.github+json' \
+  -H 'X-GitHub-Api-Version: 2022-11-28' \
+  -H 'User-Agent: TokEMS-production-bootstrap' \
+  "https://api.github.com/repos/yaojingang/TokEMS/commits/${target_sha}/check-runs?per_page=100" \
+  >"$bootstrap_dir/checks.json"
+
+python3 - "$target_sha" "$bootstrap_dir/prs.json" "$bootstrap_dir/runs.json" "$bootstrap_dir/checks.json" <<'PY'
+import json
+import sys
+
+target, pulls_file, runs_file, checks_file = sys.argv[1:]
+with open(pulls_file, encoding="utf-8") as handle:
+    pulls = json.load(handle)
+with open(runs_file, encoding="utf-8") as handle:
+    runs = json.load(handle).get("workflow_runs", [])
+with open(checks_file, encoding="utf-8") as handle:
+    checks = json.load(handle).get("check_runs", [])
+if not any(
+    item.get("merged_at")
+    and item.get("merge_commit_sha") == target
+    and (item.get("base") or {}).get("ref") == "main"
+    for item in pulls
+):
+    raise SystemExit("target commit has no merged main PR")
+if not any(
+    item.get("name") == "tokems-ci"
+    and item.get("path") == ".github/workflows/ci.yml"
+    and item.get("event") == "push"
+    and item.get("head_branch") == "main"
+    and item.get("head_sha") == target
+    and item.get("status") == "completed"
+    and item.get("conclusion") == "success"
+    and (item.get("repository") or {}).get("full_name") == "yaojingang/TokEMS"
+    and (item.get("head_repository") or {}).get("full_name") == "yaojingang/TokEMS"
+    for item in runs
+):
+    raise SystemExit("target commit has no successful official main push workflow")
+if not any(
+    item.get("name") == "quality-and-flows"
+    and item.get("head_sha") == target
+    and item.get("status") == "completed"
+    and item.get("conclusion") == "success"
+    and (item.get("app") or {}).get("slug") == "github-actions"
+    and "/yaojingang/TokEMS/actions/runs/" in (item.get("details_url") or "")
+    for item in checks
+):
+    raise SystemExit("target commit has no successful official quality-and-flows job")
+PY
+
+sudo -u ecs-user git -C "$app_dir" \
+  show "${target_sha}:tooling/production-deploy.sh" >"$bootstrap_dir/deploy.sh"
+chmod 700 "$bootstrap_dir/deploy.sh"
+bash -n "$bootstrap_dir/deploy.sh"
+sudo install -o root -g root -m 0755 \
+  "$bootstrap_dir/deploy.sh" /usr/local/sbin/tokems-deploy
+sudo bash /usr/local/sbin/tokems-deploy "$deploy_action" --target-sha "$target_sha"
+```
+
+默认模板策略为自动判断。两个规范快照相对当前线上提交发生变化时，脚本强制同步规范模板；`--sync-canonical` 可在快照未变化时主动重跑幂等同步；`--skip-canonical` 只接受快照未变化的发布。指定目标提交时使用完整 SHA：
+
+```bash
+sudo /usr/local/sbin/tokems-deploy deploy \
+  --target-sha <origin-main-full-sha>
+```
+
+生产主机曾在 Docker BuildKit 构建期间发生 OOM 并导致同机服务中断。脚本要求 `MemAvailable + SwapFree` 至少 10 GiB，并要求源码文件系统和 Docker 实际 `DockerRootDir` 各有至少 12 GiB 可用空间。备份文件系统的初始门禁按四倍当前数据库体积加至少 4 GiB 计算；构建开始的稳定主键与保留期主键证据生成后，后续门禁使用这些文件的实测大小预算最终 dump、只读验收和 post-thaw 证据。预检从 `/www/backup/TokEMS` 的最深现存父目录读取设备号，创建发布目录后再次核对同一设备，每个大文件阶段前直接检查该发布目录。任一资源不足时会在备份、迁移和容器变更前停止。当前服务器若仍保持历史资源配置，需要先扩容，或后续改造为外部构建并拉取固定镜像摘要。
+
+标准单命令发布拒绝 `docker-compose.yml` 变化。数据库、缓存、对象存储、卷、端口和服务拓扑变更进入单独评审的基础设施维护窗口。
+
+每次标准发布都有短暂写冻结窗口：六个镜像构建完成后停止 API 和 Worker，持久化恢复标记，在静止写入状态重新生成最终数据库备份与业务基线，再执行迁移和可选的规范同步。语义验收期间 API 仅允许数据库读取，Worker 暂停消费。只读验收阶段公开浏览恢复；报名、支付回调、后台保存及异步任务会在窗口内失败或重试。脚本在恢复正常 API/Worker、核对持久 ready 身份和数据复验后归档恢复标记并记录成功。选择业务低峰执行，并确认支付渠道具备回调重试。
+
+数据库实例证明、查询、dump 和迁移都设置了进程级超时；连接串指向不可达地址或数据库停止响应时，脚本会失败退出并进入受控恢复。脚本保留全部备份和回滚镜像，不会自动清理历史文件。运维侧应按已验证的恢复演练和容量预算另行制定保留周期，删除前确认目标发布已过观察期且仍有可用备份。
+
+下面各节保留为脚本实现依据和人工审计清单。标准发布固定使用单命令脚本；故障处置中的手工命令需要负责人审批并逐项记录结果。
+
 ### 7.1 只读预检
 
 ```bash
@@ -164,7 +355,8 @@ docker compose version
 docker compose config --quiet
 docker compose ps
 nginx -t
-df -h / /var/lib/docker
+docker info --format '{{.DockerRootDir}}'
+df -h / /www/backup "$(docker info --format '{{.DockerRootDir}}')"
 free -h
 ```
 
@@ -198,23 +390,23 @@ curl -fsS http://127.0.0.1:8088/api/v1/health > "$backup_dir/health-before.json"
 
 docker compose exec -T postgres sh -lc \
   'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --format=custom --no-owner --no-acl' \
-  > "$backup_dir/conference.dump"
+  > "$backup_dir/conference-build-start.dump"
 
 docker compose exec -T postgres pg_restore --list \
-  < "$backup_dir/conference.dump" \
-  > "$backup_dir/conference.dump.list"
+  < "$backup_dir/conference-build-start.dump" \
+  > "$backup_dir/conference-build-start.dump.list"
 
 docker compose exec -T postgres sh -lc \
   'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -F "," -c "select id,sold from ticket_types order by id"' \
-  > "$backup_dir/ticket-types-sold.csv"
+  > "$backup_dir/ticket-types-sold-build-start.csv"
 
 docker compose exec -T postgres sh -lc \
   'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -F "," -c "select id,sold from ticket_quotas order by id"' \
-  > "$backup_dir/ticket-quotas-sold.csv"
+  > "$backup_dir/ticket-quotas-sold-build-start.csv"
 
-test -s "$backup_dir/conference.dump"
-test -s "$backup_dir/conference.dump.list"
-sha256sum "$backup_dir/conference.dump" > "$backup_dir/conference.dump.sha256"
+test -s "$backup_dir/conference-build-start.dump"
+test -s "$backup_dir/conference-build-start.dump.list"
+sha256sum "$backup_dir/conference-build-start.dump" > "$backup_dir/conference-build-start.dump.sha256"
 printf '%s\n' "$backup_dir" > /www/backup/TokEMS/LATEST
 chmod 600 /www/backup/TokEMS/LATEST
 
@@ -329,13 +521,26 @@ test -z "$(sudo -u ecs-user git status --porcelain --untracked-files=all)"
 
 `payment-web` 使用 `tokems-web:local`，无需单独构建镜像。
 
-### 7.6 迁移数据库
+### 7.6 写冻结、最终备份与迁移
 
-常规发布：
+镜像构建完成后，所有发布都要停止 API 和 Worker 写入，并在静止写入状态重新生成最终备份、业务主键、计数和销量基线。仓库脚本会自动生成 `business-counts-before.csv`、`protected-business-ids-before.csv`、`ticket-types-sold-before.csv` 和 `ticket-quotas-sold-before.csv`。完整主键导出与失败恢复由脚本统一处理。
+
+以下片段展示最终 dump 与迁移的关键顺序，供审计发布日志：
 
 ```bash
 cd /www/wwwroot/TokEMS || exit 1
-SEED_DEMO_DATA=false docker compose run --rm db-init
+backup_dir=$(cat /www/backup/TokEMS/LATEST)
+docker compose stop --timeout 30 api worker
+docker compose exec -T postgres sh -lc \
+  'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --format=custom --no-owner --no-acl' \
+  > "$backup_dir/conference.dump"
+docker compose exec -T postgres pg_restore --list \
+  < "$backup_dir/conference.dump" \
+  > "$backup_dir/conference.dump.list"
+test -s "$backup_dir/conference.dump"
+test -s "$backup_dir/conference.dump.list"
+sha256sum "$backup_dir/conference.dump" > "$backup_dir/conference.dump.sha256"
+SEED_DEMO_DATA=false docker compose run --rm --no-deps db-init
 ```
 
 Docker Compose v2.27 的 `docker compose run` 不支持 `--no-build`。此处不要添加该参数。
@@ -350,7 +555,7 @@ Docker Compose v2.27 的 `docker compose run` 不支持 `--no-build`。此处不
 - 大会 slug 为 `tokems26`。
 - 票种和配额使用稳定 ID。
 - 报名、订单、票、发票和用户记录继续保留。
-- `ticket-types-sold.csv` 与 `ticket-quotas-sold.csv` 已生成且格式有效。
+- `ticket-types-sold-before.csv` 与 `ticket-quotas-sold-before.csv` 已在写冻结后生成且格式有效。
 
 新终端需要先恢复并校验备份目录变量：
 
@@ -361,8 +566,8 @@ case "$backup_dir" in
   *) exit 1 ;;
 esac
 test -s "$backup_dir/conference.dump"
-test -s "$backup_dir/ticket-types-sold.csv"
-test -s "$backup_dir/ticket-quotas-sold.csv"
+test -s "$backup_dir/ticket-types-sold-before.csv"
+test -s "$backup_dir/ticket-quotas-sold-before.csv"
 ```
 
 执行幂等模板同步：
@@ -479,7 +684,17 @@ docker inspect tokems-api-1
 
 ### 10.1 应用镜像回滚
 
-应用回滚优先使用发布前的 `rollback-<时间戳>` 镜像标签，并恢复该版本对应的 `.env` 构建身份：
+进入写冻结后，部署脚本先持久化恢复标记。失败处理会先停止 API/Worker、恢复旧镜像和旧 `.env`，再读取数据库当前迁移哈希。数据库已经前移时，脚本把运行环境的迁移字段对齐到数据库当前值，并以 API 只读、Worker 暂停的状态提供受控访问。数据库迁移身份暂时不可读取时，API/Worker 保持停止，恢复标记和已有证据继续保留。审计证据包括：
+
+- `automatic-rollback-identity.txt`
+- `automatic-rollback-migration-state.txt`
+- `automatic-rollback-health.json`
+- `automatic-rollback.log`
+- `/www/backup/TokEMS/RECOVERY_REQUIRED`
+
+这个受保护恢复状态使用旧应用提交和当前数据库迁移，数据库身份可确认时提供只读公开访问；身份不可确认时保持应用写服务停止。常规 `check` 与 `deploy` 会返回失败，防止把暂停写入误判为健康基线。修复代码已经合并并通过 CI 后，使用 `deploy --resume-recovery` 继续前向发布；人工完成独立恢复后，使用 `resolve-recovery` 复核正常写权限、Worker 持久 ready 身份、生产数据子集及首页投影并清除标记。静态 Gateway/Web/Admin 保留旧镜像内的迁移信息；API/Worker 使用当前数据库迁移信息。提交和构建时间必须保持一致，审计标记必须与两组迁移身份吻合。
+
+以下手工流程只适用于数据库迁移哈希仍等于备份 `.env` 中 `BUILD_MIGRATION_HASH` 的情况：
 
 ```bash
 cd /www/wwwroot/TokEMS || exit 1
@@ -510,13 +725,14 @@ docker compose \
   --env-file .env \
   up -d \
   --no-build \
+  --no-deps \
   --force-recreate \
   --wait \
   --wait-timeout 300 \
   notification-sink api worker web payment-web admin gateway
 ```
 
-发布前的 `docker-compose.yml` 与 `.env` 必须一起使用，避免新版本 Compose 合约驱动旧镜像。回滚后执行与发布相同的容器、数据库、本机 HTTP、公网 HTTP 和版本验证。
+发布前的 `docker-compose.yml` 与 `.env` 必须一起使用，避免新版本 Compose 合约驱动旧镜像。数据库哈希已经变化时，不执行上述简单手工流程；使用脚本生成的受保护恢复证据继续诊断和前向发布。回滚后执行与发布相同的容器、数据库、本机 HTTP、公网 HTTP 和版本验证。
 
 ### 10.2 数据库恢复
 
@@ -534,7 +750,7 @@ docker compose \
 
 - 公开组织 slug：`geo-conference`
 - 当前规范大会 slug：`tokems26`
-- 生产 `.env`：`PUBLIC_ORGANIZATION_SLUG=geo-conference`
+- 生产环境文件 `/etc/tokems/production.env`：`PUBLIC_ORGANIZATION_SLUG=geo-conference`
 - Nuxt 构建参数：`NUXT_PUBLIC_ORGANIZATION_SLUG=geo-conference`
 - 生产常态：`DEPLOYMENT_MODE=production`、`SEED_DEMO_DATA=false`
 - 历史模板 `tokems-demo`、`tokems-demo-2026` 不再作为 GitHub 或生产默认模板
@@ -565,8 +781,8 @@ docker compose \
 
 ## 13. 当前环境待改进项
 
-- 服务器没有 Node.js 和 pnpm，当前使用手工 Docker Compose 发布。后续可以建设基于 GitHub Actions、受保护生产环境和固定镜像摘要的自动发布。
+- 服务器没有 Node.js 和 pnpm，仓库内 Bash 脚本已覆盖单命令 Docker Compose 发布。后续优先建设基于 GitHub Actions、受保护生产环境和固定镜像摘要的外部构建流程，消除生产主机 BuildKit OOM 风险。
 - 当前 `.env` 由服务器权限保护。后续应把生产密钥迁移到 Secret Manager 或等价的受控密钥系统。
 - 服务器操作系统安全更新需要独立维护窗口处理，不能与应用发布混在同一次变更中。
 - MinIO 资产恢复演练和定期备份仍需形成独立记录。
-- 自动发布完成前，每次 GitHub 合并后都要人工执行并记录服务器发布流程。
+- GitHub Actions 自动发布完成前，每次 GitHub 合并后都要人工执行服务器部署脚本，并按模板补充日期化发布记录。

--- a/packages/database/src/canonical-homepage.test.ts
+++ b/packages/database/src/canonical-homepage.test.ts
@@ -2,7 +2,10 @@ import { createHash, randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { validateCanonicalHomepageSnapshot } from './export-canonical-homepage.js';
+import {
+  validateCanonicalExportTopology,
+  validateCanonicalHomepageSnapshot,
+} from './export-canonical-homepage.js';
 
 async function snapshot() {
   return JSON.parse(
@@ -14,6 +17,52 @@ async function snapshot() {
 }
 
 describe('canonical homepage snapshot', () => {
+  it('limits the trusted production exporter to the read-only Compose topology', () => {
+    const trusted = {
+      databaseUrl:
+        'postgresql://conference:conference@postgres:5432/conference?options=-c%20default_transaction_read_only%3Don',
+      apiBaseUrl: 'http://api:4100/api/v1',
+      trustedComposeInternal: true,
+      deploymentMode: 'production',
+    } as const;
+    expect(() => validateCanonicalExportTopology(trusted)).not.toThrow();
+    expect(() =>
+      validateCanonicalExportTopology({
+        ...trusted,
+        databaseUrl: 'postgresql://conference:conference@postgres:5432/conference',
+      }),
+    ).toThrow(/read-only topology/u);
+    expect(() =>
+      validateCanonicalExportTopology({
+        ...trusted,
+        apiBaseUrl: 'https://example.com/api/v1',
+      }),
+    ).toThrow(/read-only topology/u);
+    expect(() =>
+      validateCanonicalExportTopology({
+        ...trusted,
+        deploymentMode: 'local',
+      }),
+    ).toThrow(/read-only topology/u);
+  });
+
+  it('keeps ordinary canonical export bound to a loopback database', () => {
+    expect(() =>
+      validateCanonicalExportTopology({
+        databaseUrl: 'postgresql://conference:conference@127.0.0.1:15432/conference',
+        apiBaseUrl: 'http://127.0.0.1:8088/api/v1',
+        trustedComposeInternal: false,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateCanonicalExportTopology({
+        databaseUrl: 'postgresql://conference:conference@postgres:5432/conference',
+        apiBaseUrl: 'http://127.0.0.1:8088/api/v1',
+        trustedComposeInternal: false,
+      }),
+    ).toThrow(/loopback DATABASE_URL/u);
+  });
+
   it('contains the current public release and sanitized backend defaults', async () => {
     const value = validateCanonicalHomepageSnapshot(await snapshot());
     const backend = value.backend as {

--- a/packages/database/src/export-canonical-homepage.ts
+++ b/packages/database/src/export-canonical-homepage.ts
@@ -15,9 +15,14 @@ const publicSnapshotPath = resolve(
   repositoryRoot,
   'packages/contracts/src/canonical-homepage.public.json',
 );
-const localHomepageUrl = 'http://127.0.0.1:8088/api/v1/homepage';
+const canonicalApiBaseUrl = (
+  process.env.CANONICAL_API_BASE_URL ?? 'http://127.0.0.1:8088/api/v1'
+).replace(/\/$/u, '');
+const localHomepageUrl = `${canonicalApiBaseUrl}/homepage`;
 const localDatabaseUrl =
   process.env.DATABASE_URL ?? 'postgresql://conference:conference@127.0.0.1:15432/conference';
+const trustedComposeInternalExport =
+  process.env.CANONICAL_EXPORT_TRUSTED_COMPOSE_INTERNAL === 'true';
 const canonicalOrganizationSlug = 'geo-conference';
 const canonicalEventSlug = 'tokems26';
 const canonicalBlueprintId = '77777777-7777-4777-8777-777777777777';
@@ -120,6 +125,39 @@ function canonicalDatabaseProof(
       `${challenge}\n${identity.systemIdentifier}\n${identity.databaseName}\n${identity.databaseOid}\n${identity.startedAt}`,
     )
     .digest('hex');
+}
+
+export function validateCanonicalExportTopology(input: {
+  databaseUrl: string;
+  apiBaseUrl: string;
+  trustedComposeInternal: boolean;
+  deploymentMode?: string | undefined;
+}) {
+  const databaseUrl = new URL(input.databaseUrl);
+  const apiUrl = new URL(input.apiBaseUrl);
+  if (input.trustedComposeInternal) {
+    const databaseOptions = databaseUrl.searchParams.getAll('options').join(' ');
+    if (
+      input.deploymentMode !== 'production' ||
+      databaseUrl.hostname !== 'postgres' ||
+      (databaseUrl.port || '5432') !== '5432' ||
+      !/(?:^|\s)-c\s+default_transaction_read_only=on(?:\s|$)/u.test(databaseOptions) ||
+      apiUrl.protocol !== 'http:' ||
+      apiUrl.hostname !== 'api' ||
+      (apiUrl.port || '80') !== '4100' ||
+      apiUrl.pathname !== '/api/v1' ||
+      apiUrl.search ||
+      apiUrl.hash ||
+      apiUrl.username ||
+      apiUrl.password
+    ) {
+      throw new Error('Trusted Compose canonical export requires the production read-only topology');
+    }
+    return;
+  }
+  if (!['127.0.0.1', 'localhost', '::1'].includes(databaseUrl.hostname)) {
+    throw new Error('Canonical export only accepts a loopback DATABASE_URL');
+  }
 }
 
 function canonicalPublicSnapshot(snapshot: JsonRecord) {
@@ -831,7 +869,7 @@ async function downloadAsset(assetId: string, expectedDigest: string, expectedSi
     throw new Error(`Template asset ${assetId} exceeds the canonical per-file size limit`);
   }
   const response = await fetch(
-    `http://127.0.0.1:8088/api/v1/assets/templates/${encodeURIComponent(assetId)}`,
+    `${canonicalApiBaseUrl}/assets/templates/${encodeURIComponent(assetId)}`,
     { redirect: 'follow', signal: AbortSignal.timeout(10_000) },
   );
   if (!response.ok) throw new Error(`Template asset ${assetId} returned HTTP ${response.status}`);
@@ -865,10 +903,12 @@ async function downloadAsset(assetId: string, expectedDigest: string, expectedSi
 }
 
 async function buildSnapshot() {
-  const databaseUrl = new URL(localDatabaseUrl);
-  if (!['127.0.0.1', 'localhost', '::1'].includes(databaseUrl.hostname)) {
-    throw new Error('Canonical export only accepts a loopback DATABASE_URL');
-  }
+  validateCanonicalExportTopology({
+    databaseUrl: localDatabaseUrl,
+    apiBaseUrl: canonicalApiBaseUrl,
+    trustedComposeInternal: trustedComposeInternalExport,
+    deploymentMode: process.env.DEPLOYMENT_MODE,
+  });
 
   const client = new Client({ connectionString: localDatabaseUrl });
   await client.connect();
@@ -1590,12 +1630,18 @@ async function main() {
     await verifyCommittedFile();
     return;
   }
-  if (mode !== '--write' && mode !== '--check') {
-    throw new Error('Usage: export-canonical-homepage.ts --write | --check | --verify-file');
+  if (mode !== '--write' && mode !== '--check' && mode !== '--stdout') {
+    throw new Error(
+      'Usage: export-canonical-homepage.ts --write | --check | --stdout | --verify-file',
+    );
   }
   const snapshot = await buildStableSnapshot();
   const generated = serializedSnapshot(snapshot);
   const generatedPublic = serializedSnapshot(canonicalPublicSnapshot(snapshot));
+  if (mode === '--stdout') {
+    process.stdout.write(generated);
+    return;
+  }
   if (mode === '--write') {
     await writeAtomically(snapshotPath, generated);
     await writeAtomically(publicSnapshotPath, generatedPublic);

--- a/tooling/lib/production-deploy.test.mjs
+++ b/tooling/lib/production-deploy.test.mjs
@@ -1,0 +1,652 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const scriptPath = resolve(repositoryRoot, 'tooling/production-deploy.sh');
+const source = readFileSync(scriptPath, 'utf8');
+const workerSource = readFileSync(resolve(repositoryRoot, 'apps/worker/src/main.ts'), 'utf8');
+const dockerfileSource = readFileSync(resolve(repositoryRoot, 'Dockerfile'), 'utf8');
+
+test('production deploy script has valid Bash syntax and a read-only help path', () => {
+  const syntax = spawnSync('bash', ['-n', scriptPath], { encoding: 'utf8' });
+  assert.equal(syntax.status, 0, syntax.stderr);
+
+  const help = spawnSync('bash', [scriptPath, '--help'], { encoding: 'utf8' });
+  assert.equal(help.status, 0, help.stderr);
+  assert.match(help.stdout, /production-deploy\.sh check/);
+  assert.match(help.stdout, /production-deploy\.sh deploy/);
+  assert.match(help.stdout, /production-deploy\.sh repair-identity/);
+  assert.match(help.stdout, /production-deploy\.sh recover-interrupted/);
+  assert.match(help.stdout, /production-deploy\.sh resolve-recovery/);
+  assert.match(help.stdout, /--resume-recovery/);
+  assert.match(help.stdout, /default canonical mode is automatic/);
+
+  const modeHelp = spawnSync('bash', [scriptPath, 'check', '--help'], { encoding: 'utf8' });
+  assert.equal(modeHelp.status, 0, modeHelp.stderr);
+  assert.match(modeHelp.stdout, /complete read-only production preflight/);
+
+  const missingMode = spawnSync('bash', [scriptPath], { encoding: 'utf8' });
+  assert.equal(missingMode.status, 2);
+
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-production-install-'));
+  const installedPath = resolve(directory, 'tokems-deploy');
+  try {
+    copyFileSync(scriptPath, installedPath);
+    chmodSync(installedPath, 0o755);
+    const installedHelp = spawnSync(installedPath, ['--help'], { encoding: 'utf8' });
+    assert.equal(installedHelp.status, 0, installedHelp.stderr);
+    assert.match(installedHelp.stdout, /TokEMS production deployment/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('production deploy script pins the documented topology and release gates', () => {
+  for (const required of [
+    "readonly APP_DIR='/www/wwwroot/TokEMS'",
+    "readonly BACKUP_ROOT='/www/backup/TokEMS'",
+    "readonly GIT_USER='ecs-user'",
+    "readonly EXPECTED_ORIGIN='https://github.com/yaojingang/TokEMS.git'",
+    "readonly EXPECTED_BRANCH='production'",
+    "readonly EXPECTED_UPSTREAM='origin/main'",
+    "readonly CANONICAL_ORGANIZATION_SLUG='geo-conference'",
+    "readonly CANONICAL_EVENT_SLUG='tokems26'",
+    'MIN_BUILD_CAPACITY_KIB=10485760',
+    'quality-and-flows',
+    'merge_commit_sha',
+    'GIT_NO_REPLACE_OBJECTS=1',
+    'GIT_CONFIG_GLOBAL=/dev/null',
+    "PRODUCTION_ENV_FILE='/etc/tokems/production.env'",
+    'GIT_TERMINAL_PROMPT=0',
+    'GIT_FETCH_TIMEOUT_SECONDS=180',
+    'BUILD_TIMEOUT_SECONDS=3600',
+    "LOCAL_DOCKER_HOST='unix:///var/run/docker.sock'",
+    '--project-name "$COMPOSE_PROJECT"',
+    '-f "$active_compose_file"',
+    'COMPOSE_PARALLEL_LIMIT=1',
+    'SEED_DEMO_DATA=false',
+    'SEED_DEMO_DATA=true',
+    'assert_current_runtime_identity',
+    'assert_no_parallel_release',
+    'assert_standard_release_scope',
+    "docker info --format '{{.DockerRootDir}}'",
+    'MIN_BACKUP_RESERVE_KIB=4194304',
+    'protected-business-ids-before.csv',
+    'protected-business-ids-after.csv',
+    'TOKEMS_COMPATIBILITY_ROLLBACK',
+    'automatic-rollback-health.json',
+    'repair_runtime_identity',
+    'identity-repair-result.txt',
+    'assert_unique_production_env_keys',
+    'assert_api_uses_compose_database',
+    'system_identifier',
+    'enter_release_write_freeze',
+    'refresh_pre_mutation_database_backup',
+    'default_transaction_read_only=on',
+    'thaw_release_write_freeze',
+    'connectionTimeoutMillis: 10000',
+    'statement_timeout: 10000',
+    'query_timeout: 10000',
+    'timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker exec',
+    '--kill-after=10s',
+    'SERVICE_TRANSITION_TIMEOUT_SECONDS=360',
+    'WORKER_READY_TIMEOUT_SECONDS=2400',
+    'tokems-worker-ready.json',
+    'assert_final_backup_capacity',
+    'assert_release_verification_capacity',
+    'assert_post_thaw_evidence_capacity',
+    'DATA_COMPARE_MAX_VIRTUAL_KIB=262144',
+    'assert_ordered_subsequence',
+    'RECOVERY_REQUIRED',
+    'arm_release_recovery_marker',
+    'failed-release-database-state-pending',
+    'production-protection-cutoff.txt',
+    'retention-managed-ids-before.csv',
+    'assert_pending_recovery_policy',
+    'assert_operational_write_state',
+    'deploy --resume-recovery',
+    'resolve_pending_recovery',
+    'recover_interrupted_release',
+    "release_phase='pre-write'",
+    'docker-compose.thaw-guard.yml',
+    'start_thaw_watchdog',
+    'compare_production_data recovery-resolve "$baseline_phase"',
+    'canonical-homepage.public.resolved-runtime.json',
+    'recovery-resolve-result.txt',
+    'cp -a -- "$read_only_compose_file" "$backup_dir/docker-compose.read-only.yml"',
+    'automatic-rollback-migration-state.txt',
+    'automatic-rollback-target-writes-state.txt',
+    'automatic-rollback-canonical-state.txt',
+    'manual_review=required',
+    'writes=read-only-api-and-paused-worker',
+    '--no-deps',
+    '--connect-timeout 10',
+    '--max-time 60',
+    'public homepage content does not match the canonical public snapshot',
+  ]) {
+    assert.ok(source.includes(required), `missing production gate: ${required}`);
+  }
+});
+
+test('production deploy workflow creates recovery evidence before mutation and verifies after switch', () => {
+  const mainStart = source.indexOf('\nmain() {');
+  assert.ok(mainStart >= 0, 'top-level main function was not found');
+  const main = source.slice(mainStart);
+  const steps = [
+    'run_full_preflight',
+    'create_backup_and_rollback_point',
+    'sync_source',
+    'write_build_identity',
+    'build_images',
+    'enter_release_write_freeze',
+    'refresh_pre_mutation_database_backup',
+    'run_database_updates',
+    'switch_services',
+    'verify_release',
+    'thaw_release_write_freeze',
+    'write_success_summary',
+  ];
+  let previous = -1;
+  for (const step of steps) {
+    const current = main.indexOf(step);
+    assert.ok(current > previous, `${step} must follow the preceding release step`);
+    previous = current;
+  }
+
+  assert.match(source, /restore_application_rollback/);
+  assert.match(source, /conference\.dump/);
+  assert.match(source, /conference-build-start\.dump/);
+  assert.match(source, /rollback-/);
+  assert.match(source, /Production business counts and sold values were preserved/);
+  assert.match(source, /protected production records disappeared/);
+  assert.match(source, /Database advanced during the failed release/);
+  assert.match(source, /canonical_update_started='true'/);
+  assert.match(source, /canonical-homepage\.public\.before\.json/);
+  assert.match(source, /business-counts-post-thaw\.csv/);
+  assert.match(source, /compare_production_data post-thaw/);
+  assert.match(source, /write_pending_recovery_marker 'release-pre-write-armed'/);
+  assert.doesNotMatch(source, /return \{tuple\(row\) for row/);
+  assert.match(
+    source,
+    /enter_release_write_freeze\n\s+refresh_pre_mutation_database_backup\n\s+run_database_updates/,
+  );
+});
+
+test('production deploy protects durable and retention-managed business identity classes', () => {
+  for (const table of [
+    'organizations',
+    'events',
+    'users',
+    'customer_users',
+    'public_user_ids',
+    'customer_profiles',
+    'customer_media_assets',
+    'customer_consents',
+    'memberships',
+    'member_profiles',
+    'organization_integrations',
+    'organization_invitations',
+    'registrations',
+    'orders',
+    'order_state_logs',
+    'inventory_reservations',
+    'payments',
+    'payment_notification_inbox',
+    'refunds',
+    'invoice_requests',
+    'invoice_documents',
+    'order_access_tokens',
+    'tickets',
+    'checkin_devices',
+    'checkin_records',
+    'cooperation_requests',
+    'waitlist_entries',
+    'notification_deliveries',
+    'ai_runs',
+    'template_ai_mapping_actions',
+    'outbox_events',
+    'audit_logs',
+    'agent_connections',
+    'agent_operations',
+  ]) {
+    assert.match(
+      source,
+      new RegExp(`\\('stable', '${table}',`),
+      `missing stable protected IDs for ${table}`,
+    );
+  }
+  for (const table of [
+    'customer_auth_challenges',
+    'customer_sessions',
+    'idempotency_keys',
+    'order_access_link_attempts',
+    'agent_device_authorizations',
+    'agent_refresh_tokens',
+  ]) {
+    assert.match(
+      source,
+      new RegExp(`\\('retention', '${table}',`),
+      `missing retention evidence for ${table}`,
+    );
+  }
+  assert.doesNotMatch(source, /\('stable', 'speaker_public_routes',/);
+  assert.doesNotMatch(source, /create temp table protected_release_ids/);
+  assert.match(source, /order by %s;'/);
+});
+
+test('production data comparison streams ordered IDs and rejects a missing protected record', () => {
+  const match = source.match(/compare_production_data\(\) \{[\s\S]*?<<'PY'\n([\s\S]*?)\nPY/);
+  assert.ok(match, 'production data comparison Python program was not found');
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-production-compare-'));
+  const files = Array.from({ length: 8 }, (_, index) => resolve(directory, `${index}.csv`));
+  try {
+    writeFileSync(files[0], 'orders,2\n');
+    writeFileSync(files[1], 'orders,3\n');
+    writeFileSync(files[2], 'orders,hex-999\norders,hex-1000\n');
+    writeFileSync(
+      files[3],
+      'orders,hex-added-before\norders,hex-999\norders,hex-added-middle\norders,hex-1000\n',
+    );
+    for (const index of [4, 5, 6, 7]) writeFileSync(files[index], 'ticket,1\n');
+
+    const accepted = spawnSync('python3', ['-', 'growth', ...files], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.equal(accepted.status, 0, accepted.stderr);
+
+    for (const index of [2, 3, 4, 5, 6, 7]) writeFileSync(files[index], '');
+    const acceptedEmptySets = spawnSync('python3', ['-', 'growth', ...files], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.equal(acceptedEmptySets.status, 0, acceptedEmptySets.stderr);
+
+    writeFileSync(files[2], 'orders,hex-999\norders,hex-1000\n');
+    writeFileSync(files[3], 'orders,hex-999\norders,hex-added-after\n');
+    const rejected = spawnSync('python3', ['-', 'growth', ...files], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stderr, /protected production records disappeared/);
+
+    writeFileSync(files[1], 'orders,2\n');
+    writeFileSync(files[2], 'orders,hex-999\norders,hex-1000\n');
+    writeFileSync(files[3], 'orders,hex-999\norders,hex-added\norders,hex-1000\n');
+    const exactRejected = spawnSync('python3', ['-', 'exact', ...files], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.notEqual(exactRejected.status, 0);
+    assert.match(exactRejected.stderr, /record identities changed during the write freeze/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('canonical data comparison permits only snapshot-declared rows with zero new sales', () => {
+  const match = source.match(/compare_production_data\(\) \{[\s\S]*?<<'PY'\n([\s\S]*?)\nPY/);
+  assert.ok(match, 'production data comparison Python program was not found');
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-canonical-compare-'));
+  const files = Array.from({ length: 8 }, (_, index) => resolve(directory, `${index}.csv`));
+  const snapshotFile = resolve(directory, 'snapshot.json');
+  const encoded = (value) => Buffer.from(JSON.stringify([value]), 'utf8').toString('hex');
+  const targetRelease = 'release-target';
+  const targetVersion = 'version-target';
+  const targetTicket = 'ticket-target';
+  const targetQuota = 'quota-target';
+  try {
+    writeFileSync(files[0], 'orders,1\n');
+    writeFileSync(files[1], 'orders,1\n');
+    writeFileSync(
+      files[2],
+      [
+        `conference_template_versions,${encoded('version-old')}`,
+        `event_releases,${encoded('release-old')}`,
+        `organizations,${encoded('organization-old')}`,
+      ].join('\n') + '\n',
+    );
+    writeFileSync(
+      files[3],
+      [
+        `conference_template_versions,${encoded('version-old')}`,
+        `conference_template_versions,${encoded(targetVersion)}`,
+        `event_releases,${encoded('release-old')}`,
+        `event_releases,${encoded(targetRelease)}`,
+        `organizations,${encoded('organization-old')}`,
+      ].join('\n') + '\n',
+    );
+    writeFileSync(files[4], 'ticket-old,5\n');
+    writeFileSync(files[5], `ticket-old,5\n${targetTicket},0\n`);
+    writeFileSync(files[6], 'quota-old,7\n');
+    writeFileSync(files[7], `quota-old,7\n${targetQuota},0\n`);
+    writeFileSync(
+      snapshotFile,
+      JSON.stringify({
+        release: { id: targetRelease },
+        template: { publishedVersions: [{ id: targetVersion }] },
+        backend: { ticketTypes: [{ id: targetTicket }] },
+        ticketQuotas: [{ id: targetQuota }],
+      }),
+    );
+
+    const accepted = spawnSync('python3', ['-', 'canonical', ...files, snapshotFile], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.equal(accepted.status, 0, accepted.stderr);
+
+    writeFileSync(files[5], `ticket-old,5\n${targetTicket},1\n`);
+    const soldRejected = spawnSync('python3', ['-', 'canonical', ...files, snapshotFile], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.notEqual(soldRejected.status, 0);
+    assert.match(soldRejected.stderr, /zero sold inventory/);
+
+    writeFileSync(files[5], `ticket-old,5\n${targetTicket},0\n`);
+    writeFileSync(
+      files[3],
+      readFileSync(files[3], 'utf8') + `organizations,${encoded('organization-unexpected')}\n`,
+    );
+    const identityRejected = spawnSync('python3', ['-', 'canonical', ...files, snapshotFile], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.notEqual(identityRejected.status, 0);
+    assert.match(identityRejected.stderr, /identities changed for organizations/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('protected rollback blocks writes and persists recovery before database evidence queries', () => {
+  const rollback = source.slice(
+    source.indexOf('restore_application_rollback() {'),
+    source.indexOf('\non_exit() {'),
+  );
+  const marker = rollback.indexOf(
+    "write_pending_recovery_marker 'failed-release-database-state-pending'",
+  );
+  const stop = rollback.indexOf('compose_bounded 60 stop --timeout 30 api worker');
+  const databaseRead = rollback.indexOf('read_database_migration_hash');
+  assert.ok(marker >= 0 && marker < databaseRead, 'recovery marker must precede database evidence');
+  assert.ok(stop >= 0 && stop < databaseRead, 'write stop must precede database evidence');
+
+  const enterFreeze = source.slice(
+    source.indexOf('enter_release_write_freeze() {'),
+    source.indexOf('\nthaw_release_write_freeze() {'),
+  );
+  assert.ok(
+    enterFreeze.indexOf('arm_release_recovery_marker') <
+      enterFreeze.indexOf('compose_bounded 60 stop --timeout 30 api worker'),
+    'persistent recovery must be armed before the write freeze transition',
+  );
+  const main = source.slice(source.indexOf('main() {'));
+  assert.ok(
+    main.indexOf('enter_release_write_freeze') < main.indexOf('run_database_updates'),
+    'the armed write freeze must precede database updates',
+  );
+});
+
+test('worker publishes a persistent release identity only after startup maintenance', () => {
+  const readyWrite = workerSource.indexOf('writeFile(workerReadyTempFile');
+  const readyLog = workerSource.indexOf('`[worker] ready queue=');
+  assert.ok(readyWrite >= 0 && readyWrite < readyLog);
+  const firstConsumerStart = workerSource.indexOf('const workerRun = worker.run()');
+  const finalStartupMaintenance = workerSource.indexOf('await maintainFeishuDigests()');
+  assert.ok(finalStartupMaintenance >= 0 && finalStartupMaintenance < firstConsumerStart);
+  assert.equal(workerSource.match(/autorun: false/g)?.length, 2);
+  assert.match(workerSource, /Promise\.all\(\[worker\.waitUntilReady\(\), htmlImportWorker\.waitUntilReady\(\)\]\)/);
+  assert.match(workerSource, /rename\(workerReadyTempFile, workerReadyFile\)/);
+  assert.match(workerSource, /unlink\(workerReadyFile\)/);
+  assert.match(source, /fs\.readFileSync\('\/tmp\/tokems-worker-ready\.json'/);
+  assert.match(dockerfileSource, /com\.tokems\.worker-ready-protocol="1"/);
+  assert.match(source, /com\.tokems\.worker-ready-protocol/);
+  assert.doesNotMatch(source, /git_as_owner show "\$\{runtime_sha\}:apps\/worker\/src\/main\.ts"/);
+});
+
+test('rollback keeps the immutable pre-release identity after target verification', () => {
+  const rollback = source.slice(
+    source.indexOf('restore_application_rollback() {'),
+    source.indexOf('\non_exit() {'),
+  );
+  assert.match(rollback, /release_baseline_migration_hash/);
+  assert.match(rollback, /release_baseline_code_migration_hash/);
+  assert.doesNotMatch(rollback, /current_database_hash" != "\$runtime_migration_hash/);
+  const success = source.slice(
+    source.indexOf('write_success_summary() {'),
+    source.indexOf('\nmain() {'),
+  );
+  assert.match(success, /release_baseline_sha/);
+  assert.doesNotMatch(success, /"\$runtime_sha"/);
+});
+
+test('target pinning is shared by every mode and recovery verifies the public API', () => {
+  assert.ok(
+    source.match(/assert_target_selection "\$target_sha"/g)?.length >= 3,
+    'target selection must be rechecked by deploy, repair, and recovery modes',
+  );
+  assert.match(source, /public-health-recovery-resolve\.json/);
+  assert.match(source, /assert_health_json <"\$pending_recovery_backup_dir\/public-health-recovery-resolve\.json"/);
+});
+
+test('root deployment pins Docker Compose and trusts only protected recovery paths', () => {
+  assert.match(source, /umask 077/);
+  assert.match(source, /export DOCKER_HOST="\$LOCAL_DOCKER_HOST"/);
+  assert.match(source, /unset COMPOSE_FILE COMPOSE_PROJECT_NAME COMPOSE_PROFILES COMPOSE_ENV_FILES/);
+  assert.match(source, /--project-name "\$COMPOSE_PROJECT"/);
+  assert.match(source, /--project-directory "\$APP_DIR"/);
+  assert.match(source, /--env-file "\$active_env_file"/);
+  assert.match(source, /assert_trusted_release_directory "\$pending_recovery_backup_dir"/);
+  assert.match(source, /env -i "PATH=\$SAFE_PATH" 'HOME=\/root'/);
+  assert.match(source, /snapshot_production_environment/);
+  assert.match(source, /git_as_owner archive --format=tar "\$target_sha"/);
+  assert.match(source, /docker-compose\.build-context\.yml/);
+  assert.match(source, /Recovery backup directory must be an immediate child/);
+  assert.match(source, /Recovery evidence must be owned by root with mode 600/);
+  assert.match(source, /Git replacement references are forbidden/);
+  assert.match(source, /readlink -f \/proc\/\$\$\/fd\/9/);
+  assert.doesNotMatch(source, /TOKEMS_DEPLOY_LOCK_HELD|TOKEMS_DEPLOY_BOOTSTRAPPED|TOKEMS_RECOVERY_BOOTSTRAPPED/);
+  assert.doesNotMatch(source, /"\$APP_DIR\/\.env"|"\$\{APP_DIR\}\/\.env"/);
+  for (const key of [
+    'PUBLIC_ORIGIN',
+    'ADMIN_ORIGIN',
+    'PAYMENT_PUBLIC_ORIGIN',
+    'PAYMENT_PUBLIC_BASE_PATH',
+    'PAYMENT_PUBLIC_URL',
+    'CUSTOMER_OTP_MODE',
+    'ALLOW_INSECURE_LOCAL_AUTH',
+    'VITE_SIMPLE_AUTH',
+    'ENABLE_LOCAL_PAYMENT_SIMULATION',
+  ]) {
+    assert.match(source, new RegExp(`env_value ${key}`), `missing fixed production gate for ${key}`);
+  }
+});
+
+test('public release verification proves the deployed web bundle and document', () => {
+  assert.match(source, /public-web-version-after\.json/);
+  assert.match(source, /build_fingerprint_from_stdin web <"\$backup_dir\/public-web-version-after\.json"/);
+  assert.match(source, /public-homepage-document-after\.html/);
+  assert.match(source, /Public web bundle does not match/);
+});
+
+test('target-schema protected tables may be absent only from the pre-migration baseline', () => {
+  assert.match(source, /:'capture_role' <> 'baseline' and namespace\.oid is null/);
+  assert.match(
+    source,
+    /retention-managed-ids-after\.csv" retention comparison/,
+  );
+});
+
+test('agent terminal states expand only for post-thaw growth evidence', () => {
+  assert.match(source, /:'capture_role' = 'growth_comparison'/);
+  assert.match(
+    source,
+    /protected-business-ids-post-thaw\.csv" stable growth_comparison/,
+  );
+  assert.match(
+    source,
+    /protected-business-ids-after\.csv" stable comparison/,
+  );
+});
+
+test('a resumed write-freeze release never downgrades its persistent recovery phase', () => {
+  const backup = source.slice(
+    source.indexOf('create_backup_and_rollback_point() {'),
+    source.indexOf('\nrefresh_pre_mutation_database_backup() {'),
+  );
+  const inherited = backup.indexOf("if [[ \"$recovery_in_progress\" == 'true' ]]");
+  const writeFreeze = backup.indexOf("release_phase='write-freeze'", inherited);
+  const preWrite = backup.indexOf("release_phase='pre-write'", inherited);
+  assert.ok(inherited >= 0 && writeFreeze > inherited && preWrite > writeFreeze);
+  assert.match(backup, /resumed-write-freeze-release-armed/);
+  assert.match(backup, /recovery_marker_armed='true'/);
+});
+
+test('the thaw watchdog remains active until protected exit recovery finishes', () => {
+  const exitHandler = source.slice(source.indexOf('on_exit() {'), source.indexOf('\non_signal() {'));
+  const rollback = exitHandler.indexOf('restore_application_rollback');
+  const stopWatchdog = exitHandler.lastIndexOf('stop_thaw_watchdog');
+  assert.ok(rollback >= 0 && stopWatchdog > rollback);
+});
+
+test('the supervised watchdog helper is valid and releases only without a recovery marker', () => {
+  const match = source.match(/cat >"\$helper_script" <<'WATCHDOG'\n([\s\S]*?)\nWATCHDOG/);
+  assert.ok(match, 'supervised watchdog helper was not found');
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-watchdog-'));
+  const helper = resolve(directory, 'watchdog.sh');
+  const ready = resolve(directory, 'ready');
+  const log = resolve(directory, 'watchdog.log');
+  try {
+    writeFileSync(helper, match[1]);
+    chmodSync(helper, 0o700);
+    const syntax = spawnSync('bash', ['-n', helper], { encoding: 'utf8' });
+    assert.equal(syntax.status, 0, syntax.stderr);
+    const completed = spawnSync(
+      helper,
+      [
+        '99999999',
+        '1',
+        resolve(directory, 'absent-marker'),
+        ready,
+        log,
+        '/usr/bin:/bin',
+        'unix:///var/run/docker.sock',
+        'tokems',
+        '/tmp',
+        resolve(directory, 'env'),
+        resolve(directory, 'compose.yml'),
+      ],
+      { encoding: 'utf8' },
+    );
+    assert.equal(completed.status, 0, completed.stderr);
+    assert.equal(readFileSync(ready, 'utf8'), 'ready\n');
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('write freeze disables restart before arming recovery and keeps a retrying guard', () => {
+  const freeze = source.slice(
+    source.indexOf('enter_release_write_freeze() {'),
+    source.indexOf('\nthaw_release_write_freeze() {'),
+  );
+  const guard = freeze.indexOf('start_thaw_watchdog');
+  const restartNo = freeze.indexOf('set_write_service_restart_policy no');
+  const marker = freeze.indexOf('arm_release_recovery_marker');
+  const stop = freeze.indexOf('compose_bounded 60 stop --timeout 30 api worker');
+  assert.ok(guard >= 0 && guard < restartNo && restartNo < marker && marker < stop);
+  assert.match(source, /systemd-run/);
+  assert.match(source, /--property=Restart=on-failure/);
+  assert.match(source, /while \[\[ -e "\$recovery_marker" \|\| -L "\$recovery_marker" \]\]; do/);
+  assert.match(source, /write stop is not yet confirmed; retrying/);
+  assert.match(source, /assert_write_services_stopped/);
+});
+
+test('recovery is versioned, offline-capable, and waits for detached database work', () => {
+  assert.match(source, /protocol_version=1/);
+  assert.match(source, /production-deploy\.recovery\.sh/);
+  assert.match(source, /recovery_script_sha256/);
+  assert.match(source, /bootstrap_recovery_script "\$@"/);
+  const recover = source.slice(
+    source.indexOf('recover_interrupted_release() {'),
+    source.indexOf('\nresolve_pending_recovery() {'),
+  );
+  assert.doesNotMatch(recover, /git_fetch_origin_main|verify_github_release_gate/);
+  const resume = source.slice(
+    source.indexOf("if [[ \"$mode\" == 'deploy' && \"$resume_recovery\" == 'true' ]]") ,
+    source.indexOf("if [[ \"$mode\" == 'resolve-recovery' ]]") ,
+  );
+  assert.match(resume, /wait_for_db_init_quiescence/);
+  assert.match(resume, /pending_recovery_target_image_tag/);
+  assert.match(resume, /recovery_runtime" == 'target'/);
+  assert.match(resume, /"\$\{RELEASE_SERVICES\[@\]\}"/);
+  assert.match(source, /com\.docker\.compose\.service=db-init/);
+});
+
+test('release verifies public recovery projection and the full canonical backend snapshot', () => {
+  assert.match(source, /public-homepage-recovery-resolve\.json/);
+  assert.match(source, /canonical-homepage\.snapshot\.\$\{evidence_suffix\}\.json/);
+  assert.match(source, /export-canonical-homepage\.js --stdout/);
+  assert.match(source, /CANONICAL_EXPORT_TRUSTED_COMPOSE_INTERNAL=true/);
+  assert.match(source, /verify_canonical_full_snapshot \\\n\s+"\$resolved_full_snapshot" \\\n\s+recovery-resolve/);
+  assert.match(source, /homepage_projection=shared-by-previous-and-runtime/);
+  assert.match(source, /alternate_full_snapshot/);
+  assert.match(source, /backend settings differ from the verified target snapshot/);
+});
+
+test('production network calls are bounded and infrastructure reconciliation is isolated', () => {
+  assert.doesNotMatch(source, /curl\s+-f/);
+  assert.match(source, /readonly -a CURL_ARGS=/);
+  assert.match(source, /docker-compose\.yml changed/);
+  assert.match(
+    source,
+    /compose_bounded "\$DB_MIGRATION_TIMEOUT_SECONDS" run --rm --no-deps db-init/,
+  );
+  assert.match(
+    source,
+    /compose_bounded "\$SERVICE_TRANSITION_TIMEOUT_SECONDS" up -d \\\n\s+--no-build \\\n\s+--no-deps/,
+  );
+});
+
+test('parallel release awk gate runs portably and detects Docker mutation commands', () => {
+  const match = source.match(
+    /assert_no_parallel_release\(\) \{[\s\S]*?awk -v self_pid="\$\$" '\n([\s\S]*?)\n {2}' >\/dev\/null/,
+  );
+  assert.ok(match, 'parallel release awk program was not found');
+  const program = match[1];
+  const detected = spawnSync('awk', ['-v', 'self_pid=999', program], {
+    encoding: 'utf8',
+    input: '123 docker --context prod compose --env-file .env.production up -d --build\n',
+  });
+  assert.equal(detected.status, 0, detected.stderr);
+
+  const clear = spawnSync('awk', ['-v', 'self_pid=999', program], {
+    encoding: 'utf8',
+    input: '123 node apps/api/dist/main.js\n124 /usr/bin/buildkitd --config /etc/buildkitd.toml\n',
+  });
+  assert.equal(clear.status, 1, clear.stderr);
+});
+
+test('production deploy script excludes destructive recovery shortcuts', () => {
+  for (const forbidden of [
+    /git reset --hard/,
+    /git clean/,
+    /docker system prune/,
+    /docker compose down/,
+    /docker volume rm/,
+    /pg_restore --clean/,
+    /DROP DATABASE/i,
+    /TRUNCATE/i,
+    /rm -rf/,
+  ]) {
+    assert.doesNotMatch(source, forbidden);
+  }
+});

--- a/tooling/production-deploy.sh
+++ b/tooling/production-deploy.sh
@@ -1,0 +1,3165 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+umask 077
+
+readonly APP_DIR='/www/wwwroot/TokEMS'
+readonly BACKUP_ROOT='/www/backup/TokEMS'
+readonly ENV_DIR='/etc/tokems'
+readonly PRODUCTION_ENV_FILE='/etc/tokems/production.env'
+readonly GIT_USER='ecs-user'
+readonly EXPECTED_ORIGIN='https://github.com/yaojingang/TokEMS.git'
+readonly EXPECTED_BRANCH='production'
+readonly EXPECTED_UPSTREAM='origin/main'
+readonly GITHUB_REPOSITORY='yaojingang/TokEMS'
+readonly PUBLIC_ORIGIN='https://hui.ailingdaoli.com'
+readonly ADMIN_ORIGIN='https://admin.hui.ailingdaoli.com'
+readonly PAYMENT_URL='https://www.ailingdaoli.com/pay/hui/'
+readonly PAYMENT_ORIGIN='https://www.ailingdaoli.com'
+readonly PAYMENT_BASE_PATH='/pay/hui'
+readonly PAYMENT_PUBLIC_URL='https://www.ailingdaoli.com/pay/hui'
+readonly COMPOSE_PROJECT='tokems'
+readonly DEFAULT_COMPOSE_FILE_PATH="${APP_DIR}/docker-compose.yml"
+readonly LOCAL_DOCKER_HOST='unix:///var/run/docker.sock'
+readonly SAFE_PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+readonly LOCK_DIR='/run/lock/tokems-production-deploy'
+readonly LOCK_FILE="${LOCK_DIR}/deploy.lock"
+readonly RECOVERY_MARKER="${BACKUP_ROOT}/RECOVERY_REQUIRED"
+readonly MIN_BUILD_CAPACITY_KIB=10485760
+readonly MIN_BUILD_DISK_KIB=12582912
+readonly MIN_BACKUP_RESERVE_KIB=4194304
+readonly DB_PROOF_TIMEOUT_SECONDS=30
+readonly DB_QUERY_TIMEOUT_SECONDS=120
+readonly DB_DUMP_TIMEOUT_SECONDS=1800
+readonly DB_MIGRATION_TIMEOUT_SECONDS=1800
+readonly SERVICE_TRANSITION_TIMEOUT_SECONDS=360
+readonly GIT_FETCH_TIMEOUT_SECONDS=180
+readonly BUILD_TIMEOUT_SECONDS=3600
+readonly DATA_COMPARE_TIMEOUT_SECONDS=300
+readonly DATA_COMPARE_MAX_VIRTUAL_KIB=262144
+readonly POST_THAW_STABILIZATION_SECONDS=15
+readonly WORKER_READY_TIMEOUT_SECONDS=2400
+readonly WORKER_READY_POLL_SECONDS=5
+readonly CANONICAL_ORGANIZATION_SLUG='geo-conference'
+readonly CANONICAL_EVENT_SLUG='tokems26'
+readonly -a CURL_ARGS=(
+  --fail
+  --silent
+  --show-error
+  --connect-timeout 10
+  --max-time 60
+  --retry 2
+  --retry-delay 2
+  --retry-connrefused
+)
+
+readonly -a BUILD_SERVICES=(notification-sink api worker web admin gateway)
+readonly -a RELEASE_SERVICES=(notification-sink api worker web payment-web admin gateway)
+readonly -a LONG_RUNNING_SERVICES=(
+  postgres redis minio mailpit notification-sink api worker web payment-web admin gateway
+)
+readonly -a ROLLBACK_IMAGES=(
+  tokems-api tokems-admin tokems-web tokems-worker tokems-gateway tokems-notification-sink
+)
+readonly -a CANONICAL_SNAPSHOT_PATHS=(
+  packages/contracts/src/canonical-homepage.snapshot.json
+  packages/contracts/src/canonical-homepage.public.json
+)
+
+mode=''
+canonical_mode='auto'
+requested_target_sha=''
+target_sha=''
+source_head_before=''
+runtime_sha=''
+runtime_time=''
+runtime_migration=''
+runtime_migration_hash=''
+runtime_code_migration=''
+runtime_code_migration_hash=''
+release_baseline_sha=''
+release_baseline_time=''
+release_baseline_migration=''
+release_baseline_migration_hash=''
+release_baseline_code_migration=''
+release_baseline_code_migration_hash=''
+release_stamp=''
+backup_dir=''
+rollback_tag=''
+target_image_tag=''
+protection_cutoff=''
+backup_device_id=''
+canonical_sync_required='false'
+canonical_sync_performed='false'
+canonical_update_started='false'
+resume_recovery='false'
+recovery_in_progress='false'
+pending_recovery_backup_dir=''
+pending_recovery_phase=''
+pending_recovery_rollback_tag=''
+pending_recovery_target_sha=''
+pending_recovery_protocol=''
+pending_recovery_script=''
+pending_recovery_script_sha256=''
+pending_recovery_target_image_tag=''
+target_writes_enabled='false'
+recovery_marker_armed='false'
+protected_write_block_confirmed='false'
+release_write_freeze='false'
+read_only_compose_file=''
+backup_ready='false'
+environment_changed='false'
+images_changed='false'
+containers_switched='false'
+database_update_started='false'
+database_changed='false'
+deployment_succeeded='false'
+handling_exit='false'
+repair_env_file=''
+release_phase=''
+deployment_marker_armed='false'
+thaw_watchdog_pid=''
+thaw_watchdog_unit=''
+thaw_guard_compose_file=''
+active_env_file="$PRODUCTION_ENV_FILE"
+active_compose_file="$DEFAULT_COMPOSE_FILE_PATH"
+session_env_file=''
+release_source_dir=''
+build_compose_file=''
+
+usage() {
+  cat <<'USAGE'
+TokEMS production deployment
+
+Usage:
+  sudo bash tooling/production-deploy.sh check [options]
+  sudo bash tooling/production-deploy.sh deploy [options]
+  sudo bash tooling/production-deploy.sh repair-identity [options]
+  sudo bash tooling/production-deploy.sh recover-interrupted [options]
+  sudo bash tooling/production-deploy.sh resolve-recovery [options]
+
+Modes:
+  check                         Run the complete read-only production preflight.
+  deploy                        Back up, update from CI-passed origin/main, migrate, and release.
+  repair-identity               Back up and align protected BUILD_* metadata with the running release.
+  recover-interrupted           Restore a pre-database hard-interrupted release from its rollback point.
+  resolve-recovery              Clear a pending marker after independently restoring normal writes.
+
+Options:
+  --target-sha <40-char-sha>    Require origin/main to equal this exact commit.
+  --sync-canonical              Run the canonical template sync even when snapshots are unchanged.
+  --skip-canonical              Allowed only when canonical snapshots are unchanged.
+  --resume-recovery             Allow deploy to continue a verified read-only recovery state.
+  -h, --help                    Show this help.
+
+The default canonical mode is automatic. A snapshot change always enables the protected
+geo-conference/tokems26 synchronization and preserves production business data.
+USAGE
+}
+
+log() {
+  printf '[TokEMS deploy] %s\n' "$*"
+}
+
+die() {
+  printf '[TokEMS deploy] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+git_as_owner() {
+  sudo -u "$GIT_USER" env -i \
+    "PATH=$SAFE_PATH" \
+    'HOME=/nonexistent' \
+    GIT_TERMINAL_PROMPT=0 \
+    GIT_NO_REPLACE_OBJECTS=1 \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    git -C "$APP_DIR" "$@"
+}
+
+git_fetch_origin_main() {
+  timeout --foreground --kill-after=10s "${GIT_FETCH_TIMEOUT_SECONDS}s" \
+    sudo -u "$GIT_USER" env -i \
+    "PATH=$SAFE_PATH" \
+    'HOME=/nonexistent' \
+    GIT_TERMINAL_PROMPT=0 \
+    GIT_NO_REPLACE_OBJECTS=1 \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    git -C "$APP_DIR" fetch --prune origin main
+}
+
+compose() {
+  local -a clean_env=(env -i "PATH=$SAFE_PATH" 'HOME=/root' "DOCKER_HOST=$LOCAL_DOCKER_HOST")
+  [[ -n "${TOKEMS_READ_ONLY_DATABASE_URL+x}" ]] && clean_env+=("TOKEMS_READ_ONLY_DATABASE_URL=$TOKEMS_READ_ONLY_DATABASE_URL")
+  [[ -n "${SEED_DEMO_DATA+x}" ]] && clean_env+=("SEED_DEMO_DATA=$SEED_DEMO_DATA")
+  [[ -n "${COMPOSE_PARALLEL_LIMIT+x}" ]] && clean_env+=("COMPOSE_PARALLEL_LIMIT=$COMPOSE_PARALLEL_LIMIT")
+  "${clean_env[@]}" docker compose \
+    --project-name "$COMPOSE_PROJECT" \
+    --project-directory "$APP_DIR" \
+    --env-file "$active_env_file" \
+    -f "$active_compose_file" \
+    "$@"
+}
+
+compose_read_only_bounded() {
+  local timeout_seconds="$1"
+  shift
+  local -a clean_env=(env -i "PATH=$SAFE_PATH" 'HOME=/root' "DOCKER_HOST=$LOCAL_DOCKER_HOST")
+  [[ -n "${TOKEMS_READ_ONLY_DATABASE_URL+x}" ]] && clean_env+=("TOKEMS_READ_ONLY_DATABASE_URL=$TOKEMS_READ_ONLY_DATABASE_URL")
+  [[ -n "${SEED_DEMO_DATA+x}" ]] && clean_env+=("SEED_DEMO_DATA=$SEED_DEMO_DATA")
+  timeout --foreground --kill-after=10s "${timeout_seconds}s" \
+    "${clean_env[@]}" docker compose \
+    --project-name "$COMPOSE_PROJECT" \
+    --project-directory "$APP_DIR" \
+    --env-file "$active_env_file" \
+    -f "$active_compose_file" \
+    -f "$read_only_compose_file" \
+    "$@"
+}
+
+compose_bounded() {
+  local timeout_seconds="$1"
+  shift
+  local -a clean_env=(env -i "PATH=$SAFE_PATH" 'HOME=/root' "DOCKER_HOST=$LOCAL_DOCKER_HOST")
+  [[ -n "${TOKEMS_READ_ONLY_DATABASE_URL+x}" ]] && clean_env+=("TOKEMS_READ_ONLY_DATABASE_URL=$TOKEMS_READ_ONLY_DATABASE_URL")
+  [[ -n "${SEED_DEMO_DATA+x}" ]] && clean_env+=("SEED_DEMO_DATA=$SEED_DEMO_DATA")
+  [[ -n "${COMPOSE_PARALLEL_LIMIT+x}" ]] && clean_env+=("COMPOSE_PARALLEL_LIMIT=$COMPOSE_PARALLEL_LIMIT")
+  timeout --foreground --kill-after=10s "${timeout_seconds}s" \
+    "${clean_env[@]}" docker compose \
+    --project-name "$COMPOSE_PROJECT" \
+    --project-directory "$APP_DIR" \
+    --env-file "$active_env_file" \
+    -f "$active_compose_file" \
+    "$@"
+}
+
+compose_thaw_guard_bounded() {
+  local timeout_seconds="$1"
+  shift
+  local -a clean_env=(env -i "PATH=$SAFE_PATH" 'HOME=/root' "DOCKER_HOST=$LOCAL_DOCKER_HOST")
+  timeout --foreground --kill-after=10s "${timeout_seconds}s" \
+    "${clean_env[@]}" docker compose \
+    --project-name "$COMPOSE_PROJECT" \
+    --project-directory "$APP_DIR" \
+    --env-file "$active_env_file" \
+    -f "$active_compose_file" \
+    -f "$thaw_guard_compose_file" \
+    "$@"
+}
+
+compose_build_bounded() {
+  local timeout_seconds="$1"
+  shift
+  [[ -s "$build_compose_file" ]] || die 'Root-owned build context override is unavailable.'
+  local -a clean_env=(env -i "PATH=$SAFE_PATH" 'HOME=/root' "DOCKER_HOST=$LOCAL_DOCKER_HOST")
+  [[ -n "${COMPOSE_PARALLEL_LIMIT+x}" ]] && clean_env+=("COMPOSE_PARALLEL_LIMIT=$COMPOSE_PARALLEL_LIMIT")
+  timeout --foreground --kill-after=10s "${timeout_seconds}s" \
+    "${clean_env[@]}" docker compose \
+    --project-name "$COMPOSE_PROJECT" \
+    --project-directory "$APP_DIR" \
+    --env-file "$active_env_file" \
+    -f "$active_compose_file" \
+    -f "$build_compose_file" \
+    "$@"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command is unavailable: $1"
+}
+
+cleanup_temp_script() {
+  if [[ -f "${BASH_SOURCE[0]}" ]]; then
+    case "${BASH_SOURCE[0]}" in
+      /run/lock/tokems-production-deploy/bootstrap.*) rm -f -- "${BASH_SOURCE[0]}" ;;
+    esac
+  fi
+  if [[ -n "$repair_env_file" && -f "$repair_env_file" ]]; then
+    case "$repair_env_file" in
+      /etc/tokems/production.env.repair.* | /etc/tokems/production.env.release.*) rm -f -- "$repair_env_file" ;;
+    esac
+  fi
+  if [[ -n "$session_env_file" && -f "$session_env_file" ]]; then
+    case "$session_env_file" in
+      /run/lock/tokems-production-deploy/production.env.*) rm -f -- "$session_env_file" ;;
+    esac
+  fi
+}
+
+snapshot_production_environment() {
+  assert_trusted_recovery_file "$PRODUCTION_ENV_FILE"
+  session_env_file="$(mktemp "${LOCK_DIR}/production.env.XXXXXX")"
+  cp -- "$PRODUCTION_ENV_FILE" "$session_env_file"
+  chown root:root "$session_env_file"
+  chmod 600 "$session_env_file"
+  active_env_file="$session_env_file"
+}
+
+install_active_production_environment() {
+  local source_env_file="$active_env_file"
+  assert_trusted_root_directory "$ENV_DIR"
+  repair_env_file="$(mktemp "${PRODUCTION_ENV_FILE}.release.XXXXXX")"
+  cp -- "$source_env_file" "$repair_env_file"
+  chown root:root "$repair_env_file"
+  chmod 600 "$repair_env_file"
+  mv -f -- "$repair_env_file" "$PRODUCTION_ENV_FILE"
+  repair_env_file=''
+  active_env_file="$PRODUCTION_ENV_FILE"
+  assert_trusted_recovery_file "$PRODUCTION_ENV_FILE"
+  case "$source_env_file" in
+    /etc/tokems/production.env.repair.*) rm -f -- "$source_env_file" ;;
+  esac
+}
+
+start_thaw_watchdog() {
+  [[ -z "$thaw_watchdog_unit" ]] || die 'The release write watchdog is already running.'
+  local deploy_parent_pid="$BASHPID" deploy_parent_start helper_script helper_env_file
+  deploy_parent_start="$(awk '{ print $22 }' "/proc/${deploy_parent_pid}/stat")"
+  [[ "$deploy_parent_start" =~ ^[0-9]+$ ]] || die 'Cannot establish the deployment process lease.'
+  helper_script="$backup_dir/thaw-watchdog.sh"
+  helper_env_file="$backup_dir/thaw-watchdog.env"
+  cp -- "$active_env_file" "$helper_env_file"
+  chown root:root "$helper_env_file"
+  chmod 600 "$helper_env_file"
+  cat >"$helper_script" <<'WATCHDOG'
+#!/usr/bin/env bash
+set -u
+umask 077
+
+parent_pid="$1"
+parent_start="$2"
+recovery_marker="$3"
+ready_file="$4"
+log_file="$5"
+safe_path="$6"
+docker_host="$7"
+compose_project="$8"
+project_directory="$9"
+env_file="${10}"
+compose_file="${11}"
+
+PATH="$safe_path"
+export PATH
+exec >>"$log_file" 2>&1
+printf 'ready\n' >"$ready_file"
+chmod 600 "$ready_file"
+
+parent_lease_is_alive() {
+  [[ -r "/proc/${parent_pid}/stat" ]] || return 1
+  [[ "$(awk '{ print $22 }' "/proc/${parent_pid}/stat" 2>/dev/null)" == "$parent_start" ]]
+}
+
+while parent_lease_is_alive; do
+  sleep 2
+done
+
+while [[ -e "$recovery_marker" || -L "$recovery_marker" ]]; do
+  if timeout --foreground --kill-after=10s 60s \
+    env -i "PATH=$safe_path" 'HOME=/root' "DOCKER_HOST=$docker_host" \
+    docker compose \
+      --project-name "$compose_project" \
+      --project-directory "$project_directory" \
+      --env-file "$env_file" \
+      -f "$compose_file" \
+      stop --timeout 30 api worker; then
+    writes_stopped='true'
+    for service in api worker; do
+      container="$(env -i "PATH=$safe_path" 'HOME=/root' "DOCKER_HOST=$docker_host" \
+        docker compose \
+          --project-name "$compose_project" \
+          --project-directory "$project_directory" \
+          --env-file "$env_file" \
+          -f "$compose_file" \
+          ps -a -q "$service" 2>/dev/null || true)"
+      if [[ -n "$container" ]]; then
+        running="$(env -i "PATH=$safe_path" 'HOME=/root' "DOCKER_HOST=$docker_host" \
+          docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null || printf 'unknown')"
+        [[ "$running" == 'false' ]] || writes_stopped='false'
+      fi
+    done
+    if [[ "$writes_stopped" == 'true' ]]; then
+      printf '[%s] API and Worker write containers are stopped.\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+      exit 0
+    fi
+  fi
+  printf '[%s] write stop is not yet confirmed; retrying.\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  sleep 5
+done
+WATCHDOG
+  chown root:root "$helper_script"
+  chmod 700 "$helper_script"
+  rm -f -- "$backup_dir/thaw-watchdog.ready"
+  thaw_watchdog_unit="tokems-write-guard-${release_stamp}"
+  systemd-run \
+    --quiet \
+    --collect \
+    --unit "$thaw_watchdog_unit" \
+    --service-type=exec \
+    --property=Restart=on-failure \
+    --property=RestartSec=5s \
+    "$helper_script" \
+    "$deploy_parent_pid" \
+    "$deploy_parent_start" \
+    "$RECOVERY_MARKER" \
+    "$backup_dir/thaw-watchdog.ready" \
+    "$backup_dir/thaw-watchdog.log" \
+    "$SAFE_PATH" \
+    "$LOCAL_DOCKER_HOST" \
+    "$COMPOSE_PROJECT" \
+    "$APP_DIR" \
+    "$helper_env_file" \
+    "$active_compose_file"
+  local attempt
+  for ((attempt = 0; attempt < 50; attempt += 1)); do
+    if [[ -s "$backup_dir/thaw-watchdog.ready" ]] && systemctl is-active --quiet "$thaw_watchdog_unit"; then
+      thaw_watchdog_pid="$(systemctl show --property=MainPID --value "$thaw_watchdog_unit")"
+      [[ "$thaw_watchdog_pid" =~ ^[1-9][0-9]*$ ]] || die 'The supervised write watchdog has no running process.'
+      printf '%s\n' "$thaw_watchdog_pid" >"$backup_dir/thaw-watchdog.pid"
+      chmod 600 "$backup_dir/thaw-watchdog.pid"
+      return 0
+    fi
+    sleep 0.1
+  done
+  die 'The release write watchdog did not report a healthy startup.'
+}
+
+stop_thaw_watchdog() {
+  [[ -n "$thaw_watchdog_unit" ]] || return 0
+  systemctl stop "$thaw_watchdog_unit" 2>/dev/null || true
+  systemctl reset-failed "$thaw_watchdog_unit" 2>/dev/null || true
+  thaw_watchdog_pid=''
+  thaw_watchdog_unit=''
+}
+
+assert_thaw_watchdog_active() {
+  [[ -n "$thaw_watchdog_unit" ]] || die 'The supervised write watchdog is unavailable.'
+  systemctl is-active --quiet "$thaw_watchdog_unit" || {
+    die 'The supervised write watchdog is not active.'
+  }
+}
+
+restore_application_rollback() {
+  [[ "$backup_ready" == 'true' ]] || return 0
+
+  local protected_recovery='false' marker_status=0 stop_status=0
+  if [[ "$recovery_marker_armed" == 'true' || "$release_write_freeze" == 'true' || "$database_update_started" == 'true' || "$canonical_update_started" == 'true' || "$recovery_in_progress" == 'true' || "$target_writes_enabled" == 'true' ]]; then
+    protected_recovery='true'
+    if ! write_pending_recovery_marker 'failed-release-database-state-pending'; then
+      marker_status=1
+      log "CRITICAL: unable to persist ${RECOVERY_MARKER}."
+    fi
+    if ! compose_bounded 60 stop --timeout 30 api worker \
+      >"${backup_dir}/automatic-rollback-write-stop.log" 2>&1; then
+      stop_status=1
+      log "CRITICAL: unable to confirm that API and Worker writes stopped; intervene immediately."
+    else
+      protected_write_block_confirmed='true'
+      release_write_freeze='true'
+    fi
+    if [[ $marker_status -ne 0 || $stop_status -ne 0 ]]; then
+      return 1
+    fi
+  fi
+
+  unset TOKEMS_READ_ONLY_DATABASE_URL
+
+  log "Restoring application rollback point ${rollback_tag}"
+  active_env_file="${backup_dir}/.env"
+  active_compose_file="${backup_dir}/docker-compose.yml"
+  if [[ "$images_changed" == 'true' ]]; then
+    local image
+    for image in "${ROLLBACK_IMAGES[@]}"; do
+      docker image inspect "${image}:${rollback_tag}" >/dev/null 2>&1 || return 1
+      docker tag "${image}:${rollback_tag}" "${image}:local" || return 1
+    done
+  fi
+
+  local current_database_hash='' current_database_migration=''
+  if [[ "$database_update_started" == 'true' ]]; then
+    if ! current_database_hash="$(read_database_migration_hash)"; then
+      log 'Database migration identity is unavailable; old images and environment are restored while API and Worker remain stopped.'
+      return 1
+    fi
+    if [[ ! "$current_database_hash" =~ ^[0-9a-f]{64}$ ]]; then
+      log 'Database migration identity is invalid; old images and environment are restored while API and Worker remain stopped.'
+      return 1
+    fi
+    if [[ "$current_database_hash" != "$release_baseline_migration_hash" ]]; then
+      if ! current_database_migration="$(migration_name_for_hash "$current_database_hash")" || [[ -z "$current_database_migration" ]]; then
+        log 'Database migration cannot be mapped to reviewed source; API and Worker remain stopped.'
+        return 1
+      fi
+      database_changed='true'
+    fi
+  fi
+
+  if [[ "$database_changed" == 'true' ]]; then
+    log "Database advanced during the failed release; aligning read-only rollback metadata with ${current_database_migration}"
+    cp -- "$backup_dir/.env" "$backup_dir/.env.rollback-runtime" || return 1
+    chown root:root "$backup_dir/.env.rollback-runtime" || return 1
+    chmod 600 "$backup_dir/.env.rollback-runtime" || return 1
+    active_env_file="$backup_dir/.env.rollback-runtime"
+    set_env_value BUILD_MIGRATION "$current_database_migration"
+    set_env_value BUILD_MIGRATION_HASH "$current_database_hash"
+    set_release_metadata_value TOKEMS_COMPATIBILITY_ROLLBACK active
+    set_release_metadata_value TOKEMS_ROLLBACK_CODE_MIGRATION "$release_baseline_code_migration"
+    set_release_metadata_value TOKEMS_ROLLBACK_CODE_MIGRATION_HASH "$release_baseline_code_migration_hash"
+    printf 'mode=read-only-application-rollback-pending-review\ndatabase_migration=%s\ndatabase_migration_hash=%s\n' \
+      "$current_database_migration" "$current_database_hash" \
+      >"${backup_dir}/automatic-rollback-identity.txt"
+    chmod 600 "${backup_dir}/automatic-rollback-identity.txt"
+    printf 'database_migration_changed=true\nautomatic_database_restore=false\nmanual_review=required\nwrites=read-only-api-and-paused-worker\n' \
+      >"${backup_dir}/automatic-rollback-migration-state.txt"
+    chmod 600 "${backup_dir}/automatic-rollback-migration-state.txt"
+  fi
+
+  if [[ "$environment_changed" == 'true' || "$database_changed" == 'true' ]]; then
+    install_active_production_environment || return 1
+  fi
+
+  if [[ "$target_writes_enabled" == 'true' ]]; then
+    printf 'target_writes_enabled=true\nmanual_review=required\nwrites=read-only-api-and-paused-worker\n' \
+      >"${backup_dir}/automatic-rollback-target-writes-state.txt"
+    chmod 600 "${backup_dir}/automatic-rollback-target-writes-state.txt"
+  fi
+
+  if [[ "$protected_recovery" == 'true' ]]; then
+    local recovery_reason='resumed-release-failed'
+    [[ "$database_changed" == 'false' ]] || recovery_reason='database-migration-changed'
+    [[ "$canonical_update_started" == 'false' ]] || recovery_reason='canonical-update-started'
+    [[ "$target_writes_enabled" == 'false' ]] || recovery_reason='target-writes-were-enabled'
+    if ! write_pending_recovery_marker "$recovery_reason"; then
+      log "Unable to persist ${RECOVERY_MARKER}; continuing the read-only application recovery."
+    fi
+    [[ -s "$read_only_compose_file" ]] || return 1
+    export TOKEMS_READ_ONLY_DATABASE_URL
+    TOKEMS_READ_ONLY_DATABASE_URL="$(read_only_database_url)" || return 1
+  fi
+
+  if [[ "$canonical_update_started" == 'true' ]]; then
+    printf 'canonical_update_started=true\nautomatic_database_restore=false\nmanual_review=required\nwrites=read-only-api-and-paused-worker\n' \
+      >"${backup_dir}/automatic-rollback-canonical-state.txt"
+    chmod 600 "${backup_dir}/automatic-rollback-canonical-state.txt"
+  fi
+
+  if [[ "$containers_switched" == 'true' || "$database_changed" == 'true' ]]; then
+    if [[ "$protected_recovery" == 'true' ]]; then
+      compose_read_only_bounded "$SERVICE_TRANSITION_TIMEOUT_SECONDS" \
+        up -d \
+        --no-build \
+        --no-deps \
+        --force-recreate \
+        --wait \
+        --wait-timeout 300 \
+        "${RELEASE_SERVICES[@]}" \
+        >"${backup_dir}/automatic-rollback.log" 2>&1 || return 1
+    else
+      compose_bounded "$SERVICE_TRANSITION_TIMEOUT_SECONDS" \
+        up -d \
+        --no-build \
+        --no-deps \
+        --force-recreate \
+        --wait \
+        --wait-timeout 300 \
+        "${RELEASE_SERVICES[@]}" \
+        >"${backup_dir}/automatic-rollback.log" 2>&1 || return 1
+    fi
+  fi
+
+  curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/health' \
+    >"${backup_dir}/automatic-rollback-health.json" || return 1
+  assert_health_json <"${backup_dir}/automatic-rollback-health.json" || return 1
+  assert_current_runtime_identity || return 1
+  assert_api_uses_compose_database || return 1
+
+  if [[ "$protected_recovery" == 'true' ]]; then
+    curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/homepage' \
+      >"${backup_dir}/automatic-rollback-homepage.json" || return 1
+    local projection_state
+    if verify_homepage_file \
+      "${backup_dir}/automatic-rollback-homepage.json" \
+      "${backup_dir}/canonical-homepage.public.before.json"; then
+      projection_state='public_projection=matches_previous_release'
+    else
+      projection_state='public_projection=differs_from_previous_release'
+    fi
+    if [[ "$canonical_update_started" == 'true' ]]; then
+      printf '%s\n' "$projection_state" >>"${backup_dir}/automatic-rollback-canonical-state.txt"
+    fi
+    if [[ "$database_changed" == 'true' ]]; then
+      printf '%s\n' "$projection_state" >>"${backup_dir}/automatic-rollback-migration-state.txt"
+    fi
+    if [[ "$target_writes_enabled" == 'true' ]]; then
+      printf '%s\n' "$projection_state" >>"${backup_dir}/automatic-rollback-target-writes-state.txt"
+    fi
+    return 1
+  fi
+
+  return 0
+}
+
+on_exit() {
+  local exit_code=$?
+  [[ "$handling_exit" == 'false' ]] || return
+  handling_exit='true'
+  trap - EXIT ERR
+  trap '' HUP INT TERM
+  set +e
+
+  if [[ $exit_code -ne 0 && "$deployment_succeeded" != 'true' && "$backup_ready" == 'true' ]]; then
+    printf 'status=failed\ntarget_sha=%s\nruntime_before=%s\nbackup_dir=%s\n' \
+      "$target_sha" "$release_baseline_sha" "$backup_dir" \
+      >"${backup_dir}/deployment-result.txt"
+    chmod 600 "${backup_dir}/deployment-result.txt"
+    if restore_application_rollback; then
+      if [[ "$recovery_marker_armed" == 'false' && "$release_write_freeze" == 'false' && "$database_update_started" == 'false' && "$canonical_update_started" == 'false' && "$target_writes_enabled" == 'false' ]]; then
+        clear_pending_recovery_marker || log "Pre-database rollback completed, but ${RECOVERY_MARKER} still requires manual review."
+      fi
+      printf 'recovery=application-rollback\n' >>"${backup_dir}/deployment-result.txt"
+      log "Application rollback restored. Database backups remain at ${backup_dir}."
+    else
+      printf 'recovery=manual-follow-through-required\n' >>"${backup_dir}/deployment-result.txt"
+      if [[ "$recovery_marker_armed" == 'true' || "$release_write_freeze" == 'true' || "$database_update_started" == 'true' || "$canonical_update_started" == 'true' || "$recovery_in_progress" == 'true' || "$target_writes_enabled" == 'true' ]]; then
+        if [[ "$protected_write_block_confirmed" == 'true' ]]; then
+          log "Protected recovery needs manual follow-through; API and Worker writes are blocked. Evidence: ${backup_dir}."
+        else
+          log "CRITICAL: protected recovery could not confirm the write block. Intervene immediately and inspect ${backup_dir}."
+        fi
+      else
+        log "Automatic application rollback needs manual follow-through from ${backup_dir}."
+      fi
+    fi
+  fi
+
+  if [[ "$deployment_succeeded" == 'true' || "$protected_write_block_confirmed" == 'true' || ( ! -e "$RECOVERY_MARKER" && ! -L "$RECOVERY_MARKER" ) ]]; then
+    stop_thaw_watchdog
+  elif [[ -n "$thaw_watchdog_unit" ]] && systemctl is-active --quiet "$thaw_watchdog_unit"; then
+    log "The supervised write watchdog ${thaw_watchdog_unit} remains active until API and Worker writes are confirmed stopped."
+    thaw_watchdog_pid=''
+    thaw_watchdog_unit=''
+  elif [[ -n "$thaw_watchdog_unit" ]]; then
+    log "CRITICAL: the supervised write watchdog ${thaw_watchdog_unit} is not active while recovery remains pending."
+    thaw_watchdog_pid=''
+    thaw_watchdog_unit=''
+  fi
+  cleanup_temp_script
+  exit "$exit_code"
+}
+
+on_signal() {
+  local signal_name="$1" exit_code="$2"
+  log "Received ${signal_name}; starting the protected exit path."
+  exit "$exit_code"
+}
+
+trap on_exit EXIT
+trap 'on_signal HUP 129' HUP
+trap 'on_signal INT 130' INT
+trap 'on_signal TERM 143' TERM
+
+parse_arguments() {
+  [[ $# -gt 0 ]] || {
+    usage >&2
+    exit 2
+  }
+
+  mode="$1"
+  shift
+  case "$mode" in
+    check | deploy | repair-identity | recover-interrupted | resolve-recovery) ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target-sha)
+        [[ $# -ge 2 ]] || die '--target-sha requires a value'
+        requested_target_sha="$2"
+        shift 2
+        ;;
+      --sync-canonical)
+        canonical_mode='always'
+        shift
+        ;;
+      --skip-canonical)
+        canonical_mode='never'
+        shift
+        ;;
+      --resume-recovery)
+        resume_recovery='true'
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *) die "Unknown option: $1" ;;
+    esac
+  done
+
+  if [[ -n "$requested_target_sha" && ! "$requested_target_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    die '--target-sha must be a full lowercase 40-character Git SHA'
+  fi
+  if [[ ( "$mode" == 'repair-identity' || "$mode" == 'recover-interrupted' || "$mode" == 'resolve-recovery' ) && "$canonical_mode" != 'auto' ]]; then
+    die 'Canonical synchronization options apply only to check and deploy modes.'
+  fi
+  if [[ "$resume_recovery" == 'true' && "$mode" != 'deploy' ]]; then
+    die '--resume-recovery applies only to deploy mode.'
+  fi
+}
+
+assert_target_selection() {
+  local actual_sha="$1"
+  if [[ -n "$requested_target_sha" && "$requested_target_sha" != "$actual_sha" ]]; then
+    die "origin/main is ${actual_sha}; requested target was ${requested_target_sha}."
+  fi
+}
+
+pin_local_runtime_controls() {
+  PATH="$SAFE_PATH"
+  export PATH
+  export DOCKER_HOST="$LOCAL_DOCKER_HOST"
+  unset DOCKER_CONTEXT DOCKER_CONFIG
+  unset DOCKER_TLS_VERIFY DOCKER_CERT_PATH DOCKER_API_VERSION
+  unset COMPOSE_FILE COMPOSE_PROJECT_NAME COMPOSE_PROFILES COMPOSE_ENV_FILES
+  unset COMPOSE_PATH_SEPARATOR COMPOSE_CONVERT_WINDOWS_PATHS COMPOSE_IGNORE_ORPHANS
+  unset BUILD_SHA BUILD_TIME BUILD_MIGRATION BUILD_MIGRATION_HASH
+  unset TOKEMS_READ_ONLY_DATABASE_URL SEED_DEMO_DATA COMPOSE_PARALLEL_LIMIT
+}
+
+require_root_and_base_commands() {
+  [[ "$(id -u)" -eq 0 ]] || die 'Run this command with sudo or as root.'
+  local command_name
+  for command_name in bash sudo env git flock curl python3 docker nginx awk grep sed sha256sum find sort tail tar install ps mkdir stat dirname df mktemp cp mv chmod chown rm basename date timeout sleep cat readlink systemd-run systemctl; do
+    require_command "$command_name"
+  done
+  [[ "$(cd "$APP_DIR" && pwd -P)" == "$APP_DIR" ]] || die 'Production app path resolved unexpectedly.'
+  if [[ ! -e "$ENV_DIR" && ! -L "$ENV_DIR" ]]; then
+    install -d -o root -g root -m 700 "$ENV_DIR"
+  fi
+  assert_trusted_root_directory "$ENV_DIR"
+  [[ "$(stat -c '%a' "$ENV_DIR")" == '700' ]] || die "Production environment directory must have mode 700: ${ENV_DIR}"
+  if [[ "$mode" != 'recover-interrupted' ]]; then
+    [[ -d "$APP_DIR/.git" ]] || die "Git checkout is missing at ${APP_DIR}"
+    assert_trusted_recovery_file "$PRODUCTION_ENV_FILE"
+  fi
+  [[ -S /var/run/docker.sock ]] || die 'The local Docker Unix socket is unavailable.'
+  ensure_trusted_backup_root
+}
+
+assert_trusted_root_directory() {
+  local directory="$1" mode numeric_mode
+  [[ -d "$directory" && ! -L "$directory" ]] || die "Trusted directory is missing or symbolic: ${directory}"
+  [[ "$(stat -c '%u' "$directory")" == '0' ]] || die "Trusted directory must be owned by root: ${directory}"
+  mode="$(stat -c '%a' "$directory")"
+  numeric_mode=$((8#$mode))
+  (( (numeric_mode & 0022) == 0 )) || die "Trusted directory must not be writable by group or others: ${directory}"
+}
+
+ensure_trusted_backup_root() {
+  assert_trusted_root_directory /www
+  if [[ ! -e /www/backup && ! -L /www/backup ]]; then
+    install -d -o root -g root -m 700 /www/backup
+  fi
+  assert_trusted_root_directory /www/backup
+  if [[ ! -e "$BACKUP_ROOT" && ! -L "$BACKUP_ROOT" ]]; then
+    install -d -o root -g root -m 700 "$BACKUP_ROOT"
+  fi
+  assert_trusted_root_directory "$BACKUP_ROOT"
+}
+
+assert_trusted_release_directory() {
+  local directory="$1" release_name
+  [[ "$(dirname "$directory")" == "$BACKUP_ROOT" ]] || die 'Recovery backup directory must be an immediate child of the backup root.'
+  release_name="$(basename "$directory")"
+  [[ "$release_name" =~ ^[0-9]{8}-[0-9]{6}$ ]] || die 'Recovery backup directory has an invalid release name.'
+  assert_trusted_root_directory "$directory"
+  [[ "$(stat -c '%a' "$directory")" == '700' ]] || die 'Recovery backup directory must have mode 700.'
+}
+
+assert_trusted_recovery_file() {
+  local file_name="$1"
+  [[ -f "$file_name" && ! -L "$file_name" ]] || die "Recovery evidence must be a regular non-symbolic file: ${file_name}"
+  [[ "$(stat -c '%u:%a' "$file_name")" == '0:600' ]] || {
+    die "Recovery evidence must be owned by root with mode 600: ${file_name}"
+  }
+}
+
+assert_no_parallel_release() {
+  if ps -eo pid=,args= | awk -v self_pid="$$" '
+    $1 != self_pid && ($0 ~ /docker[ ]+.*compose[ ]+([^ ]+[ ]+)*(build|run|up|stop|restart)([ ]|$)/ || $0 ~ /docker[-]compose[ ]+([^ ]+[ ]+)*(build|run|up|stop|restart)([ ]|$)/ || $0 ~ /docker[ ]+.*buildx[ ]+([^ ]+[ ]+)*build([ ]|$)/ || $0 ~ /docker[ ]+([^ ]+[ ]+)*build([ ]|$)/ || $0 ~ /buildctl[ ]+([^ ]+[ ]+)*build([ ]|$)/) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' >/dev/null; then
+    die 'Another Docker build, migration, or service switch is already running on this host.'
+  fi
+  local db_init_containers
+  db_init_containers="$(docker ps -q \
+    --filter "label=com.docker.compose.project=${COMPOSE_PROJECT}" \
+    --filter 'label=com.docker.compose.service=db-init')"
+  if [[ -n "$db_init_containers" ]]; then
+    if [[ "$mode" == 'deploy' && "$resume_recovery" == 'true' ]]; then
+      log 'A detached db-init container belongs to the interrupted release; recovery will wait for it.'
+    else
+      die 'A TokEMS db-init container is still running; database state must become quiescent first.'
+    fi
+  fi
+}
+
+wait_for_db_init_quiescence() {
+  local deadline=$((SECONDS + DB_MIGRATION_TIMEOUT_SECONDS)) containers
+  while true; do
+    containers="$(docker ps -q \
+      --filter "label=com.docker.compose.project=${COMPOSE_PROJECT}" \
+      --filter 'label=com.docker.compose.service=db-init')"
+    [[ -n "$containers" ]] || return 0
+    (( SECONDS < deadline )) || die 'Detached db-init did not finish within the recovery timeout.'
+    sleep 5
+  done
+}
+
+assert_recovery_migration_chain() {
+  local current_hash="$1" baseline_hash="$2" target_hash="$3"
+  local source_dir="$pending_recovery_backup_dir/source/packages/database/drizzle"
+  [[ -d "$source_dir" && ! -L "$source_dir" ]] || die 'Protected target migration source is unavailable.'
+  python3 - "$source_dir" "$current_hash" "$baseline_hash" "$target_hash" <<'PY'
+import hashlib
+import pathlib
+import re
+import sys
+
+source = pathlib.Path(sys.argv[1])
+current, baseline, target = sys.argv[2:]
+files = sorted(path for path in source.iterdir() if re.fullmatch(r"[0-9]{4}_.+\.sql", path.name))
+hashes = [hashlib.sha256(path.read_bytes()).hexdigest() for path in files]
+if len(hashes) != len(set(hashes)):
+    raise SystemExit("target migration chain contains duplicate hashes")
+try:
+    baseline_index = hashes.index(baseline)
+    current_index = hashes.index(current)
+    target_index = hashes.index(target)
+except ValueError as error:
+    raise SystemExit("current database hash is outside the protected target migration chain") from error
+if not baseline_index <= current_index <= target_index:
+    raise SystemExit("current database hash is outside the baseline-to-target migration interval")
+print("Protected recovery migration chain verified")
+PY
+}
+
+acquire_deploy_lock() {
+  if [[ -L "$LOCK_DIR" ]]; then
+    die "Deployment lock directory must not be a symbolic link: ${LOCK_DIR}"
+  fi
+  if [[ ! -e "$LOCK_DIR" ]]; then
+    mkdir -m 700 -- "$LOCK_DIR" || die "Unable to create deployment lock directory: ${LOCK_DIR}"
+  fi
+  [[ -d "$LOCK_DIR" && ! -L "$LOCK_DIR" ]] || die 'Deployment lock path is not a trusted directory.'
+  [[ "$(stat -c '%u:%a' "$LOCK_DIR")" == '0:700' ]] || {
+    die 'Deployment lock directory must be owned by root with mode 700.'
+  }
+  [[ ! -L "$LOCK_FILE" ]] || die 'Deployment lock file must not be a symbolic link.'
+  if [[ -e "$LOCK_FILE" ]]; then
+    [[ -f "$LOCK_FILE" && "$(stat -c '%u' "$LOCK_FILE")" == '0' ]] || {
+      die 'Deployment lock file is not a root-owned regular file.'
+    }
+  fi
+  if [[ -e /proc/$$/fd/9 ]] && [[ "$(readlink -f /proc/$$/fd/9)" == "$LOCK_FILE" ]]; then
+    flock -n 9 || die 'Inherited deployment lock descriptor is not held by this release.'
+    return 0
+  fi
+  exec 9>>"$LOCK_FILE"
+  chmod 600 "$LOCK_FILE"
+  flock -n 9 || die 'Another TokEMS deployment is already running.'
+}
+
+read_pending_recovery_marker() {
+  [[ ! -L "$RECOVERY_MARKER" ]] || die "Recovery marker must not be a symbolic link: ${RECOVERY_MARKER}"
+  [[ -f "$RECOVERY_MARKER" ]] || die "Recovery marker is not a regular file: ${RECOVERY_MARKER}"
+  [[ "$(stat -c '%u:%a' "$RECOVERY_MARKER")" == '0:600' ]] || {
+    die 'Recovery marker must be owned by root with mode 600.'
+  }
+  pending_recovery_backup_dir="$(awk -F= '$1 == "backup_dir" { value = substr($0, index($0, "=") + 1) } END { print value }' "$RECOVERY_MARKER")"
+  pending_recovery_phase="$(awk -F= '$1 == "phase" { value = substr($0, index($0, "=") + 1) } END { print value }' "$RECOVERY_MARKER")"
+  pending_recovery_rollback_tag="$(awk -F= '$1 == "rollback_tag" { value = substr($0, index($0, "=") + 1) } END { print value }' "$RECOVERY_MARKER")"
+  pending_recovery_target_sha="$(awk -F= '$1 == "target_sha" { value = substr($0, index($0, "=") + 1) } END { print value }' "$RECOVERY_MARKER")"
+  pending_recovery_protocol="$(awk -F= '$1 == "protocol_version" { value = substr($0, index($0, "=") + 1) } END { print value }' "$RECOVERY_MARKER")"
+  pending_recovery_script="$(awk -F= '$1 == "recovery_script" { value = substr($0, index($0, "=") + 1) } END { print value }' "$RECOVERY_MARKER")"
+  pending_recovery_script_sha256="$(awk -F= '$1 == "recovery_script_sha256" { value = substr($0, index($0, "=") + 1) } END { print value }' "$RECOVERY_MARKER")"
+  pending_recovery_target_image_tag="$(awk -F= '$1 == "target_image_tag" { value = substr($0, index($0, "=") + 1) } END { print value }' "$RECOVERY_MARKER")"
+  assert_trusted_release_directory "$pending_recovery_backup_dir"
+  [[ -z "$pending_recovery_rollback_tag" || "$pending_recovery_rollback_tag" =~ ^rollback-[0-9]{8}-[0-9]{6}$ ]] || {
+    die 'Recovery marker contains an invalid rollback image tag.'
+  }
+  [[ "$pending_recovery_target_sha" =~ ^[0-9a-f]{40}$ ]] || {
+    die 'Recovery marker contains an invalid target commit.'
+  }
+  [[ "$pending_recovery_protocol" == '1' ]] || die 'Recovery marker protocol is unsupported.'
+  [[ "$pending_recovery_script" == "${pending_recovery_backup_dir}/production-deploy.recovery.sh" ]] || {
+    die 'Recovery marker points outside its protected release directory.'
+  }
+  [[ "$pending_recovery_script_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+    die 'Recovery marker contains an invalid recovery script digest.'
+  }
+  [[ "$pending_recovery_target_image_tag" =~ ^release-[0-9]{8}-[0-9]{6}$ ]] || {
+    die 'Recovery marker contains an invalid target image tag.'
+  }
+  assert_trusted_recovery_file "$pending_recovery_script"
+  [[ "$(sha256sum "$pending_recovery_script" | awk '{ print $1 }')" == "$pending_recovery_script_sha256" ]] || {
+    die 'Protected recovery script digest does not match the marker.'
+  }
+}
+
+assert_pending_recovery_policy() {
+  if [[ -e "$RECOVERY_MARKER" || -L "$RECOVERY_MARKER" ]]; then
+    read_pending_recovery_marker
+    if [[ "$pending_recovery_phase" == 'pre-write' ]]; then
+      if [[ "$mode" == 'recover-interrupted' ]]; then
+        recovery_in_progress='true'
+        log "Recovering the pre-database interrupted release recorded at ${pending_recovery_backup_dir}"
+        return 0
+      fi
+      die "A pre-database release interruption is pending at ${pending_recovery_backup_dir}; run recover-interrupted before any normal release."
+    fi
+    [[ -z "$pending_recovery_phase" || "$pending_recovery_phase" == 'write-freeze' ]] || {
+      die "Recovery marker contains an unsupported release phase: ${pending_recovery_phase}"
+    }
+    if [[ "$mode" == 'deploy' && "$resume_recovery" == 'true' ]]; then
+      recovery_in_progress='true'
+      active_env_file="${pending_recovery_backup_dir}/.env"
+      active_compose_file="${pending_recovery_backup_dir}/docker-compose.yml"
+      assert_trusted_recovery_file "$active_env_file"
+      assert_trusted_recovery_file "$active_compose_file"
+      read_only_compose_file="${pending_recovery_backup_dir}/docker-compose.read-only.yml"
+      assert_trusted_recovery_file "$read_only_compose_file"
+      [[ -s "$read_only_compose_file" ]] || die 'Pending recovery read-only Compose override is empty.'
+      wait_for_db_init_quiescence
+      local image current_database_hash baseline_database_hash target_database_hash recovery_runtime='rollback'
+      assert_trusted_recovery_file "$pending_recovery_backup_dir/.env.release"
+      current_database_hash="$(read_database_migration_hash)"
+      baseline_database_hash="$(env_file_value BUILD_MIGRATION_HASH "$pending_recovery_backup_dir/.env")"
+      target_database_hash="$(env_file_value BUILD_MIGRATION_HASH "$pending_recovery_backup_dir/.env.release")"
+      [[ "$current_database_hash" =~ ^[0-9a-f]{64}$ && "$baseline_database_hash" =~ ^[0-9a-f]{64}$ && "$target_database_hash" =~ ^[0-9a-f]{64}$ ]] || {
+        die 'Recovery migration identity is incomplete.'
+      }
+      if [[ "$current_database_hash" == "$baseline_database_hash" ]]; then
+        log "Restoring the rollback runtime in read-only mode before resuming ${pending_recovery_target_sha}"
+        for image in "${ROLLBACK_IMAGES[@]}"; do
+          docker image inspect "${image}:${pending_recovery_rollback_tag}" >/dev/null
+          docker tag "${image}:${pending_recovery_rollback_tag}" "${image}:local"
+        done
+      else
+        log "Completing the interrupted target migration before resuming ${pending_recovery_target_sha}"
+        recovery_runtime='target'
+        assert_recovery_migration_chain "$current_database_hash" "$baseline_database_hash" "$target_database_hash"
+        active_env_file="$pending_recovery_backup_dir/.env.release"
+        for image in "${ROLLBACK_IMAGES[@]}"; do
+          docker image inspect "${image}:${pending_recovery_target_image_tag}" >/dev/null
+          docker tag "${image}:${pending_recovery_target_image_tag}" "${image}:local"
+        done
+        if [[ "$current_database_hash" != "$target_database_hash" ]]; then
+          (export SEED_DEMO_DATA=false; compose_bounded "$DB_MIGRATION_TIMEOUT_SECONDS" run --rm --no-deps db-init)
+          current_database_hash="$(read_database_migration_hash)"
+          [[ "$current_database_hash" == "$target_database_hash" ]] || {
+            die 'Interrupted target migration did not converge to its recorded migration hash.'
+          }
+        fi
+        canonical_mode='always'
+      fi
+      export TOKEMS_READ_ONLY_DATABASE_URL
+      TOKEMS_READ_ONLY_DATABASE_URL="$(read_only_database_url)"
+      if [[ "$recovery_runtime" == 'target' ]]; then
+        compose_read_only_bounded "$SERVICE_TRANSITION_TIMEOUT_SECONDS" up -d \
+          --no-build \
+          --no-deps \
+          --force-recreate \
+          --wait \
+          --wait-timeout 300 \
+          "${RELEASE_SERVICES[@]}"
+      else
+        compose_read_only_bounded "$SERVICE_TRANSITION_TIMEOUT_SECONDS" up -d \
+          --no-build \
+          --no-deps \
+          --force-recreate \
+          --wait \
+          --wait-timeout 300 \
+          api worker
+      fi
+      assert_operational_write_state recovery
+      return 0
+    fi
+    if [[ "$mode" == 'resolve-recovery' ]]; then
+      recovery_in_progress='true'
+      active_compose_file="${pending_recovery_backup_dir}/docker-compose.yml"
+      read_only_compose_file="${pending_recovery_backup_dir}/docker-compose.read-only.yml"
+      assert_trusted_recovery_file "$active_compose_file"
+      assert_trusted_recovery_file "$read_only_compose_file"
+      return 0
+    fi
+    die "A protected recovery is pending at ${pending_recovery_backup_dir}; writes may remain frozen. Resolve it or run deploy --resume-recovery."
+  fi
+  [[ "$resume_recovery" == 'false' ]] || die 'No pending recovery marker exists to resume.'
+  [[ "$mode" != 'resolve-recovery' ]] || die 'No pending recovery marker exists to resolve.'
+  [[ "$mode" != 'recover-interrupted' ]] || die 'No pre-database interrupted release exists to recover.'
+}
+
+write_pending_recovery_marker() {
+  local reason="$1" marker_temp="${RECOVERY_MARKER}.tmp.$$" recovery_script recovery_script_sha256
+  install -d -m 700 "$BACKUP_ROOT"
+  [[ ! -L "$RECOVERY_MARKER" ]] || return 1
+  recovery_script="$backup_dir/production-deploy.recovery.sh"
+  [[ -f "$recovery_script" && ! -L "$recovery_script" ]] || return 1
+  recovery_script_sha256="$(sha256sum "$recovery_script" | awk '{ print $1 }')" || return 1
+  printf 'status=protected-release\nprotocol_version=1\nphase=%s\nreason=%s\nbackup_dir=%s\ntarget_sha=%s\nrollback_tag=%s\ntarget_image_tag=%s\nrecovery_script=%s\nrecovery_script_sha256=%s\n' \
+    "$release_phase" "$reason" "$backup_dir" "$target_sha" "$rollback_tag" "$target_image_tag" "$recovery_script" "$recovery_script_sha256" >"$marker_temp" || return 1
+  chmod 600 "$marker_temp" || return 1
+  mv -f -- "$marker_temp" "$RECOVERY_MARKER" || return 1
+}
+
+bootstrap_recovery_script() {
+  read_pending_recovery_marker
+  local current_script_sha256
+  current_script_sha256="$(sha256sum "${BASH_SOURCE[0]}" | awk '{ print $1 }')"
+  [[ "$current_script_sha256" != "$pending_recovery_script_sha256" ]] || return 0
+  log "Loading the exact protected recovery script for ${pending_recovery_target_sha}"
+  exec env -i \
+    "PATH=$SAFE_PATH" \
+    'HOME=/root' \
+    bash "$pending_recovery_script" "$@"
+}
+
+arm_release_recovery_marker() {
+  release_phase='write-freeze'
+  write_pending_recovery_marker 'release-write-freeze-armed' || {
+    die "Unable to persist ${RECOVERY_MARKER} before the protected release window."
+  }
+  recovery_marker_armed='true'
+  deployment_marker_armed='true'
+}
+
+clear_pending_recovery_marker() {
+  [[ -e "$RECOVERY_MARKER" || -L "$RECOVERY_MARKER" ]] || return 0
+  read_pending_recovery_marker
+  local resolved_marker="${pending_recovery_backup_dir}/RECOVERY_RESOLVED-$(date '+%Y%m%d-%H%M%S')"
+  [[ ! -e "$resolved_marker" ]] || die "Resolved recovery evidence already exists: ${resolved_marker}"
+  mv -- "$RECOVERY_MARKER" "$resolved_marker"
+  chmod 600 "$resolved_marker"
+  deployment_marker_armed='false'
+}
+
+assert_minimal_git_state() {
+  [[ "$(git_as_owner branch --show-current)" == "$EXPECTED_BRANCH" ]] || {
+    die "Server branch must be ${EXPECTED_BRANCH}."
+  }
+  [[ "$(git_as_owner remote get-url origin)" == "$EXPECTED_ORIGIN" ]] || {
+    die "origin must be ${EXPECTED_ORIGIN}."
+  }
+  [[ -z "$(git_as_owner status --porcelain --untracked-files=all)" ]] || {
+    die 'Server Git worktree contains uncommitted or untracked files.'
+  }
+  [[ "$(git_as_owner rev-parse --abbrev-ref --symbolic-full-name '@{upstream}')" == "$EXPECTED_UPSTREAM" ]] || {
+    die "${EXPECTED_BRANCH} must track ${EXPECTED_UPSTREAM}."
+  }
+  [[ -z "$(git_as_owner for-each-ref --format='%(refname)' refs/replace)" ]] || {
+    die 'Git replacement references are forbidden in the production checkout.'
+  }
+}
+
+bootstrap_latest_script() {
+  log 'Loading the deployment script from the latest origin/main commit'
+  git_fetch_origin_main
+  local latest_sha latest_script_sha current_script_sha temp_script
+  latest_sha="$(git_as_owner rev-parse origin/main)"
+  assert_target_selection "$latest_sha"
+  git_as_owner merge-base --is-ancestor "$(git_as_owner rev-parse HEAD)" "$latest_sha" || {
+    die 'Server production branch cannot fast-forward to origin/main.'
+  }
+  target_sha="$latest_sha"
+  verify_github_release_gate
+  latest_script_sha="$(git_as_owner show "${latest_sha}:tooling/production-deploy.sh" | sha256sum | awk '{ print $1 }')"
+  current_script_sha="$(sha256sum "${BASH_SOURCE[0]}" | awk '{ print $1 }')"
+  [[ "$current_script_sha" != "$latest_script_sha" ]] || return 0
+  temp_script="$(mktemp "${LOCK_DIR}/bootstrap.XXXXXX")"
+  git_as_owner show "${latest_sha}:tooling/production-deploy.sh" >"$temp_script" || {
+    rm -f -- "$temp_script"
+    die 'origin/main does not contain the production deployment script.'
+  }
+  chmod 700 "$temp_script"
+  bash -n "$temp_script" || {
+    rm -f -- "$temp_script"
+    die 'The deployment script on origin/main failed shell syntax validation.'
+  }
+
+  exec env -i \
+    "PATH=$SAFE_PATH" \
+    'HOME=/root' \
+    bash "$temp_script" "$@"
+}
+
+env_value() {
+  local key="$1"
+  env_file_value "$key" "$active_env_file"
+}
+
+env_file_value() {
+  local key="$1" env_file="$2"
+  awk -F= -v expected_key="$key" '
+    $1 == expected_key { value = substr($0, index($0, "=") + 1); found = 1 }
+    END { if (found) print value }
+  ' \
+    "$env_file"
+}
+
+env_key_count() {
+  local key="$1"
+  awk -F= -v expected_key="$key" '$1 == expected_key { count += 1 } END { print count + 0 }' \
+    "$active_env_file"
+}
+
+assert_unique_production_env_keys() {
+  local verify_build_keys="${1:-true}" key count
+  for key in \
+    DEPLOYMENT_MODE \
+    SEED_DEMO_DATA \
+    PUBLIC_ORGANIZATION_SLUG \
+    NUXT_PUBLIC_ORGANIZATION_SLUG \
+    PUBLIC_ORIGIN \
+    ADMIN_ORIGIN \
+    PAYMENT_PUBLIC_ORIGIN \
+    PAYMENT_PUBLIC_BASE_PATH \
+    PAYMENT_PUBLIC_URL \
+    CUSTOMER_OTP_MODE \
+    ALLOW_INSECURE_LOCAL_AUTH \
+    VITE_SIMPLE_AUTH \
+    ENABLE_LOCAL_PAYMENT_SIMULATION; do
+    count="$(env_key_count "$key")"
+    [[ "$count" == '1' ]] || die "Production .env must contain exactly one ${key} entry."
+  done
+  if [[ "$verify_build_keys" == 'true' ]]; then
+    for key in BUILD_SHA BUILD_TIME BUILD_MIGRATION BUILD_MIGRATION_HASH; do
+      count="$(env_key_count "$key")"
+      [[ "$count" == '1' ]] || die "Production .env must contain exactly one ${key} entry."
+    done
+  fi
+  count="$(env_key_count GATEWAY_BIND_ADDRESS)"
+  (( count <= 1 )) || die 'Production .env contains duplicate GATEWAY_BIND_ADDRESS entries.'
+  if [[ "$verify_build_keys" == 'true' ]]; then
+    for key in \
+      TOKEMS_COMPATIBILITY_ROLLBACK \
+      TOKEMS_ROLLBACK_CODE_MIGRATION \
+      TOKEMS_ROLLBACK_CODE_MIGRATION_HASH; do
+      count="$(env_key_count "$key")"
+      (( count <= 1 )) || die "Production .env contains duplicate ${key} entries."
+    done
+  fi
+}
+
+assert_production_environment() {
+  local verify_build_keys="${1:-true}"
+  assert_unique_production_env_keys "$verify_build_keys"
+  [[ "$(env_value DEPLOYMENT_MODE)" == 'production' ]] || die 'DEPLOYMENT_MODE must equal production.'
+  [[ "$(env_value SEED_DEMO_DATA)" == 'false' ]] || die 'SEED_DEMO_DATA must remain false in .env.'
+  [[ "$(env_value PUBLIC_ORGANIZATION_SLUG)" == "$CANONICAL_ORGANIZATION_SLUG" ]] || {
+    die "PUBLIC_ORGANIZATION_SLUG must equal ${CANONICAL_ORGANIZATION_SLUG}."
+  }
+  [[ "$(env_value NUXT_PUBLIC_ORGANIZATION_SLUG)" == "$CANONICAL_ORGANIZATION_SLUG" ]] || {
+    die "NUXT_PUBLIC_ORGANIZATION_SLUG must equal ${CANONICAL_ORGANIZATION_SLUG}."
+  }
+  [[ "$(env_value PUBLIC_ORIGIN)" == "$PUBLIC_ORIGIN" ]] || die "PUBLIC_ORIGIN must equal ${PUBLIC_ORIGIN}."
+  [[ "$(env_value ADMIN_ORIGIN)" == "$ADMIN_ORIGIN" ]] || die "ADMIN_ORIGIN must equal ${ADMIN_ORIGIN}."
+  [[ "$(env_value PAYMENT_PUBLIC_ORIGIN)" == "$PAYMENT_ORIGIN" ]] || {
+    die "PAYMENT_PUBLIC_ORIGIN must equal ${PAYMENT_ORIGIN}."
+  }
+  [[ "$(env_value PAYMENT_PUBLIC_BASE_PATH)" == "$PAYMENT_BASE_PATH" ]] || {
+    die "PAYMENT_PUBLIC_BASE_PATH must equal ${PAYMENT_BASE_PATH}."
+  }
+  [[ "$(env_value PAYMENT_PUBLIC_URL)" == "$PAYMENT_PUBLIC_URL" ]] || {
+    die "PAYMENT_PUBLIC_URL must equal ${PAYMENT_PUBLIC_URL}."
+  }
+  [[ "$(env_value CUSTOMER_OTP_MODE)" == 'provider' ]] || die 'CUSTOMER_OTP_MODE must equal provider.'
+  [[ "$(env_value ALLOW_INSECURE_LOCAL_AUTH)" == 'false' ]] || {
+    die 'ALLOW_INSECURE_LOCAL_AUTH must equal false.'
+  }
+  [[ "$(env_value VITE_SIMPLE_AUTH)" == 'false' ]] || die 'VITE_SIMPLE_AUTH must equal false.'
+  [[ "$(env_value ENABLE_LOCAL_PAYMENT_SIMULATION)" == 'false' ]] || {
+    die 'ENABLE_LOCAL_PAYMENT_SIMULATION must equal false.'
+  }
+  if awk -F= '$1 ~ /^(COMPOSE_|DOCKER_(HOST|CONTEXT|CONFIG|TLS_VERIFY|CERT_PATH|API_VERSION)$)/ { found = 1 } END { exit(found ? 0 : 1) }' "$active_env_file"; then
+    die 'Production .env must not define Docker or Compose control variables.'
+  fi
+  local gateway_bind
+  gateway_bind="$(env_value GATEWAY_BIND_ADDRESS)"
+  [[ -z "$gateway_bind" || "$gateway_bind" == '127.0.0.1' ]] || {
+    die 'GATEWAY_BIND_ADDRESS must remain on 127.0.0.1.'
+  }
+}
+
+github_get() {
+  local url="$1"
+  local -a headers=(
+    -H 'Accept: application/vnd.github+json'
+    -H 'X-GitHub-Api-Version: 2022-11-28'
+    -H 'User-Agent: TokEMS-production-deploy'
+  )
+  curl "${CURL_ARGS[@]}" --location "${headers[@]}" "$url"
+}
+
+verify_github_release_gate() {
+  log "Verifying merged PR and successful main CI for ${target_sha}"
+  github_get "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${target_sha}/pulls?per_page=100" \
+    | python3 -c '
+import json, sys
+target = sys.argv[1]
+pulls = json.load(sys.stdin)
+valid = [
+    item for item in pulls
+    if item.get("merged_at")
+    and item.get("merge_commit_sha") == target
+    and (item.get("base") or {}).get("ref") == "main"
+]
+if not valid:
+    raise SystemExit("origin/main is not associated with a merged pull request")
+print("Merged PR verified: #{}".format(valid[0]["number"]))
+' "$target_sha"
+
+  github_get "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=main&event=push&per_page=100" \
+    | python3 -c '
+import json, sys
+target = sys.argv[1]
+payload = json.load(sys.stdin)
+valid = [
+    item for item in payload.get("workflow_runs", [])
+    if item.get("name") == "tokems-ci"
+    and item.get("path") == ".github/workflows/ci.yml"
+    and item.get("event") == "push"
+    and item.get("head_branch") == "main"
+    and item.get("head_sha") == target
+    and item.get("status") == "completed"
+    and item.get("conclusion") == "success"
+    and (item.get("repository") or {}).get("full_name") == "yaojingang/TokEMS"
+    and (item.get("head_repository") or {}).get("full_name") == "yaojingang/TokEMS"
+]
+if not valid:
+    raise SystemExit("official main push workflow has not completed successfully for origin/main")
+print("Official main push workflow verified: run {}".format(valid[0]["id"]))
+' "$target_sha"
+
+  github_get "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${target_sha}/check-runs?per_page=100" \
+    | python3 -c '
+import json, sys
+target = sys.argv[1]
+payload = json.load(sys.stdin)
+valid = [
+    item for item in payload.get("check_runs", [])
+    if item.get("name") == "quality-and-flows"
+    and item.get("head_sha") == target
+    and item.get("status") == "completed"
+    and item.get("conclusion") == "success"
+    and (item.get("app") or {}).get("slug") == "github-actions"
+    and "/yaojingang/TokEMS/actions/runs/" in (item.get("details_url") or "")
+]
+if not valid:
+    raise SystemExit("official GitHub Actions quality-and-flows job has not completed successfully for origin/main")
+print("Official GitHub Actions quality-and-flows job verified")
+' "$target_sha"
+}
+
+combined_build_capacity_kib() {
+  awk '
+    $1 == "MemAvailable:" { memory = $2 }
+    $1 == "SwapFree:" { swap = $2 }
+    END { print memory + swap }
+  ' /proc/meminfo
+}
+
+assert_build_capacity() {
+  local capacity_kib app_disk_kib docker_disk_kib docker_root
+  capacity_kib="$(combined_build_capacity_kib)"
+  app_disk_kib="$(df -Pk "$APP_DIR" | awk 'NR == 2 { print $4 }')"
+  docker_root="$(docker info --format '{{.DockerRootDir}}')"
+  [[ -n "$docker_root" && -d "$docker_root" ]] || die 'Docker reported an invalid data-root directory.'
+  docker_disk_kib="$(df -Pk "$docker_root" | awk 'NR == 2 { print $4 }')"
+
+  (( capacity_kib >= MIN_BUILD_CAPACITY_KIB )) || {
+    die "In-place image build requires at least $((MIN_BUILD_CAPACITY_KIB / 1048576)) GiB of MemAvailable + SwapFree. Current: $((capacity_kib / 1048576)) GiB. Expand memory or adopt prebuilt images before deployment."
+  }
+  (( app_disk_kib >= MIN_BUILD_DISK_KIB )) || {
+    die "${APP_DIR} filesystem needs at least $((MIN_BUILD_DISK_KIB / 1048576)) GiB free for a release build."
+  }
+  (( docker_disk_kib >= MIN_BUILD_DISK_KIB )) || {
+    die "Docker data-root ${docker_root} needs at least $((MIN_BUILD_DISK_KIB / 1048576)) GiB free for a release build."
+  }
+}
+
+read_database_size_bytes() {
+  compose_bounded "$DB_QUERY_TIMEOUT_SECONDS" exec -T postgres sh -lc \
+    'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Atc "select pg_database_size(current_database())"'
+}
+
+resolved_compose_database_url() {
+  compose config --format json | python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+services = payload.get("services") or {}
+
+def database_url(service_name):
+    environment = (services.get(service_name) or {}).get("environment") or {}
+    if not isinstance(environment, dict):
+        raise SystemExit(f"{service_name} environment is unavailable")
+    value = environment.get("DATABASE_URL")
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"{service_name} DATABASE_URL is unavailable")
+    return value
+
+api_url = database_url("api")
+if database_url("db-init") != api_url or database_url("worker") != api_url:
+    raise SystemExit("API, Worker, and db-init resolve different DATABASE_URL values")
+sys.stdout.write(api_url)
+'
+}
+
+database_proof_from_api_container() {
+  local challenge="$1" source_mode="$2" api_container
+  api_container="$(compose ps -q api)"
+  [[ -n "$api_container" ]] || die 'API container is unavailable for database identity proof.'
+
+  if [[ "$source_mode" == 'runtime' ]]; then
+    timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker exec \
+      -e TOKEMS_DB_CHALLENGE="$challenge" \
+      "$api_container" \
+      node --input-type=module -e \
+      "import { createHash } from 'node:crypto'; import pg from 'pg'; const client = new pg.Client({connectionString: process.env.DATABASE_URL, connectionTimeoutMillis: 10000, statement_timeout: 10000, query_timeout: 10000}); try { await client.connect(); const result = await client.query(\`select system_identifier::text as \"systemIdentifier\", current_database() as \"databaseName\", (select oid::text from pg_database where datname = current_database()) as \"databaseOid\", extract(epoch from pg_postmaster_start_time())::text as \"startedAt\" from pg_control_system()\`); const row=result.rows[0]; console.log(createHash('sha256').update([process.env.TOKEMS_DB_CHALLENGE,row.systemIdentifier,row.databaseName,row.databaseOid,row.startedAt].join('\\n')).digest('hex')); } finally { await client.end().catch(() => {}); }"
+    return
+  fi
+
+  [[ "$source_mode" == 'compose' ]] || die 'Unknown API database proof source mode.'
+  resolved_compose_database_url | timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker exec -i \
+    -e TOKEMS_DB_CHALLENGE="$challenge" \
+    "$api_container" \
+    node --input-type=module -e \
+    "import { createHash } from 'node:crypto'; import pg from 'pg'; let connectionString=''; for await (const chunk of process.stdin) connectionString += chunk; const client = new pg.Client({connectionString, connectionTimeoutMillis: 10000, statement_timeout: 10000, query_timeout: 10000}); try { await client.connect(); const result = await client.query(\`select system_identifier::text as \"systemIdentifier\", current_database() as \"databaseName\", (select oid::text from pg_database where datname = current_database()) as \"databaseOid\", extract(epoch from pg_postmaster_start_time())::text as \"startedAt\" from pg_control_system()\`); const row=result.rows[0]; console.log(createHash('sha256').update([process.env.TOKEMS_DB_CHALLENGE,row.systemIdentifier,row.databaseName,row.databaseOid,row.startedAt].join('\\n')).digest('hex')); } finally { await client.end().catch(() => {}); }"
+}
+
+database_proof_from_compose_postgres() {
+  local challenge="$1" identity
+  identity="$(
+    compose_bounded "$DB_PROOF_TIMEOUT_SECONDS" exec -T postgres sh -lc \
+      'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -F "|" -c '\''select system_identifier::text, current_database(), (select oid::text from pg_database where datname = current_database()), extract(epoch from pg_postmaster_start_time())::text from pg_control_system()'\'''
+  )"
+  python3 -c '
+import hashlib, sys
+fields = sys.argv[2].split("|")
+if len(fields) != 4 or any(not field for field in fields):
+    raise SystemExit("Compose PostgreSQL identity is incomplete")
+print(hashlib.sha256("\n".join([sys.argv[1], *fields]).encode()).hexdigest())
+' "$challenge" "$identity"
+}
+
+assert_api_uses_compose_database() {
+  local challenge runtime_proof resolved_proof postgres_proof
+  challenge="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+  runtime_proof="$(database_proof_from_api_container "$challenge" runtime)"
+  resolved_proof="$(database_proof_from_api_container "$challenge" compose)"
+  postgres_proof="$(database_proof_from_compose_postgres "$challenge")"
+  [[ "$runtime_proof" =~ ^[0-9a-f]{64}$ && "$resolved_proof" =~ ^[0-9a-f]{64}$ && "$postgres_proof" =~ ^[0-9a-f]{64}$ ]] || {
+    die 'Database identity proof returned an invalid digest.'
+  }
+  [[ "$runtime_proof" == "$postgres_proof" ]] || {
+    die 'The running API is not connected to the protected Compose PostgreSQL database.'
+  }
+  [[ "$resolved_proof" == "$postgres_proof" ]] || {
+    die 'Resolved API, Worker, and db-init configuration does not target the protected Compose PostgreSQL database.'
+  }
+}
+
+database_write_mode_from_api_container() {
+  local api_container
+  api_container="$(compose ps -q api)"
+  [[ -n "$api_container" ]] || die 'API container is unavailable for write-mode verification.'
+  timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker exec \
+    "$api_container" \
+    node --input-type=module -e \
+    "import pg from 'pg'; const client = new pg.Client({connectionString: process.env.DATABASE_URL, connectionTimeoutMillis: 10000, statement_timeout: 10000, query_timeout: 10000}); try { await client.connect(); const result = await client.query('show default_transaction_read_only'); console.log(result.rows[0].default_transaction_read_only); } finally { await client.end().catch(() => {}); }"
+}
+
+assert_operational_write_state() {
+  local expected_mode="$1" database_mode worker_container runtime_command image_command
+  database_mode="$(database_write_mode_from_api_container)"
+  worker_container="$(compose ps -q worker)"
+  [[ -n "$worker_container" ]] || die 'Worker container is unavailable for command verification.'
+  runtime_command="$(timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker inspect --format '{{json .Config.Cmd}}' "$worker_container")"
+  image_command="$(timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker image inspect --format '{{json .Config.Cmd}}' tokems-worker:local)"
+
+  if [[ "$expected_mode" == 'normal' ]]; then
+    [[ "$database_mode" == 'off' ]] || die 'Production API database session is unexpectedly read-only.'
+    python3 -c '
+import json, sys
+if json.loads(sys.argv[1]) != json.loads(sys.argv[2]):
+    raise SystemExit("Worker command differs from the standard image command")
+' "$runtime_command" "$image_command"
+    return
+  fi
+
+  [[ "$expected_mode" == 'recovery' ]] || die 'Unknown operational write-state expectation.'
+  [[ "$database_mode" == 'on' ]] || die 'Pending recovery API is not using a read-only database session.'
+  python3 -c '
+import json, sys
+expected = ["node", "-e", "setInterval(() => {}, 1000)"]
+if json.loads(sys.argv[1]) != expected:
+    raise SystemExit("Pending recovery Worker is not paused")
+' "$runtime_command"
+}
+
+assert_backup_capacity() {
+  local database_bytes required_kib available_kib capacity_path
+  database_bytes="$(read_database_size_bytes)"
+  [[ "$database_bytes" =~ ^[0-9]+$ ]] || die 'PostgreSQL returned an invalid database size.'
+  capacity_path="$BACKUP_ROOT"
+  while [[ ! -e "$capacity_path" ]]; do
+    [[ "$capacity_path" != '/' ]] || die 'No existing parent was found for the production backup directory.'
+    capacity_path="$(dirname "$capacity_path")"
+  done
+  [[ -d "$capacity_path" ]] || die "Backup capacity path is not a directory: ${capacity_path}"
+  backup_device_id="$(stat -c '%d' "$capacity_path")"
+  available_kib="$(df -Pk "$capacity_path" | awk 'NR == 2 { print $4 }')"
+  required_kib=$(( (database_bytes * 4 + 1023) / 1024 + MIN_BACKUP_RESERVE_KIB ))
+  (( available_kib >= required_kib )) || {
+    die "Backup filesystem needs $((required_kib / 1048576)) GiB free for two dumps, production-ID evidence, and the protected reserve."
+  }
+}
+
+assert_final_backup_capacity() {
+  local database_bytes stable_bytes retention_bytes required_bytes required_kib available_kib
+  database_bytes="$(read_database_size_bytes)"
+  [[ "$database_bytes" =~ ^[0-9]+$ ]] || die 'PostgreSQL returned an invalid final database size.'
+  [[ -d "$backup_dir" ]] || die "Release backup directory is missing: ${backup_dir}"
+  [[ "$(stat -c '%d' "$backup_dir")" == "$backup_device_id" ]] || {
+    die 'The release backup directory is on a different filesystem from the preflight capacity check.'
+  }
+  stable_bytes="$(stat -c '%s' "$backup_dir/protected-business-ids-build-start.csv")"
+  retention_bytes="$(stat -c '%s' "$backup_dir/retention-managed-ids-build-start.csv")"
+  available_kib="$(df -Pk "$backup_dir" | awk 'NR == 2 { print $4 }')"
+  required_bytes=$(( database_bytes + 6 * stable_bytes + 4 * retention_bytes ))
+  required_kib=$(( (required_bytes + 1023) / 1024 + MIN_BACKUP_RESERVE_KIB ))
+  (( available_kib >= required_kib )) || {
+    die "Final backup and measured production-ID evidence need $((required_kib / 1048576)) GiB free after the image build."
+  }
+}
+
+assert_release_verification_capacity() {
+  local stable_bytes retention_bytes required_bytes required_kib available_kib
+  stable_bytes="$(stat -c '%s' "$backup_dir/protected-business-ids-before.csv")"
+  retention_bytes="$(stat -c '%s' "$backup_dir/retention-managed-ids-before.csv")"
+  available_kib="$(df -Pk "$backup_dir" | awk 'NR == 2 { print $4 }')"
+  required_bytes=$(( 2 * stable_bytes + retention_bytes ))
+  required_kib=$(( (required_bytes + 1023) / 1024 + MIN_BACKUP_RESERVE_KIB ))
+  (( available_kib >= required_kib )) || {
+    die "Release verification evidence needs $((required_kib / 1048576)) GiB free after the final database backup."
+  }
+}
+
+assert_post_thaw_evidence_capacity() {
+  local stable_bytes required_kib available_kib
+  stable_bytes="$(stat -c '%s' "$backup_dir/protected-business-ids-after.csv")"
+  available_kib="$(df -Pk "$backup_dir" | awk 'NR == 2 { print $4 }')"
+  required_kib=$(( (stable_bytes + 1023) / 1024 + MIN_BACKUP_RESERVE_KIB ))
+  (( available_kib >= required_kib )) || {
+    die "Post-thaw production evidence needs $((required_kib / 1048576)) GiB free before writes resume."
+  }
+}
+
+json_sha_from_stdin() {
+  python3 -c '
+import json, re, sys
+payload = json.load(sys.stdin)
+sha = payload.get("sha") or (payload.get("build") or {}).get("sha")
+if not isinstance(sha, str) or not re.fullmatch(r"[0-9a-f]{40}", sha):
+    raise SystemExit("version response did not contain a full build SHA")
+print(sha)
+'
+}
+
+build_fingerprint_from_stdin() {
+  local expected_service="$1"
+  python3 -c '
+import json, re, sys
+payload = json.load(sys.stdin)
+build = payload.get("build", payload)
+expected_service = sys.argv[1]
+if build.get("service") != expected_service:
+    raise SystemExit(f"expected {expected_service} build metadata")
+values = [build.get(key) for key in ("sha", "builtAt", "migration", "migrationHash")]
+if not isinstance(values[0], str) or not re.fullmatch(r"[0-9a-f]{40}", values[0]):
+    raise SystemExit("build metadata did not contain a full SHA")
+if any(not isinstance(value, str) or not value or value == "unknown" for value in values[1:]):
+    raise SystemExit("build metadata contains an unknown value")
+print("|".join(values))
+' "$expected_service"
+}
+
+assert_health_json() {
+  python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+if payload.get("status") != "ok":
+    raise SystemExit("health status is not ok")
+database = payload.get("database") or {}
+if database.get("ok") is not True or (database.get("migration") or {}).get("ok") is not True:
+    raise SystemExit("database or migration health is not current")
+'
+}
+
+assert_service_healthy() {
+  local service="$1" container_id running health
+  container_id="$(compose ps -q "$service")"
+  [[ -n "$container_id" ]] || die "Compose service has no container: ${service}"
+  running="$(docker inspect --format '{{.State.Running}}' "$container_id")"
+  health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container_id")"
+  [[ "$running" == 'true' ]] || die "Compose service is not running: ${service}"
+  [[ "$health" == 'healthy' || "$health" == 'none' ]] || die "Compose service is not healthy: ${service} (${health})"
+}
+
+wait_for_worker_ready() {
+  local deadline=$((SECONDS + WORKER_READY_TIMEOUT_SECONDS))
+  local worker_container started_at running ready_fingerprint expected_fingerprint started_epoch ready_protocol
+  local persistent_ready_supported='false'
+  expected_fingerprint="${runtime_sha}|${runtime_time}|${runtime_migration}|${runtime_migration_hash}"
+  worker_container="$(compose ps -q worker)"
+  [[ -n "$worker_container" ]] || die 'Worker container is unavailable for readiness capability detection.'
+  ready_protocol="$(docker inspect --format '{{index .Config.Labels "com.tokems.worker-ready-protocol"}}' "$worker_container")"
+  if [[ "$ready_protocol" == '1' ]]; then
+    persistent_ready_supported='true'
+  fi
+  while (( SECONDS < deadline )); do
+    worker_container="$(compose ps -q worker)"
+    [[ -n "$worker_container" ]] || die 'Worker container disappeared while waiting for readiness.'
+    running="$(timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker inspect --format '{{.State.Running}}' "$worker_container")"
+    [[ "$running" == 'true' ]] || die 'Worker stopped before reporting readiness.'
+    started_at="$(timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker inspect --format '{{.State.StartedAt}}' "$worker_container")"
+    if [[ "$persistent_ready_supported" == 'true' ]]; then
+      if ready_fingerprint="$(
+        timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" \
+          docker exec "$worker_container" node -e \
+          "const fs=require('node:fs');const value=JSON.parse(fs.readFileSync('/tmp/tokems-worker-ready.json','utf8'));process.stdout.write([value.sha,value.builtAt,value.migration,value.migrationHash].join('|'))" \
+          2>/dev/null
+      )" && [[ "$ready_fingerprint" == "$expected_fingerprint" ]]; then
+        log 'Worker startup maintenance completed and its persistent ready identity matches the running release.'
+        return 0
+      fi
+    else
+      started_epoch="$(date -d "$started_at" '+%s')" || die 'Unable to parse the legacy Worker start time.'
+      if (( $(date '+%s') - started_epoch >= 300 )); then
+        log 'Legacy Worker predates the persistent ready identity; five minutes of healthy uptime satisfies this transitional preflight.'
+        return 0
+      fi
+      if timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" \
+        docker logs --since "$started_at" "$worker_container" 2>&1 \
+        | grep -F '[worker] ready queue=' >/dev/null; then
+        log 'Legacy Worker startup maintenance ready signal was observed.'
+        return 0
+      fi
+    fi
+    sleep "$WORKER_READY_POLL_SECONDS"
+  done
+  die "Worker did not report readiness within ${WORKER_READY_TIMEOUT_SECONDS} seconds."
+}
+
+assert_runtime_image() {
+  local service="$1" image="$2" container_id running_image tagged_image
+  container_id="$(compose ps -q "$service")"
+  running_image="$(docker inspect --format '{{.Image}}' "$container_id")"
+  tagged_image="$(docker image inspect --format '{{.Id}}' "${image}:local")"
+  [[ "$running_image" == "$tagged_image" ]] || {
+    die "${image}:local does not match the currently running ${service} container."
+  }
+}
+
+assert_runtime_image_tags() {
+  assert_runtime_image api tokems-api
+  assert_runtime_image worker tokems-worker
+  assert_runtime_image web tokems-web
+  assert_runtime_image payment-web tokems-web
+  assert_runtime_image admin tokems-admin
+  assert_runtime_image gateway tokems-gateway
+  assert_runtime_image notification-sink tokems-notification-sink
+}
+
+assert_current_runtime_identity() {
+  local verify_environment="${1:-true}"
+  local gateway_json web_json admin_json health_json worker_json
+  local gateway_fingerprint web_fingerprint admin_fingerprint api_fingerprint worker_fingerprint
+  local gateway_sha gateway_time gateway_migration gateway_migration_hash
+  local api_sha api_time api_migration api_migration_hash
+  local worker_container
+
+  gateway_json="$(curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/version.json')"
+  web_json="$(curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/web-version.json')"
+  admin_json="$(curl "${CURL_ARGS[@]}" -H 'Host: admin.hui.ailingdaoli.com' 'http://127.0.0.1:8088/admin/version.json')"
+  health_json="$(curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/health')"
+  printf '%s' "$health_json" | assert_health_json
+  worker_container="$(compose ps -q worker)"
+  worker_json="$(
+    timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker exec "$worker_container" node -e \
+      "console.log(JSON.stringify({service:'worker',sha:process.env.BUILD_SHA,builtAt:process.env.BUILD_TIME,migration:process.env.BUILD_MIGRATION,migrationHash:process.env.BUILD_MIGRATION_HASH}))"
+  )"
+
+  gateway_fingerprint="$(printf '%s' "$gateway_json" | build_fingerprint_from_stdin gateway)"
+  web_fingerprint="$(printf '%s' "$web_json" | build_fingerprint_from_stdin web)"
+  admin_fingerprint="$(printf '%s' "$admin_json" | build_fingerprint_from_stdin admin)"
+  api_fingerprint="$(printf '%s' "$health_json" | build_fingerprint_from_stdin api)"
+  worker_fingerprint="$(printf '%s' "$worker_json" | build_fingerprint_from_stdin worker)"
+
+  [[ "$web_fingerprint" == "$gateway_fingerprint" ]] || die 'Current web and gateway build identities are mixed.'
+  [[ "$admin_fingerprint" == "$gateway_fingerprint" ]] || die 'Current admin and gateway build identities are mixed.'
+  [[ "$worker_fingerprint" == "$api_fingerprint" ]] || die 'Current worker and API build identities are mixed.'
+
+  IFS='|' read -r gateway_sha gateway_time gateway_migration gateway_migration_hash <<<"$gateway_fingerprint"
+  IFS='|' read -r api_sha api_time api_migration api_migration_hash <<<"$api_fingerprint"
+  [[ "$api_sha" == "$gateway_sha" && "$api_time" == "$gateway_time" ]] || {
+    die 'Current API and Gateway code identities are mixed.'
+  }
+
+  runtime_sha="$gateway_sha"
+  runtime_time="$gateway_time"
+  runtime_code_migration="$gateway_migration"
+  runtime_code_migration_hash="$gateway_migration_hash"
+  runtime_migration="$api_migration"
+  runtime_migration_hash="$api_migration_hash"
+
+  if [[ "$api_migration" != "$gateway_migration" || "$api_migration_hash" != "$gateway_migration_hash" ]]; then
+    [[ "$(env_value TOKEMS_COMPATIBILITY_ROLLBACK)" == 'active' ]] || {
+      die 'Current API and Gateway migration identities are mixed without a compatibility rollback marker.'
+    }
+    [[ "$(env_value TOKEMS_ROLLBACK_CODE_MIGRATION)" == "$gateway_migration" ]] || {
+      die 'Compatibility rollback code migration marker does not match Gateway.'
+    }
+    [[ "$(env_value TOKEMS_ROLLBACK_CODE_MIGRATION_HASH)" == "$gateway_migration_hash" ]] || {
+      die 'Compatibility rollback code migration hash marker does not match Gateway.'
+    }
+    log "Compatibility rollback baseline detected: code=${gateway_sha}, database=${api_migration}"
+  elif [[ "$verify_environment" == 'true' && -n "$(env_value TOKEMS_COMPATIBILITY_ROLLBACK)" ]]; then
+    die 'Compatibility rollback marker is stale for a uniform runtime identity.'
+  fi
+
+  if [[ "$verify_environment" == 'true' ]]; then
+    [[ "$(env_value BUILD_SHA)" == "$runtime_sha" ]] || die 'Production .env BUILD_SHA does not match the running release.'
+    [[ "$(env_value BUILD_TIME)" == "$runtime_time" ]] || die 'Production .env BUILD_TIME does not match the running release.'
+    [[ "$(env_value BUILD_MIGRATION)" == "$runtime_migration" ]] || die 'Production .env BUILD_MIGRATION does not match the running release.'
+    [[ "$(env_value BUILD_MIGRATION_HASH)" == "$runtime_migration_hash" ]] || {
+      die 'Production .env BUILD_MIGRATION_HASH does not match the running release.'
+    }
+  fi
+}
+
+capture_release_baseline() {
+  [[ -z "$release_baseline_sha" ]] || die 'Release baseline identity was already captured.'
+  [[ -n "$runtime_sha" && -n "$runtime_time" && -n "$runtime_migration" && -n "$runtime_migration_hash" ]] || {
+    die 'Current runtime identity is incomplete; the release baseline cannot be captured.'
+  }
+  release_baseline_sha="$runtime_sha"
+  release_baseline_time="$runtime_time"
+  release_baseline_migration="$runtime_migration"
+  release_baseline_migration_hash="$runtime_migration_hash"
+  release_baseline_code_migration="$runtime_code_migration"
+  release_baseline_code_migration_hash="$runtime_code_migration_hash"
+}
+
+determine_canonical_sync() {
+  local changed='false' diff_status=0
+  if git_as_owner diff --quiet "$release_baseline_sha" "$target_sha" -- "${CANONICAL_SNAPSHOT_PATHS[@]}"; then
+    changed='false'
+  else
+    diff_status=$?
+    [[ $diff_status -eq 1 ]] || die 'Unable to compare canonical snapshots across release commits.'
+    changed='true'
+  fi
+
+  case "$canonical_mode" in
+    always) canonical_sync_required='true' ;;
+    auto) canonical_sync_required="$changed" ;;
+    never)
+      [[ "$changed" == 'false' ]] || {
+        die 'Canonical snapshots changed; this release must run the protected canonical sync.'
+      }
+      canonical_sync_required='false'
+      ;;
+  esac
+}
+
+assert_standard_release_scope() {
+  if ! git_as_owner diff --quiet "$release_baseline_sha" "$target_sha" -- docker-compose.yml; then
+    die 'docker-compose.yml changed; use the reviewed infrastructure maintenance procedure for this release.'
+  fi
+}
+
+run_full_preflight() {
+  log 'Running production preflight'
+  assert_minimal_git_state
+  assert_production_environment
+  assert_no_parallel_release
+  assert_pending_recovery_policy
+
+  git_fetch_origin_main
+  target_sha="$(git_as_owner rev-parse origin/main)"
+  assert_target_selection "$target_sha"
+  if [[ "$recovery_in_progress" == 'true' ]]; then
+    git_as_owner cat-file -e "${pending_recovery_target_sha}^{commit}"
+    git_as_owner merge-base --is-ancestor "$pending_recovery_target_sha" "$target_sha" || {
+      die 'Current origin/main does not descend from the interrupted release target.'
+    }
+    log "Resumed recovery target lineage verified: ${pending_recovery_target_sha} -> ${target_sha}"
+  fi
+  source_head_before="$(git_as_owner rev-parse HEAD)"
+  git_as_owner merge-base --is-ancestor "$source_head_before" "$target_sha" || {
+    die 'Server production branch cannot fast-forward to origin/main.'
+  }
+
+  compose config --quiet
+  docker info >/dev/null
+  nginx -t
+
+  local service
+  for service in "${LONG_RUNNING_SERVICES[@]}"; do
+    assert_service_healthy "$service"
+  done
+  assert_runtime_image_tags
+
+  assert_current_runtime_identity
+  capture_release_baseline
+  assert_api_uses_compose_database
+  if [[ "$recovery_in_progress" == 'true' ]]; then
+    assert_operational_write_state recovery
+  else
+    assert_operational_write_state normal
+    wait_for_worker_ready
+  fi
+  git_as_owner cat-file -e "${release_baseline_sha}^{commit}"
+  git_as_owner merge-base --is-ancestor "$release_baseline_sha" "$target_sha" || {
+    die 'The running production build is not an ancestor of origin/main.'
+  }
+  [[ "$(curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/version.json" | json_sha_from_stdin)" == "$release_baseline_sha" ]] || {
+    die 'Public version endpoint differs from the local Gateway release.'
+  }
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/health" | assert_health_json
+
+  verify_github_release_gate
+  assert_standard_release_scope
+  determine_canonical_sync
+  assert_build_capacity
+  assert_backup_capacity
+
+  log "Runtime commit: ${release_baseline_sha}"
+  log "Target commit:  ${target_sha}"
+  log "Canonical sync: ${canonical_sync_required}"
+}
+
+capture_business_snapshot() {
+  local output_file="$1"
+  compose_bounded "$DB_QUERY_TIMEOUT_SECONDS" exec -T postgres sh -lc \
+    'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -F ","' \
+    >"$output_file" <<'SQL'
+select metric, value
+from (values
+  ('customer_users', (select count(*)::bigint from customer_users)),
+  ('registrations', (select count(*)::bigint from registrations)),
+  ('orders', (select count(*)::bigint from orders)),
+  ('tickets', (select count(*)::bigint from tickets)),
+  ('invoice_requests', (select count(*)::bigint from invoice_requests))
+) as snapshot(metric, value)
+order by metric;
+SQL
+}
+
+set_production_protection_cutoff() {
+  local cutoff_temp="$backup_dir/production-protection-cutoff.txt.tmp.$$"
+  protection_cutoff="$(date --utc '+%Y-%m-%dT%H:%M:%SZ')"
+  printf '%s\n' "$protection_cutoff" >"$cutoff_temp"
+  chmod 600 "$cutoff_temp"
+  mv -f -- "$cutoff_temp" "$backup_dir/production-protection-cutoff.txt"
+}
+
+capture_protected_business_ids() {
+  local output_file="$1" protection_profile="${2:-stable}" capture_role="${3:-baseline}"
+  [[ "$protection_profile" == 'stable' || "$protection_profile" == 'retention' ]] || {
+    die "Unexpected production protection profile: ${protection_profile}"
+  }
+  [[ "$capture_role" == 'baseline' || "$capture_role" == 'comparison' || "$capture_role" == 'growth_comparison' ]] || {
+    die "Unexpected production protection capture role: ${capture_role}"
+  }
+  if [[ -z "$protection_cutoff" ]]; then
+    [[ -s "$backup_dir/production-protection-cutoff.txt" ]] || {
+      die 'The fixed production protection cutoff evidence is missing.'
+    }
+    protection_cutoff="$(<"$backup_dir/production-protection-cutoff.txt")"
+  fi
+  date -d "$protection_cutoff" '+%s' >/dev/null 2>&1 || die 'The production protection cutoff is invalid.'
+  compose_bounded "$DB_QUERY_TIMEOUT_SECONDS" exec -T \
+    -e PROTECTION_PROFILE="$protection_profile" \
+    -e PROTECTION_CUTOFF="$protection_cutoff" \
+    -e CAPTURE_ROLE="$capture_role" \
+    postgres sh -lc \
+    'psql -q -v ON_ERROR_STOP=1 -v protection_profile="$PROTECTION_PROFILE" -v protection_cutoff="$PROTECTION_CUTOFF" -v capture_role="$CAPTURE_ROLE" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -F ","' \
+    >"$output_file" <<'SQL'
+create temp table release_protected_manifest (
+  profile text not null,
+  table_name text not null,
+  row_predicate text not null,
+  primary key (profile, table_name)
+);
+
+insert into release_protected_manifest (profile, table_name, row_predicate) values
+  ('stable', 'organizations', 'true'),
+  ('stable', 'events', 'true'),
+  ('stable', 'users', 'true'),
+  ('stable', 'customer_users', 'true'),
+  ('stable', 'public_user_ids', 'true'),
+  ('stable', 'customer_profiles', 'true'),
+  ('stable', 'customer_media_assets', 'true'),
+  ('stable', 'customer_consents', 'true'),
+  ('stable', 'memberships', 'true'),
+  ('stable', 'member_profiles', 'true'),
+  ('stable', 'organization_integrations', 'true'),
+  ('stable', 'organization_invitations', 'true'),
+  ('stable', 'event_feishu_digest_subscriptions', 'true'),
+  ('stable', 'feishu_digest_deliveries', 'true'),
+  ('stable', 'event_releases', 'true'),
+  ('stable', 'conference_template_versions', 'true'),
+  ('stable', 'registrations', 'true'),
+  ('stable', 'orders', 'true'),
+  ('stable', 'attendee_claim_tokens', 'true'),
+  ('stable', 'registration_purchase_attempts', 'true'),
+  ('stable', 'order_state_logs', 'true'),
+  ('stable', 'inventory_reservations', 'true'),
+  ('stable', 'payments', 'true'),
+  ('stable', 'attendee_showcase_profiles', 'true'),
+  ('stable', 'attendee_need_submissions', 'true'),
+  ('stable', 'attendee_need_questions', 'true'),
+  ('stable', 'payment_notification_inbox', 'true'),
+  ('stable', 'refunds', 'true'),
+  ('stable', 'invoice_requests', 'true'),
+  ('stable', 'invoice_documents', 'true'),
+  ('stable', 'invoice_state_logs', 'true'),
+  ('stable', 'invoice_export_jobs', 'true'),
+  ('stable', 'order_access_tokens', 'true'),
+  ('stable', 'tickets', 'true'),
+  ('stable', 'checkin_devices', 'true'),
+  ('stable', 'checkin_sync_batches', 'true'),
+  ('stable', 'checkin_records', 'true'),
+  ('stable', 'cooperation_requests', 'true'),
+  ('stable', 'waitlist_entries', 'true'),
+  ('stable', 'notification_deliveries', $predicate$not (channel = 'sms' and subject is not distinct from '登录验证码')$predicate$),
+  ('stable', 'ai_runs', 'true'),
+  ('stable', 'template_ai_mapping_actions', 'true'),
+  ('stable', 'outbox_events', $predicate$event_type <> 'CustomerOtpRequested'$predicate$),
+  ('stable', 'audit_logs', 'true'),
+  ('stable', 'agent_connections', 'true'),
+  ('stable', 'agent_device_authorizations', $predicate$status not in ('denied', 'consumed', 'expired')$predicate$),
+  ('stable', 'agent_refresh_tokens', format($predicate$revoked_at is null and expires_at >= %L::timestamptz$predicate$, :'protection_cutoff')),
+  ('stable', 'agent_operations', $predicate$status not in ('succeeded', 'failed', 'denied', 'cancelled', 'expired')$predicate$),
+  ('retention', 'customer_auth_challenges', 'true'),
+  ('retention', 'customer_sessions', 'true'),
+  ('retention', 'idempotency_keys', 'true'),
+  ('retention', 'order_access_link_attempts', 'true'),
+  ('retention', 'notification_deliveries', $predicate$channel = 'sms' and subject is not distinct from '登录验证码'$predicate$),
+  ('retention', 'outbox_events', $predicate$event_type = 'CustomerOtpRequested'$predicate$),
+  ('retention', 'agent_device_authorizations', 'true'),
+  ('retention', 'agent_refresh_tokens', 'true'),
+  ('retention', 'agent_operations', 'true');
+
+select $guard_command$
+do $guard$
+begin
+  raise exception 'a protected production table is missing or has no primary key';
+end
+$guard$;
+$guard_command$
+where exists (
+    select 1
+    from release_protected_manifest manifest
+    left join pg_class relation on relation.relname = manifest.table_name
+    left join pg_namespace namespace
+      on namespace.oid = relation.relnamespace
+     and namespace.nspname = 'public'
+    where (:'capture_role' <> 'baseline' and namespace.oid is null)
+       or (namespace.oid is not null and not exists (
+        select 1
+        from pg_constraint primary_key
+        where primary_key.conrelid = relation.oid
+          and primary_key.contype = 'p'
+      ))
+  )
+\gexec
+
+select format(
+  'select %L, encode(convert_to(jsonb_build_array(%s)::text, %L), %L) from %I.%I t where %s order by %s;',
+  protected_table.table_name,
+  protected_table.key_expression,
+  'UTF8',
+  'hex',
+  protected_table.schema_name,
+  protected_table.table_name,
+  protected_table.row_predicate,
+  protected_table.key_expression
+)
+from (
+  select
+    namespace.nspname as schema_name,
+    relation.relname as table_name,
+    case
+      when :'capture_role' = 'growth_comparison'
+       and manifest.profile = 'stable'
+       and manifest.table_name in ('agent_device_authorizations', 'agent_refresh_tokens', 'agent_operations')
+        then 'true'
+      else manifest.row_predicate
+    end as row_predicate,
+    string_agg(format('t.%I', attribute.attname), ', ' order by key_column.ordinality) as key_expression
+  from release_protected_manifest manifest
+  join pg_class relation on relation.relname = manifest.table_name
+  join pg_namespace namespace
+    on namespace.oid = relation.relnamespace
+   and namespace.nspname = 'public'
+  join pg_constraint primary_key
+    on primary_key.conrelid = relation.oid
+   and primary_key.contype = 'p'
+  cross join lateral unnest(primary_key.conkey) with ordinality as key_column(attnum, ordinality)
+  join pg_attribute attribute
+    on attribute.attrelid = relation.oid
+   and attribute.attnum = key_column.attnum
+  where manifest.profile = :'protection_profile'
+    and relation.relkind in ('r', 'p')
+  group by
+    namespace.nspname,
+    relation.relname,
+    manifest.table_name,
+    manifest.profile,
+    manifest.row_predicate
+) protected_table
+order by protected_table.table_name collate "C"
+\gexec
+SQL
+}
+
+capture_ticket_sales() {
+  local ticket_file="$1" quota_file="$2"
+  compose_bounded "$DB_QUERY_TIMEOUT_SECONDS" exec -T postgres sh -lc \
+    'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -F ","' \
+    >"$ticket_file" <<'SQL'
+select id, sold from ticket_types order by id;
+SQL
+  compose_bounded "$DB_QUERY_TIMEOUT_SECONDS" exec -T postgres sh -lc \
+    'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -F ","' \
+    >"$quota_file" <<'SQL'
+select id, sold from ticket_quotas order by id;
+SQL
+}
+
+read_database_migration_hash() {
+  compose_bounded "$DB_QUERY_TIMEOUT_SECONDS" exec -T postgres sh -lc \
+    'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Atc '\''select hash from "drizzle"."__drizzle_migrations" order by created_at desc limit 1'\'''
+}
+
+migration_name_for_hash() {
+  local expected_hash="$1" migration_file migration_hash
+  while IFS= read -r migration_file; do
+    migration_hash="$(sha256sum "$migration_file" | awk '{ print $1 }')"
+    if [[ "$migration_hash" == "$expected_hash" ]]; then
+      basename "$migration_file"
+      return 0
+    fi
+  done < <(
+    find "$APP_DIR/packages/database/drizzle" -maxdepth 1 -type f \
+      -name '[0-9][0-9][0-9][0-9]_*.sql' -print \
+      | sort
+  )
+  return 1
+}
+
+create_backup_and_rollback_point() {
+  release_stamp="$(date '+%Y%m%d-%H%M%S')"
+  backup_dir="${BACKUP_ROOT}/${release_stamp}"
+  rollback_tag="rollback-${release_stamp}"
+  target_image_tag="release-${release_stamp}"
+  [[ ! -e "$backup_dir" ]] || die "Backup directory already exists: ${backup_dir}"
+
+  assert_api_uses_compose_database
+  log "Creating backup and rollback point at ${backup_dir}"
+  install -d -m 700 "$BACKUP_ROOT"
+  install -d -m 700 "$backup_dir"
+  [[ "$(stat -c '%d' "$backup_dir")" == "$backup_device_id" ]] || {
+    die 'The created release backup directory is on a different filesystem from the preflight capacity check.'
+  }
+  cp -- "${BASH_SOURCE[0]}" "$backup_dir/production-deploy.recovery.sh"
+  chown root:root "$backup_dir/production-deploy.recovery.sh"
+  chmod 600 "$backup_dir/production-deploy.recovery.sh"
+  bash -n "$backup_dir/production-deploy.recovery.sh"
+  set_production_protection_cutoff
+  if [[ "$recovery_in_progress" == 'true' ]]; then
+    [[ -s "$read_only_compose_file" ]] || die 'Pending recovery read-only Compose override disappeared before backup.'
+    cp -a -- "$read_only_compose_file" "$backup_dir/docker-compose.read-only.yml"
+    chmod 600 "$backup_dir/docker-compose.read-only.yml"
+    chown root:root "$backup_dir/docker-compose.read-only.yml"
+    read_only_compose_file="$backup_dir/docker-compose.read-only.yml"
+  fi
+  cp -- "$active_env_file" "$backup_dir/.env"
+  git_as_owner show "${target_sha}:docker-compose.yml" >"$backup_dir/docker-compose.yml"
+  git_as_owner show "${release_baseline_sha}:packages/contracts/src/canonical-homepage.snapshot.json" \
+    >"$backup_dir/canonical-homepage.snapshot.before.json"
+  git_as_owner show "${release_baseline_sha}:packages/contracts/src/canonical-homepage.public.json" \
+    >"$backup_dir/canonical-homepage.public.before.json"
+  chmod 600 \
+    "$backup_dir/.env" \
+    "$backup_dir/docker-compose.yml" \
+    "$backup_dir/canonical-homepage.snapshot.before.json" \
+    "$backup_dir/canonical-homepage.public.before.json"
+  chown root:root \
+    "$backup_dir/.env" \
+    "$backup_dir/docker-compose.yml" \
+    "$backup_dir/canonical-homepage.snapshot.before.json" \
+    "$backup_dir/canonical-homepage.public.before.json"
+
+  release_source_dir="$backup_dir/source"
+  install -d -o root -g root -m 700 "$release_source_dir"
+  git_as_owner archive --format=tar "$target_sha" | tar -xf - -C "$release_source_dir"
+  [[ "$(sha256sum "$release_source_dir/tooling/production-deploy.sh" | awk '{ print $1 }')" == \
+    "$(git_as_owner show "${target_sha}:tooling/production-deploy.sh" | sha256sum | awk '{ print $1 }')" ]] || {
+    die 'Root-owned release source snapshot does not match the verified target commit.'
+  }
+  cp -- "$backup_dir/.env" "$backup_dir/.env.release"
+  chown root:root "$backup_dir/.env.release"
+  chmod 600 "$backup_dir/.env.release"
+  active_env_file="$backup_dir/.env.release"
+  active_compose_file="$backup_dir/docker-compose.yml"
+  build_compose_file="$backup_dir/docker-compose.build-context.yml"
+  cat >"$build_compose_file" <<YAML
+services:
+  notification-sink:
+    build:
+      context: ${release_source_dir}
+  api:
+    build:
+      context: ${release_source_dir}
+  worker:
+    build:
+      context: ${release_source_dir}
+  web:
+    build:
+      context: ${release_source_dir}
+  payment-web:
+    build:
+      context: ${release_source_dir}
+  admin:
+    build:
+      context: ${release_source_dir}
+  gateway:
+    build:
+      context: ${release_source_dir}
+YAML
+  chown root:root "$build_compose_file"
+  chmod 600 "$build_compose_file"
+  compose config --quiet
+  printf '%s\n' "$release_baseline_sha" >"$backup_dir/runtime-commit-before.txt"
+  printf '%s\n' "$source_head_before" >"$backup_dir/source-head-before.txt"
+  compose ps >"$backup_dir/compose-ps-before.txt"
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/version.json" >"$backup_dir/version-before.json"
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/health" >"$backup_dir/health-before.json"
+  capture_business_snapshot "$backup_dir/business-counts-build-start.csv"
+  capture_protected_business_ids "$backup_dir/protected-business-ids-build-start.csv"
+  capture_protected_business_ids "$backup_dir/retention-managed-ids-build-start.csv" retention
+  capture_ticket_sales "$backup_dir/ticket-types-sold-build-start.csv" "$backup_dir/ticket-quotas-sold-build-start.csv"
+
+  compose_bounded "$DB_DUMP_TIMEOUT_SECONDS" exec -T postgres sh -lc \
+    'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --format=custom --no-owner --no-acl' \
+    >"$backup_dir/conference-build-start.dump"
+  compose_bounded "$DB_QUERY_TIMEOUT_SECONDS" exec -T postgres pg_restore --list \
+    <"$backup_dir/conference-build-start.dump" \
+    >"$backup_dir/conference-build-start.dump.list"
+  [[ -s "$backup_dir/conference-build-start.dump" ]] || die 'Build-start database backup is empty.'
+  [[ -s "$backup_dir/conference-build-start.dump.list" ]] || die 'Build-start database backup catalog is empty.'
+  sha256sum "$backup_dir/conference-build-start.dump" >"$backup_dir/conference-build-start.dump.sha256"
+
+  local image
+  for image in "${ROLLBACK_IMAGES[@]}"; do
+    docker image inspect "${image}:local" >/dev/null
+    docker tag "${image}:local" "${image}:${rollback_tag}"
+  done
+  docker image inspect \
+    "tokems-api:${rollback_tag}" \
+    "tokems-admin:${rollback_tag}" \
+    "tokems-web:${rollback_tag}" \
+    "tokems-worker:${rollback_tag}" \
+    "tokems-gateway:${rollback_tag}" \
+    "tokems-notification-sink:${rollback_tag}" \
+    >"$backup_dir/images-before.json"
+
+  printf '%s\n' "$backup_dir" >"${BACKUP_ROOT}/LATEST.tmp.$$"
+  chmod 600 "${BACKUP_ROOT}/LATEST.tmp.$$"
+  mv -f -- "${BACKUP_ROOT}/LATEST.tmp.$$" "${BACKUP_ROOT}/LATEST"
+  backup_ready='true'
+  if [[ "$recovery_in_progress" == 'true' ]]; then
+    release_phase='write-freeze'
+    recovery_marker_armed='true'
+    write_pending_recovery_marker 'resumed-write-freeze-release-armed' || {
+      die "Unable to preserve ${RECOVERY_MARKER} for the resumed protected release."
+    }
+  else
+    release_phase='pre-write'
+    write_pending_recovery_marker 'release-pre-write-armed' || {
+      die "Unable to persist ${RECOVERY_MARKER} before source, environment, or image changes."
+    }
+  fi
+  deployment_marker_armed='true'
+}
+
+refresh_pre_mutation_database_backup() {
+  [[ "$release_write_freeze" == 'true' ]] || {
+    die 'The final pre-mutation database backup requires the API and Worker write freeze.'
+  }
+  assert_final_backup_capacity
+  log 'Capturing the final database backup and business baseline after the write freeze'
+  set_production_protection_cutoff
+  capture_business_snapshot "$backup_dir/business-counts-before.csv"
+  capture_protected_business_ids "$backup_dir/protected-business-ids-before.csv"
+  capture_protected_business_ids "$backup_dir/retention-managed-ids-before.csv" retention
+  capture_ticket_sales "$backup_dir/ticket-types-sold-before.csv" "$backup_dir/ticket-quotas-sold-before.csv"
+
+  compose_bounded "$DB_DUMP_TIMEOUT_SECONDS" exec -T postgres sh -lc \
+    'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --format=custom --no-owner --no-acl' \
+    >"$backup_dir/conference.dump"
+  compose_bounded "$DB_QUERY_TIMEOUT_SECONDS" exec -T postgres pg_restore --list \
+    <"$backup_dir/conference.dump" \
+    >"$backup_dir/conference.dump.list"
+  [[ -s "$backup_dir/conference.dump" ]] || die 'Final pre-mutation database backup is empty.'
+  [[ -s "$backup_dir/conference.dump.list" ]] || die 'Final pre-mutation database backup catalog is empty.'
+  sha256sum "$backup_dir/conference.dump" >"$backup_dir/conference.dump.sha256"
+  assert_release_verification_capacity
+}
+
+sync_source() {
+  log 'Fast-forwarding production to the verified origin/main commit'
+  git_fetch_origin_main
+  [[ "$(git_as_owner rev-parse origin/main)" == "$target_sha" ]] || {
+    die 'origin/main changed after preflight; run the deployment again with the new target.'
+  }
+  git_as_owner merge --ff-only "$target_sha"
+  [[ "$(git_as_owner rev-parse HEAD)" == "$target_sha" ]] || die 'Server HEAD does not equal target commit.'
+  [[ -z "$(git_as_owner status --porcelain --untracked-files=all)" ]] || {
+    die 'Server worktree changed during source synchronization.'
+  }
+  compose config --quiet
+}
+
+set_env_value() {
+  local key="$1" value="$2" env_file="${3:-$active_env_file}"
+  [[ "$key" =~ ^BUILD_(SHA|TIME|MIGRATION|MIGRATION_HASH)$ ]] || die "Unexpected build environment key: ${key}"
+  if grep -q "^${key}=" "$env_file"; then
+    sed -i "s|^${key}=.*$|${key}=${value}|" "$env_file"
+  else
+    printf '%s=%s\n' "$key" "$value" >>"$env_file"
+  fi
+}
+
+set_release_metadata_value() {
+  local key="$1" value="$2" env_file="${3:-$active_env_file}"
+  [[ "$key" =~ ^TOKEMS_(COMPATIBILITY_ROLLBACK|ROLLBACK_CODE_MIGRATION|ROLLBACK_CODE_MIGRATION_HASH)$ ]] || {
+    die "Unexpected release metadata key: ${key}"
+  }
+  if grep -q "^${key}=" "$env_file"; then
+    sed -i "s|^${key}=.*$|${key}=${value}|" "$env_file"
+  else
+    printf '%s=%s\n' "$key" "$value" >>"$env_file"
+  fi
+}
+
+clear_compatibility_release_metadata() {
+  local env_file="${1:-$active_env_file}"
+  sed -i \
+    -e '/^TOKEMS_COMPATIBILITY_ROLLBACK=/d' \
+    -e '/^TOKEMS_ROLLBACK_CODE_MIGRATION=/d' \
+    -e '/^TOKEMS_ROLLBACK_CODE_MIGRATION_HASH=/d' \
+    "$env_file"
+}
+
+clear_build_identity() {
+  local env_file="$1"
+  sed -i \
+    -e '/^BUILD_SHA=/d' \
+    -e '/^BUILD_TIME=/d' \
+    -e '/^BUILD_MIGRATION=/d' \
+    -e '/^BUILD_MIGRATION_HASH=/d' \
+    "$env_file"
+}
+
+write_build_identity() {
+  local migration migration_hash build_time
+  migration="$(
+    find "$release_source_dir/packages/database/drizzle" -maxdepth 1 -type f \
+      -name '[0-9][0-9][0-9][0-9]_*.sql' -printf '%f\n' \
+      | sort \
+      | tail -n 1
+  )"
+  [[ -n "$migration" ]] || die 'No numbered database migration was found.'
+  migration_hash="$(sha256sum "$release_source_dir/packages/database/drizzle/$migration" | awk '{ print $1 }')"
+  build_time="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+  environment_changed='true'
+  clear_compatibility_release_metadata
+  set_env_value BUILD_SHA "$target_sha"
+  set_env_value BUILD_TIME "$build_time"
+  set_env_value BUILD_MIGRATION "$migration"
+  set_env_value BUILD_MIGRATION_HASH "$migration_hash"
+  chown root:root "$active_env_file"
+  chmod 600 "$active_env_file"
+
+  BUILD_SHA="$target_sha"
+  BUILD_TIME="$build_time"
+  BUILD_MIGRATION="$migration"
+  BUILD_MIGRATION_HASH="$migration_hash"
+  export COMPOSE_PARALLEL_LIMIT=1
+  [[ "$target_sha" != 'unknown' && "$build_time" != 'unknown' && "$migration" != 'unknown' && "$migration_hash" != 'unknown' ]] || {
+    die 'Build identity contains an unknown value.'
+  }
+  compose config --quiet
+  printf 'BUILD_SHA=%s\nBUILD_TIME=%s\nBUILD_MIGRATION=%s\nBUILD_MIGRATION_HASH=%s\n' \
+    "$target_sha" "$build_time" "$migration" "$migration_hash" \
+    >"$backup_dir/build-identity.txt"
+}
+
+assert_source_unchanged() {
+  [[ "$(git_as_owner rev-parse HEAD)" == "$target_sha" ]] || die 'Git HEAD changed during deployment.'
+  [[ -z "$(git_as_owner status --porcelain --untracked-files=all)" ]] || {
+    die 'Git worktree changed during deployment.'
+  }
+}
+
+build_images() {
+  local service build_log image
+  images_changed='true'
+  for service in "${BUILD_SERVICES[@]}"; do
+    assert_no_parallel_release
+    assert_build_capacity
+    build_log="$backup_dir/build-${service}.log"
+    log "Building ${service} with COMPOSE_PARALLEL_LIMIT=1"
+    if ! compose_build_bounded "$BUILD_TIMEOUT_SECONDS" build "$service" >"$build_log" 2>&1; then
+      tail -n 80 "$build_log" >&2 || true
+      return 1
+    fi
+    docker info >/dev/null
+    assert_source_unchanged
+  done
+  for image in "${ROLLBACK_IMAGES[@]}"; do
+    docker image inspect "${image}:local" >/dev/null
+    docker tag "${image}:local" "${image}:${target_image_tag}"
+  done
+  docker image inspect \
+    "tokems-api:${target_image_tag}" \
+    "tokems-admin:${target_image_tag}" \
+    "tokems-web:${target_image_tag}" \
+    "tokems-worker:${target_image_tag}" \
+    "tokems-gateway:${target_image_tag}" \
+    "tokems-notification-sink:${target_image_tag}" \
+    >"$backup_dir/images-target.json"
+}
+
+read_only_database_url() {
+  resolved_compose_database_url | python3 -c '
+import sys
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+value = sys.stdin.read()
+parts = urlsplit(value)
+if parts.scheme not in {"postgres", "postgresql"} or not parts.hostname or not parts.path:
+    raise SystemExit("resolved DATABASE_URL is not a PostgreSQL URL")
+items = parse_qsl(parts.query, keep_blank_values=True)
+query = [(key, item) for key, item in items if key != "options"]
+existing_options = [item for key, item in items if key == "options" and item.strip()]
+query.append(("options", " ".join([*existing_options, "-c default_transaction_read_only=on"])))
+sys.stdout.write(urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment)))
+'
+}
+
+set_write_service_restart_policy() {
+  local policy="$1" service container current_policy
+  [[ "$policy" == 'no' || "$policy" == 'unless-stopped' ]] || die "Unexpected restart policy: ${policy}"
+  for service in api worker; do
+    container="$(compose ps -q "$service")"
+    [[ -n "$container" ]] || die "Cannot update restart policy for missing service: ${service}"
+    docker update --restart "$policy" "$container" >/dev/null
+    current_policy="$(docker inspect --format '{{.HostConfig.RestartPolicy.Name}}' "$container")"
+    [[ "$current_policy" == "$policy" ]] || die "Restart policy update was not persisted for ${service}."
+  done
+}
+
+assert_write_services_stopped() {
+  local service container running
+  for service in api worker; do
+    container="$(compose ps -a -q "$service")"
+    [[ -n "$container" ]] || continue
+    running="$(docker inspect --format '{{.State.Running}}' "$container")"
+    [[ "$running" == 'false' ]] || die "Write service is still running after the freeze request: ${service}"
+  done
+}
+
+enter_release_write_freeze() {
+  assert_no_parallel_release
+  log 'Freezing API and Worker writes for the final database backup, migration, and release verification'
+  read_only_compose_file="$backup_dir/docker-compose.read-only.yml"
+  cat >"$read_only_compose_file" <<'YAML'
+services:
+  api:
+    environment:
+      DATABASE_URL: ${TOKEMS_READ_ONLY_DATABASE_URL:?TOKEMS_READ_ONLY_DATABASE_URL is required}
+  worker:
+    command: [node, -e, "setInterval(() => {}, 1000)"]
+YAML
+  chmod 600 "$read_only_compose_file"
+  containers_switched='true'
+  start_thaw_watchdog
+  set_write_service_restart_policy no
+  arm_release_recovery_marker
+  compose_bounded 60 stop --timeout 30 api worker >"$backup_dir/release-write-freeze.log" 2>&1
+  assert_write_services_stopped
+  protected_write_block_confirmed='true'
+  release_write_freeze='true'
+}
+
+thaw_release_write_freeze() {
+  [[ "$release_write_freeze" == 'true' ]] || return 0
+  log 'Re-enabling production writes with the verified target API and Worker'
+  unset TOKEMS_READ_ONLY_DATABASE_URL
+  assert_no_parallel_release
+  assert_post_thaw_evidence_capacity
+  protected_write_block_confirmed='false'
+  target_writes_enabled='true'
+  thaw_guard_compose_file="$backup_dir/docker-compose.thaw-guard.yml"
+  cat >"$thaw_guard_compose_file" <<'YAML'
+services:
+  api:
+    restart: "no"
+  worker:
+    restart: "no"
+YAML
+  chmod 600 "$thaw_guard_compose_file"
+  [[ -n "$thaw_watchdog_unit" ]] || start_thaw_watchdog
+  assert_thaw_watchdog_active
+  compose_thaw_guard_bounded "$SERVICE_TRANSITION_TIMEOUT_SECONDS" up -d \
+    --no-build \
+    --no-deps \
+    --force-recreate \
+    --wait \
+    --wait-timeout 300 \
+    api worker \
+    >"$backup_dir/release-write-thaw.log" 2>&1
+  assert_service_healthy api
+  assert_service_healthy worker
+  curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/health' | assert_health_json
+  assert_current_runtime_identity
+  assert_api_uses_compose_database
+  assert_operational_write_state normal
+  wait_for_worker_ready
+  assert_thaw_watchdog_active
+  log "Observing ready API and Worker writes for ${POST_THAW_STABILIZATION_SECONDS} seconds before final data verification"
+  sleep "$POST_THAW_STABILIZATION_SECONDS"
+  assert_service_healthy api
+  assert_service_healthy worker
+  assert_thaw_watchdog_active
+  curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/health' | assert_health_json
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/health" | assert_health_json
+  capture_business_snapshot "$backup_dir/business-counts-post-thaw.csv"
+  capture_protected_business_ids "$backup_dir/protected-business-ids-post-thaw.csv" stable growth_comparison
+  capture_ticket_sales "$backup_dir/ticket-types-sold-post-thaw.csv" "$backup_dir/ticket-quotas-sold-post-thaw.csv"
+  compare_production_data post-thaw before false growth
+  set_write_service_restart_policy unless-stopped \
+    >"$backup_dir/restart-policy-restore.log"
+  release_write_freeze='false'
+}
+
+run_database_updates() {
+  assert_no_parallel_release
+  log 'Running database migrations with SEED_DEMO_DATA=false'
+  database_update_started='true'
+  if ! (export SEED_DEMO_DATA=false; compose_bounded "$DB_MIGRATION_TIMEOUT_SECONDS" run --rm --no-deps db-init) >"$backup_dir/db-init.log" 2>&1; then
+    log "Database migration failed; protected log: ${backup_dir}/db-init.log"
+    return 1
+  fi
+  [[ "$(read_database_migration_hash)" == "$BUILD_MIGRATION_HASH" ]] || {
+    log 'Database migration command completed without the target migration hash.'
+    return 1
+  }
+
+  if [[ "$canonical_sync_required" == 'true' ]]; then
+    log "Synchronizing canonical ${CANONICAL_ORGANIZATION_SLUG}/${CANONICAL_EVENT_SLUG} template"
+    canonical_update_started='true'
+    if ! (export SEED_DEMO_DATA=true; compose_bounded "$DB_MIGRATION_TIMEOUT_SECONDS" run --rm --no-deps db-init) >"$backup_dir/canonical-sync.log" 2>&1; then
+      log "Canonical sync failed; protected log: ${backup_dir}/canonical-sync.log"
+      return 1
+    fi
+    canonical_sync_performed='true'
+  fi
+  if [[ "$release_write_freeze" != 'true' ]]; then
+    assert_api_uses_compose_database
+  fi
+}
+
+switch_services() {
+  assert_no_parallel_release
+  log 'Switching application containers to the new images'
+  containers_switched='true'
+  local switch_status=0
+  if [[ "$release_write_freeze" == 'true' ]]; then
+    export TOKEMS_READ_ONLY_DATABASE_URL
+    TOKEMS_READ_ONLY_DATABASE_URL="$(read_only_database_url)"
+    compose_read_only_bounded "$SERVICE_TRANSITION_TIMEOUT_SECONDS" up -d \
+      --no-build \
+      --no-deps \
+      --force-recreate \
+      --wait \
+      --wait-timeout 300 \
+      "${RELEASE_SERVICES[@]}" \
+      >"$backup_dir/compose-switch.log" 2>&1 || switch_status=$?
+  else
+    compose_bounded "$SERVICE_TRANSITION_TIMEOUT_SECONDS" up -d \
+      --no-build \
+      --no-deps \
+      --force-recreate \
+      --wait \
+      --wait-timeout 300 \
+      "${RELEASE_SERVICES[@]}" \
+      >"$backup_dir/compose-switch.log" 2>&1 || switch_status=$?
+  fi
+  if [[ $switch_status -ne 0 ]]; then
+    tail -n 160 "$backup_dir/compose-switch.log" >&2 || true
+    return 1
+  fi
+}
+
+compare_production_data() {
+  local after_phase="${1:-after}"
+  local before_phase="${2:-before}"
+  local include_retention="${3:-true}"
+  local comparison_mode="${4:-auto}"
+  if [[ "$comparison_mode" == 'auto' ]]; then
+    comparison_mode='exact'
+    [[ "$canonical_sync_performed" == 'false' ]] || comparison_mode='canonical'
+  fi
+  [[ "$comparison_mode" == 'exact' || "$comparison_mode" == 'growth' || "$comparison_mode" == 'canonical' ]] || {
+    die "Unexpected production data comparison mode: ${comparison_mode}"
+  }
+  local -a comparison_files=(
+    "$backup_dir/business-counts-${before_phase}.csv"
+    "$backup_dir/business-counts-${after_phase}.csv"
+    "$backup_dir/protected-business-ids-${before_phase}.csv"
+    "$backup_dir/protected-business-ids-${after_phase}.csv"
+    "$backup_dir/ticket-types-sold-${before_phase}.csv"
+    "$backup_dir/ticket-types-sold-${after_phase}.csv"
+    "$backup_dir/ticket-quotas-sold-${before_phase}.csv"
+    "$backup_dir/ticket-quotas-sold-${after_phase}.csv"
+  )
+  if [[ "$include_retention" == 'true' ]]; then
+    comparison_files+=(
+      "$backup_dir/retention-managed-ids-${before_phase}.csv"
+      "$backup_dir/retention-managed-ids-${after_phase}.csv"
+    )
+  elif [[ "$include_retention" != 'false' ]]; then
+    die "Unexpected retention comparison mode: ${include_retention}"
+  fi
+  if [[ "$comparison_mode" == 'canonical' ]]; then
+    comparison_files+=("$release_source_dir/packages/contracts/src/canonical-homepage.snapshot.json")
+  fi
+  (
+    ulimit -v "$DATA_COMPARE_MAX_VIRTUAL_KIB"
+    timeout --foreground --kill-after=10s "${DATA_COMPARE_TIMEOUT_SECONDS}s" python3 - \
+      "$comparison_mode" "${comparison_files[@]}" <<'PY'
+import csv
+import json
+import sys
+
+
+def read_pairs(file_name):
+    with open(file_name, newline="", encoding="utf-8") as handle:
+        return {row[0]: int(row[1]) for row in csv.reader(handle) if row}
+
+
+mode = sys.argv[1]
+files = sys.argv[2:]
+canonical_snapshot = None
+if mode == "canonical":
+    with open(files.pop(), encoding="utf-8") as handle:
+        canonical_snapshot = json.load(handle)
+before_counts = read_pairs(files[0])
+after_counts = read_pairs(files[1])
+if mode in {"exact", "canonical"}:
+    if before_counts != after_counts:
+        raise SystemExit("protected production counts changed during the write freeze")
+else:
+    for key, before in before_counts.items():
+        after = after_counts.get(key)
+        if after is None or after < before:
+            raise SystemExit(f"production count decreased for {key}: {before} -> {after}")
+
+def iter_protected_rows(file_name):
+    with open(file_name, newline="", encoding="utf-8") as handle:
+        for row in csv.reader(handle):
+            if not row:
+                continue
+            current = tuple(row)
+            if len(current) != 2:
+                raise SystemExit(f"invalid protected ID row in {file_name}")
+            yield current
+
+
+def assert_ordered_subsequence(before_file, after_file):
+    after_rows = iter_protected_rows(after_file)
+    current_after = next(after_rows, None)
+    missing = []
+    for expected in iter_protected_rows(before_file):
+        while current_after is not None and current_after != expected:
+            current_after = next(after_rows, None)
+        if current_after is None:
+            missing.append(expected)
+            if len(missing) == 5:
+                break
+            continue
+        current_after = next(after_rows, None)
+    for _ in after_rows:
+        pass
+    if missing:
+        raise SystemExit(f"protected production records disappeared: {missing}")
+
+
+def assert_exact_rows(before_file, after_file):
+    if list(iter_protected_rows(before_file)) != list(iter_protected_rows(after_file)):
+        raise SystemExit("protected production record identities changed during the write freeze")
+
+
+def rows_by_table(file_name):
+    result = {}
+    for table, encoded_key in iter_protected_rows(file_name):
+        result.setdefault(table, []).append(encoded_key)
+    return result
+
+
+def decoded_single_key(encoded_key, label):
+    try:
+        value = json.loads(bytes.fromhex(encoded_key).decode("utf-8"))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SystemExit(f"invalid protected key encoding for {label}") from error
+    if not isinstance(value, list) or len(value) != 1 or not isinstance(value[0], str):
+        raise SystemExit(f"unexpected protected key shape for {label}")
+    return value[0]
+
+
+def assert_canonical_rows(before_file, after_file):
+    before_tables = rows_by_table(before_file)
+    after_tables = rows_by_table(after_file)
+    allowed_ids = {
+        "event_releases": {canonical_snapshot["release"]["id"]},
+        "conference_template_versions": {
+            item["id"] for item in canonical_snapshot["template"]["publishedVersions"]
+        },
+    }
+    for table in set(before_tables) | set(after_tables):
+        before = before_tables.get(table, [])
+        after = after_tables.get(table, [])
+        if table not in allowed_ids:
+            if before != after:
+                raise SystemExit(f"protected production record identities changed for {table}")
+            continue
+        before_set = set(before)
+        after_set = set(after)
+        if len(before_set) != len(before) or len(after_set) != len(after):
+            raise SystemExit(f"duplicate protected record identity for {table}")
+        if not before_set <= after_set:
+            raise SystemExit(f"protected production records disappeared from {table}")
+        before_ids = {decoded_single_key(item, table) for item in before}
+        expected_additions = allowed_ids[table] - before_ids
+        actual_additions = {
+            decoded_single_key(item, table) for item in after_set - before_set
+        }
+        if actual_additions != expected_additions:
+            raise SystemExit(f"canonical synchronization added unexpected identities to {table}")
+
+
+if mode == "exact":
+    identity_check = assert_exact_rows
+elif mode == "canonical":
+    identity_check = assert_canonical_rows
+else:
+    identity_check = assert_ordered_subsequence
+identity_check(files[2], files[3])
+if len(files) == 10:
+    identity_check(files[8], files[9])
+
+
+def assert_canonical_ticket_rows(label, before_rows, after_rows, expected_ids):
+    if not set(before_rows) <= set(after_rows):
+        raise SystemExit(f"protected {label} records disappeared")
+    for key, before in before_rows.items():
+        if after_rows[key] != before:
+            raise SystemExit(f"{label} sold value changed during the write freeze")
+    expected_additions = expected_ids - set(before_rows)
+    actual_additions = set(after_rows) - set(before_rows)
+    if actual_additions != expected_additions:
+        raise SystemExit(f"canonical synchronization added unexpected {label} identities")
+    if any(after_rows[key] != 0 for key in actual_additions):
+        raise SystemExit(f"new canonical {label} must start with zero sold inventory")
+
+
+for label, before_file, after_file in (
+    ("ticket type", files[4], files[5]),
+    ("ticket quota", files[6], files[7]),
+):
+    before_rows = read_pairs(before_file)
+    after_rows = read_pairs(after_file)
+    if mode == "exact" and before_rows != after_rows:
+        raise SystemExit(f"{label} sold values changed during the write freeze")
+    if mode == "canonical":
+        if label == "ticket type":
+            expected_ids = {
+                item["id"] for item in canonical_snapshot["backend"]["ticketTypes"]
+            }
+        else:
+            expected_ids = {item["id"] for item in canonical_snapshot["ticketQuotas"]}
+        assert_canonical_ticket_rows(label, before_rows, after_rows, expected_ids)
+    for key, before in before_rows.items():
+        after = after_rows.get(key)
+        if after is None or after < before:
+            raise SystemExit(f"{label} sold count decreased for {key}: {before} -> {after}")
+
+print("Production business counts and sold values were preserved")
+PY
+  )
+}
+
+verify_build_identity_files() {
+  python3 - \
+    "$target_sha" \
+    "$BUILD_MIGRATION" \
+    "$BUILD_MIGRATION_HASH" \
+    "$backup_dir/version-after.json" \
+    "$backup_dir/web-version-after.json" \
+    "$backup_dir/admin-version-after.json" \
+    "$backup_dir/health-after.json" \
+    "$backup_dir/worker-version-after.json" <<'PY'
+import json
+import sys
+
+target, migration, migration_hash = sys.argv[1:4]
+file_names = sys.argv[4:]
+labels = ("gateway", "web", "admin", "api", "worker")
+built_at = None
+
+for label, file_name in zip(labels, file_names):
+    with open(file_name, encoding="utf-8") as handle:
+        payload = json.load(handle)
+    build = payload.get("build", payload) if label == "api" else payload
+    expected = {
+        "sha": target,
+        "migration": migration,
+        "migrationHash": migration_hash,
+    }
+    for key, value in expected.items():
+        if build.get(key) != value:
+            raise SystemExit(f"{label} returned an unexpected {key}")
+    if build.get("service") != label:
+        raise SystemExit(f"{label} returned metadata for another service")
+    if not build.get("builtAt") or build.get("builtAt") == "unknown":
+        raise SystemExit(f"{label} returned an unknown build time")
+    if built_at is None:
+        built_at = build["builtAt"]
+    elif build["builtAt"] != built_at:
+        raise SystemExit(f"{label} returned a mixed build time")
+
+with open(file_names[3], encoding="utf-8") as handle:
+    health = json.load(handle)
+if health.get("status") != "ok":
+    raise SystemExit("API health status is not ok")
+database = health.get("database") or {}
+if database.get("ok") is not True or (database.get("migration") or {}).get("ok") is not True:
+    raise SystemExit("database migration health is not current")
+
+print("Gateway, web, admin, API, and worker build identities are consistent")
+PY
+}
+
+verify_homepage_file() {
+  local file_name="$1"
+  local expected_snapshot="${2:-${release_source_dir:-$APP_DIR}/packages/contracts/src/canonical-homepage.public.json}"
+  python3 - \
+    "$file_name" \
+    "$expected_snapshot" \
+    "$CANONICAL_EVENT_SLUG" <<'PY'
+from copy import deepcopy
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    actual = json.load(handle)
+with open(sys.argv[2], encoding="utf-8") as handle:
+    expected = json.load(handle)["publicEvent"]
+
+if actual.get("slug") != sys.argv[3]:
+    raise SystemExit("public homepage did not return the canonical event slug")
+
+normalized = deepcopy(actual)
+normalized["publicMetrics"] = deepcopy(expected.get("publicMetrics"))
+expected_experience = expected.get("experience") or {}
+actual_experience = normalized.get("experience") or {}
+if expected_experience.get("overrideRevisions") is None and actual_experience.get("overrideRevisions") == {}:
+    actual_experience["overrideRevisions"] = None
+expected_template = expected_experience.get("template") or {}
+actual_template = actual_experience.get("template") or {}
+if expected_template.get("bindingRevision") is None:
+    actual_template["bindingRevision"] = None
+
+expected_tickets = {item.get("id"): item for item in expected.get("tickets", [])}
+for ticket in normalized.get("tickets", []):
+    expected_ticket = expected_tickets.get(ticket.get("id"))
+    if expected_ticket is not None:
+        ticket["remaining"] = expected_ticket.get("remaining")
+
+if normalized != expected:
+    raise SystemExit("public homepage content does not match the canonical public snapshot")
+PY
+}
+
+verify_canonical_full_snapshot() {
+  local expected_snapshot="${1:-$release_source_dir/packages/contracts/src/canonical-homepage.snapshot.json}"
+  local evidence_suffix="${2:-production}"
+  local alternate_expected_snapshot="${3:-}"
+  local actual_snapshot="$backup_dir/canonical-homepage.snapshot.${evidence_suffix}.json"
+  [[ -s "$expected_snapshot" ]] || die 'Verified target canonical full snapshot is unavailable.'
+  [[ -z "$alternate_expected_snapshot" || -s "$alternate_expected_snapshot" ]] || {
+    die 'Alternate verified canonical full snapshot is unavailable.'
+  }
+  compose_read_only_bounded "$DB_QUERY_TIMEOUT_SECONDS" run --rm --no-deps \
+    -e CANONICAL_API_BASE_URL=http://api:4100/api/v1 \
+    -e CANONICAL_EXPORT_TRUSTED_COMPOSE_INTERNAL=true \
+    api \
+    node node_modules/@conference/database/dist/export-canonical-homepage.js --stdout \
+    >"$actual_snapshot"
+  chmod 600 "$actual_snapshot"
+  python3 - "$expected_snapshot" "$actual_snapshot" "$alternate_expected_snapshot" <<'PY'
+import json
+import sys
+
+
+def canonical(file_name):
+    with open(file_name, encoding="utf-8") as handle:
+        return json.dumps(json.load(handle), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+actual = canonical(sys.argv[2])
+expected_files = [sys.argv[1], *([sys.argv[3]] if sys.argv[3] else [])]
+for expected_file in expected_files:
+    if canonical(expected_file) == actual:
+        print("Production canonical homepage and backend settings match a verified release snapshot")
+        break
+else:
+    raise SystemExit("production canonical homepage and backend settings differ from the verified target snapshot")
+PY
+}
+
+verify_release() {
+  log 'Verifying containers, build identity, HTTP, canonical homepage, and production data'
+  local service worker_container
+  for service in "${LONG_RUNNING_SERVICES[@]}"; do
+    assert_service_healthy "$service"
+  done
+  assert_api_uses_compose_database
+
+  compose ps >"$backup_dir/compose-ps-after.txt"
+  compose logs --no-color --tail=200 api worker db-init gateway >"$backup_dir/runtime-logs-after.txt" 2>&1
+
+  curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/version.json' >"$backup_dir/version-after.json"
+  curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/web-version.json' >"$backup_dir/web-version-after.json"
+  curl "${CURL_ARGS[@]}" -H 'Host: admin.hui.ailingdaoli.com' \
+    'http://127.0.0.1:8088/admin/version.json' >"$backup_dir/admin-version-after.json"
+  curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/health' >"$backup_dir/health-after.json"
+  curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/homepage' >"$backup_dir/homepage-after.json"
+
+  worker_container="$(compose ps -q worker)"
+  timeout --foreground --kill-after=10s "${DB_PROOF_TIMEOUT_SECONDS}s" docker exec "$worker_container" node -e \
+    "console.log(JSON.stringify({service:'worker',sha:process.env.BUILD_SHA,builtAt:process.env.BUILD_TIME,migration:process.env.BUILD_MIGRATION,migrationHash:process.env.BUILD_MIGRATION_HASH}))" \
+    >"$backup_dir/worker-version-after.json"
+
+  verify_build_identity_files
+  verify_homepage_file "$backup_dir/homepage-after.json"
+
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/version.json" >"$backup_dir/public-version-after.json"
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/web-version.json" >"$backup_dir/public-web-version-after.json"
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/health" >"$backup_dir/public-health-after.json"
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/homepage" >"$backup_dir/public-homepage-after.json"
+  curl "${CURL_ARGS[@]}" --location --max-redirs 5 --max-filesize 5242880 \
+    "${PUBLIC_ORIGIN}/" >"$backup_dir/public-homepage-document-after.html"
+  curl "${CURL_ARGS[@]}" --head "${PUBLIC_ORIGIN}/" >"$backup_dir/public-homepage-headers.txt"
+  curl "${CURL_ARGS[@]}" --head "${ADMIN_ORIGIN}/admin/" >"$backup_dir/public-admin-headers.txt"
+  curl "${CURL_ARGS[@]}" --head "$PAYMENT_URL" >"$backup_dir/public-payment-headers.txt"
+  [[ "$(json_sha_from_stdin <"$backup_dir/public-version-after.json")" == "$target_sha" ]] || {
+    die 'Public version endpoint does not match the target commit.'
+  }
+  [[ "$(build_fingerprint_from_stdin web <"$backup_dir/public-web-version-after.json")" == \
+    "$(build_fingerprint_from_stdin web <"$backup_dir/web-version-after.json")" ]] || {
+    die 'Public web bundle does not match the verified local target bundle.'
+  }
+  [[ -s "$backup_dir/public-homepage-document-after.html" ]] || {
+    die 'Public homepage returned an empty document.'
+  }
+  assert_health_json <"$backup_dir/public-health-after.json"
+  verify_homepage_file "$backup_dir/public-homepage-after.json"
+  verify_canonical_full_snapshot
+
+  capture_business_snapshot "$backup_dir/business-counts-after.csv"
+  capture_protected_business_ids "$backup_dir/protected-business-ids-after.csv" stable comparison
+  capture_protected_business_ids "$backup_dir/retention-managed-ids-after.csv" retention comparison
+  capture_ticket_sales "$backup_dir/ticket-types-sold-after.csv" "$backup_dir/ticket-quotas-sold-after.csv"
+  compare_production_data
+  docker image inspect \
+    tokems-api:local \
+    tokems-admin:local \
+    tokems-web:local \
+    tokems-worker:local \
+    tokems-gateway:local \
+    tokems-notification-sink:local \
+    >"$backup_dir/images-after.json"
+  nginx -t
+  assert_source_unchanged
+}
+
+repair_runtime_identity() {
+  log 'Validating the running release before repairing protected production build identity'
+  assert_minimal_git_state
+  assert_production_environment false
+  assert_no_parallel_release
+  assert_pending_recovery_policy
+  compose config --quiet
+  docker info >/dev/null
+  nginx -t
+
+  local service source_sha repair_stamp repair_dir
+  for service in "${LONG_RUNNING_SERVICES[@]}"; do
+    assert_service_healthy "$service"
+  done
+  assert_runtime_image_tags
+  assert_current_runtime_identity false
+  assert_api_uses_compose_database
+  assert_operational_write_state normal
+  wait_for_worker_ready
+
+  source_sha="$(git_as_owner rev-parse HEAD)"
+  git_fetch_origin_main
+  target_sha="$(git_as_owner rev-parse origin/main)"
+  assert_target_selection "$target_sha"
+  git_as_owner cat-file -e "${runtime_sha}^{commit}"
+  git_as_owner merge-base --is-ancestor "$runtime_sha" "$target_sha" || {
+    die 'The running release is not an ancestor of origin/main.'
+  }
+  git_as_owner merge-base --is-ancestor "$source_sha" "$target_sha" || {
+    die 'The server source checkout cannot fast-forward to origin/main.'
+  }
+  [[ "$(curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/version.json" | json_sha_from_stdin)" == "$runtime_sha" ]] || {
+    die 'Public version endpoint differs from the verified local runtime.'
+  }
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/health" | assert_health_json
+  verify_github_release_gate
+
+  repair_stamp="$(date '+%Y%m%d-%H%M%S')"
+  repair_dir="${BACKUP_ROOT}/identity-repair-${repair_stamp}"
+  [[ ! -e "$repair_dir" ]] || die "Identity repair directory already exists: ${repair_dir}"
+  install -d -m 700 "$BACKUP_ROOT"
+  install -d -m 700 "$repair_dir"
+  cp -- "$active_env_file" "$repair_dir/.env.before"
+  chown root:root "$repair_dir/.env.before"
+  chmod 600 "$repair_dir/.env.before"
+
+  repair_env_file="$(mktemp "${PRODUCTION_ENV_FILE}.repair.XXXXXX")"
+  cp -- "$active_env_file" "$repair_env_file"
+  clear_build_identity "$repair_env_file"
+  clear_compatibility_release_metadata "$repair_env_file"
+  set_env_value BUILD_SHA "$runtime_sha" "$repair_env_file"
+  set_env_value BUILD_TIME "$runtime_time" "$repair_env_file"
+  set_env_value BUILD_MIGRATION "$runtime_migration" "$repair_env_file"
+  set_env_value BUILD_MIGRATION_HASH "$runtime_migration_hash" "$repair_env_file"
+  if [[ "$runtime_code_migration_hash" != "$runtime_migration_hash" ]]; then
+    set_release_metadata_value TOKEMS_COMPATIBILITY_ROLLBACK active "$repair_env_file"
+    set_release_metadata_value TOKEMS_ROLLBACK_CODE_MIGRATION "$runtime_code_migration" "$repair_env_file"
+    set_release_metadata_value TOKEMS_ROLLBACK_CODE_MIGRATION_HASH "$runtime_code_migration_hash" "$repair_env_file"
+  fi
+  chown root:root "$repair_env_file"
+  chmod 600 "$repair_env_file"
+  [[ "$(env_file_value BUILD_SHA "$repair_env_file")" == "$runtime_sha" ]] || die 'Repaired BUILD_SHA validation failed.'
+  [[ "$(env_file_value BUILD_TIME "$repair_env_file")" == "$runtime_time" ]] || die 'Repaired BUILD_TIME validation failed.'
+  [[ "$(env_file_value BUILD_MIGRATION "$repair_env_file")" == "$runtime_migration" ]] || die 'Repaired BUILD_MIGRATION validation failed.'
+  [[ "$(env_file_value BUILD_MIGRATION_HASH "$repair_env_file")" == "$runtime_migration_hash" ]] || {
+    die 'Repaired BUILD_MIGRATION_HASH validation failed.'
+  }
+  active_env_file="$repair_env_file"
+  if ! (compose config --quiet && assert_current_runtime_identity); then
+    active_env_file="$session_env_file"
+    die 'Identity repair validation failed; the protected production environment was not changed.'
+  fi
+  install_active_production_environment
+
+  printf 'status=repaired\nruntime_sha=%s\nruntime_migration=%s\ntarget_sha=%s\n' \
+    "$runtime_sha" "$runtime_migration" "$target_sha" \
+    >"$repair_dir/identity-repair-result.txt"
+  chmod 600 "$repair_dir/identity-repair-result.txt"
+  log "Production build identity now matches the healthy running release ${runtime_sha}."
+  log "Identity repair backup: ${repair_dir}"
+}
+
+recover_interrupted_release() {
+  log 'Restoring the application state recorded before the interrupted database-free release phase'
+  assert_no_parallel_release
+  assert_pending_recovery_policy
+  [[ "$pending_recovery_phase" == 'pre-write' ]] || die 'recover-interrupted accepts only a pre-database release marker.'
+  [[ -n "$pending_recovery_rollback_tag" ]] || die 'Interrupted release marker is missing its rollback image tag.'
+
+  backup_dir="$pending_recovery_backup_dir"
+  rollback_tag="$pending_recovery_rollback_tag"
+  target_sha="$pending_recovery_target_sha"
+  if [[ -n "$requested_target_sha" && "$requested_target_sha" != "$target_sha" ]]; then
+    die "Interrupted release target is ${target_sha}; requested target was ${requested_target_sha}."
+  fi
+  assert_trusted_recovery_file "$backup_dir/.env"
+  assert_trusted_recovery_file "$backup_dir/docker-compose.yml"
+  active_env_file="$backup_dir/.env"
+  active_compose_file="$backup_dir/docker-compose.yml"
+  assert_production_environment false
+
+  local image service
+  for image in "${ROLLBACK_IMAGES[@]}"; do
+    docker image inspect "${image}:${rollback_tag}" >/dev/null
+    docker tag "${image}:${rollback_tag}" "${image}:local"
+  done
+
+  install_active_production_environment
+
+  compose_bounded "$SERVICE_TRANSITION_TIMEOUT_SECONDS" \
+    up -d \
+    --no-build \
+    --no-deps \
+    --force-recreate \
+    --wait \
+    --wait-timeout 300 \
+    "${RELEASE_SERVICES[@]}" \
+    >"$backup_dir/interrupted-release-recovery.log" 2>&1
+
+  compose config --quiet
+  docker info >/dev/null
+  nginx -t
+  for service in "${LONG_RUNNING_SERVICES[@]}"; do
+    assert_service_healthy "$service"
+  done
+  assert_runtime_image_tags
+  assert_current_runtime_identity
+  assert_api_uses_compose_database
+  assert_operational_write_state normal
+  wait_for_worker_ready
+  [[ "$(curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/version.json" | json_sha_from_stdin)" == "$runtime_sha" ]] || {
+    die 'Recovered public version differs from the restored local runtime.'
+  }
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/health" \
+    >"$backup_dir/public-health-interrupted-recovery.json"
+  chmod 600 "$backup_dir/public-health-interrupted-recovery.json"
+  assert_health_json <"$backup_dir/public-health-interrupted-recovery.json"
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/homepage" \
+    >"$backup_dir/public-homepage-interrupted-recovery.json"
+  chmod 600 "$backup_dir/public-homepage-interrupted-recovery.json"
+  verify_homepage_file \
+    "$backup_dir/public-homepage-interrupted-recovery.json" \
+    "$backup_dir/canonical-homepage.public.before.json"
+
+  printf 'status=recovered-pre-write\nruntime_sha=%s\ntarget_sha=%s\nrollback_tag=%s\n' \
+    "$runtime_sha" "$target_sha" "$rollback_tag" \
+    >"$backup_dir/interrupted-release-recovery-result.txt"
+  chmod 600 "$backup_dir/interrupted-release-recovery-result.txt"
+  clear_pending_recovery_marker
+  log "Interrupted pre-database release recovered to ${runtime_sha}; evidence remains at ${backup_dir}."
+}
+
+resolve_pending_recovery() {
+  log 'Verifying independently restored production writes before clearing the recovery marker'
+  assert_minimal_git_state
+  assert_production_environment
+  assert_no_parallel_release
+  assert_pending_recovery_policy
+  compose config --quiet
+  docker info >/dev/null
+  nginx -t
+
+  local service baseline_phase expected_file resolved_snapshot resolved_full_snapshot
+  local alternate_full_snapshot='' previous_projection='false' runtime_projection='false'
+  for service in "${LONG_RUNNING_SERVICES[@]}"; do
+    assert_service_healthy "$service"
+  done
+  assert_runtime_image_tags
+  assert_current_runtime_identity
+  assert_api_uses_compose_database
+  assert_operational_write_state normal
+  wait_for_worker_ready
+  curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/health' | assert_health_json
+
+  git_fetch_origin_main
+  target_sha="$(git_as_owner rev-parse origin/main)"
+  assert_target_selection "$target_sha"
+  git_as_owner cat-file -e "${runtime_sha}^{commit}"
+  git_as_owner merge-base --is-ancestor "$runtime_sha" "$target_sha" || {
+    die 'Resolved runtime is not an ancestor of origin/main.'
+  }
+  verify_github_release_gate
+  [[ "$(curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/version.json" | json_sha_from_stdin)" == "$runtime_sha" ]] || {
+    die 'Resolved public version differs from the verified local runtime.'
+  }
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/health" \
+    >"$pending_recovery_backup_dir/public-health-recovery-resolve.json"
+  chmod 600 "$pending_recovery_backup_dir/public-health-recovery-resolve.json"
+  assert_health_json <"$pending_recovery_backup_dir/public-health-recovery-resolve.json"
+
+  backup_dir="$pending_recovery_backup_dir"
+  baseline_phase='before'
+  if [[ ! -s "$backup_dir/business-counts-before.csv" ]] || \
+    [[ ! -f "$backup_dir/protected-business-ids-before.csv" ]] || \
+    [[ ! -f "$backup_dir/ticket-types-sold-before.csv" ]] || \
+    [[ ! -f "$backup_dir/ticket-quotas-sold-before.csv" ]]; then
+    baseline_phase='build-start'
+  fi
+  expected_file="business-counts-${baseline_phase}.csv"
+  [[ -s "$backup_dir/$expected_file" ]] || die "Recovery baseline evidence is missing: ${expected_file}"
+  for expected_file in \
+    "protected-business-ids-${baseline_phase}.csv" \
+    "ticket-types-sold-${baseline_phase}.csv" \
+    "ticket-quotas-sold-${baseline_phase}.csv"; do
+    [[ -f "$backup_dir/$expected_file" ]] || die "Recovery baseline evidence is missing: ${expected_file}"
+  done
+  capture_business_snapshot "$backup_dir/business-counts-recovery-resolve.csv"
+  capture_protected_business_ids "$backup_dir/protected-business-ids-recovery-resolve.csv" stable growth_comparison
+  capture_ticket_sales \
+    "$backup_dir/ticket-types-sold-recovery-resolve.csv" \
+    "$backup_dir/ticket-quotas-sold-recovery-resolve.csv"
+  compare_production_data recovery-resolve "$baseline_phase" false growth
+
+  git_as_owner show "${runtime_sha}:packages/contracts/src/canonical-homepage.public.json" \
+    >"$backup_dir/canonical-homepage.public.resolved-runtime.json"
+  git_as_owner show "${runtime_sha}:packages/contracts/src/canonical-homepage.snapshot.json" \
+    >"$backup_dir/canonical-homepage.snapshot.resolved-runtime.json"
+  chmod 600 \
+    "$backup_dir/canonical-homepage.public.resolved-runtime.json" \
+    "$backup_dir/canonical-homepage.snapshot.resolved-runtime.json"
+  curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/homepage' \
+    >"$backup_dir/homepage-recovery-resolve.json"
+  if verify_homepage_file \
+    "$backup_dir/homepage-recovery-resolve.json" \
+    "$backup_dir/canonical-homepage.public.before.json" 2>/dev/null; then
+    previous_projection='true'
+  fi
+  if verify_homepage_file \
+    "$backup_dir/homepage-recovery-resolve.json" \
+    "$backup_dir/canonical-homepage.public.resolved-runtime.json" 2>/dev/null; then
+    runtime_projection='true'
+  fi
+  if [[ "$previous_projection" == 'true' && "$runtime_projection" == 'true' ]]; then
+    resolved_snapshot="$backup_dir/canonical-homepage.public.resolved-runtime.json"
+    resolved_full_snapshot="$backup_dir/canonical-homepage.snapshot.resolved-runtime.json"
+    alternate_full_snapshot="$backup_dir/canonical-homepage.snapshot.before.json"
+    printf 'homepage_projection=shared-by-previous-and-runtime\n' >"$backup_dir/recovery-resolve-result.txt"
+  elif [[ "$previous_projection" == 'true' ]]; then
+    resolved_snapshot="$backup_dir/canonical-homepage.public.before.json"
+    resolved_full_snapshot="$backup_dir/canonical-homepage.snapshot.before.json"
+    printf 'homepage_projection=previous-release\n' >"$backup_dir/recovery-resolve-result.txt"
+  elif [[ "$runtime_projection" == 'true' ]]; then
+    resolved_snapshot="$backup_dir/canonical-homepage.public.resolved-runtime.json"
+    resolved_full_snapshot="$backup_dir/canonical-homepage.snapshot.resolved-runtime.json"
+    printf 'homepage_projection=resolved-runtime\n' >"$backup_dir/recovery-resolve-result.txt"
+  else
+    die 'Resolved homepage matches neither the previous release nor the verified running release snapshot.'
+  fi
+  curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/homepage" \
+    >"$backup_dir/public-homepage-recovery-resolve.json"
+  chmod 600 "$backup_dir/public-homepage-recovery-resolve.json"
+  verify_homepage_file "$backup_dir/public-homepage-recovery-resolve.json" "$resolved_snapshot"
+  export TOKEMS_READ_ONLY_DATABASE_URL
+  TOKEMS_READ_ONLY_DATABASE_URL="$(read_only_database_url)"
+  verify_canonical_full_snapshot \
+    "$resolved_full_snapshot" \
+    recovery-resolve \
+    "$alternate_full_snapshot"
+  unset TOKEMS_READ_ONLY_DATABASE_URL
+  printf 'baseline=%s\nruntime_sha=%s\n' "$baseline_phase" "$runtime_sha" \
+    >>"$backup_dir/recovery-resolve-result.txt"
+  chmod 600 "$backup_dir/recovery-resolve-result.txt"
+  clear_pending_recovery_marker
+  log "Normal API writes and the standard Worker command are verified; recovery evidence remains at ${pending_recovery_backup_dir}."
+}
+
+write_success_summary() {
+  install_active_production_environment
+  printf 'status=deployed\nruntime_before=%s\ntarget_sha=%s\ncanonical_sync=%s\nbackup_dir=%s\nrollback_tag=%s\n' \
+    "$release_baseline_sha" \
+    "$target_sha" \
+    "$canonical_sync_performed" \
+    "$backup_dir" \
+    "$rollback_tag" \
+    >"$backup_dir/deployment-result.txt"
+  chmod 600 "$backup_dir/deployment-result.txt"
+  clear_pending_recovery_marker
+  stop_thaw_watchdog
+  deployment_succeeded='true'
+  log "Deployment completed: ${release_baseline_sha} -> ${target_sha}"
+  log "Backup: ${backup_dir}"
+  log "Rollback images: ${rollback_tag}"
+  log "Canonical sync performed: ${canonical_sync_performed}"
+}
+
+main() {
+  [[ $# -gt 0 ]] || {
+    usage >&2
+    return 2
+  }
+
+  parse_arguments "$@"
+  pin_local_runtime_controls
+  require_root_and_base_commands
+  acquire_deploy_lock
+  if [[ "$mode" == 'recover-interrupted' ]]; then
+    bootstrap_recovery_script "$@"
+    recover_interrupted_release
+    return 0
+  fi
+  assert_minimal_git_state
+  bootstrap_latest_script "$@"
+  snapshot_production_environment
+  if [[ "$mode" == 'repair-identity' ]]; then
+    repair_runtime_identity
+    return 0
+  fi
+  if [[ "$mode" == 'resolve-recovery' ]]; then
+    resolve_pending_recovery
+    return 0
+  fi
+  run_full_preflight
+
+  if [[ "$mode" == 'check' ]]; then
+    log 'Production preflight passed; source checkout, environment, database, images, and containers were unchanged.'
+    return 0
+  fi
+
+  create_backup_and_rollback_point
+  sync_source
+  write_build_identity
+  build_images
+  enter_release_write_freeze
+  refresh_pre_mutation_database_backup
+  run_database_updates
+  switch_services
+  verify_release
+  thaw_release_write_freeze
+  write_success_summary
+}
+
+main "$@"


### PR DESCRIPTION
## 概要
- 增加生产单命令部署、备份、恢复与提交身份门禁
- 将规范大会模板及关联后台设置纳入完整快照验收
- 增加 Worker 就绪标记、写入守护和生产数据保护
- 补充生产部署手册、安装说明和专项测试

## 验证
- pnpm check
- node --test tooling/lib/production-deploy.test.mjs
- pnpm canonical:check
- pnpm audit:security
- git diff --check