### PR TITLE
fix: repair production canonical drift automatically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - 每次生产变更都要先创建数据库备份、记录当前提交和容器状态，并为当前应用镜像添加 `rollback-<时间戳>` 标签。
 - Docker 构建和运行必须使用同一组 `BUILD_SHA`、`BUILD_TIME`、`BUILD_MIGRATION`、`BUILD_MIGRATION_HASH`。任何值为 `unknown` 时禁止切换生产流量。
 - 常规发布固定使用 `SEED_DEMO_DATA=false`。只有已确认需要同步仓库规范模板时，才允许按 Runbook 的“规范模板同步”流程临时运行 `SEED_DEMO_DATA=true`。
+- 自动发布预检必须以只读数据库连接导出生产完整规范快照并与目标提交比较；Git 快照变化或生产状态漂移时都要启用规范同步，`--skip-canonical` 不得跳过漂移修复。
 - 规范模板的组织 slug 为 `geo-conference`，大会 slug 为 `tokems26`。线上报名、订单、票、发票、库存销量和用户数据必须保留。
 - 本地 `http://127.0.0.1:8088/` 当前实际展示的 `geo-conference` / `tokems26` 是唯一规范大会模板。首页文案或关联后台设置发生任何变化后，推送 GitHub 前必须运行 `pnpm canonical:export`，并提交完整规范快照 `packages/contracts/src/canonical-homepage.snapshot.json` 及前台派生快照 `packages/contracts/src/canonical-homepage.public.json`。
 - 每次推送 GitHub 前都必须运行 `pnpm canonical:check`。本地首页、数据库或当前发布快照不可读取，快照存在漂移，或脱敏校验失败时禁止推送。

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -27,7 +27,7 @@ sudo /usr/local/sbin/tokems-deploy deploy --resume-recovery
 sudo /usr/local/sbin/tokems-deploy resolve-recovery
 ```
 
-脚本不依赖宿主机 Node.js 或 pnpm。它会验证目标提交来自已合并 PR 且官方 main push 的 `quality-and-flows` 成功，证明运行 API、目标 Compose 和备份操作使用同一个 PostgreSQL 实例，随后依次执行构建开始备份、镜像回滚标签、root-only 源码与环境快照、Fast-forward、串行镜像构建、写冻结后的最终数据库备份、迁移、按快照差异自动触发的规范模板同步、应用容器切换和完整验收。验收包含公开首页和生产数据库重新导出的脱敏完整后台模板快照。备份与日志保存在 `/www/backup/TokEMS/<时间戳>`，容量检查直接读取这个目录实际所在的文件系统。任何资源、Git、CI、Compose、Nginx、数据保护或健康门禁失败都会终止发布。首次修改源码、环境或镜像前会持久化 `RECOVERY_REQUIRED`；数据库写冻结后把阶段更新为 `write-freeze`，完整发布通过后才归档。`pre-write` 阶段的硬中断使用保存于发布备份中的精确恢复脚本离线恢复；受保护窗口由独立的 systemd 监督单元持续守护，部署控制器退出且恢复标记仍存在时反复停止 API/Worker，再由恢复流程收集数据库迁移证据并恢复应用。数据库不可用时继续保留标记并保持 API/Worker 停止。
+脚本不依赖宿主机 Node.js 或 pnpm。它会验证目标提交来自已合并 PR 且官方 main push 的 `quality-and-flows` 成功，证明运行 API、目标 Compose 和备份操作使用同一个 PostgreSQL 实例，并通过只读导出核对线上完整规范状态与目标快照。Git 快照发生变化或线上已存在漂移时，规范同步会自动启用。随后脚本依次执行构建开始备份、镜像回滚标签、root-only 源码与环境快照、Fast-forward、串行镜像构建、写冻结后的最终数据库备份、迁移、规范模板同步、应用容器切换和完整验收。验收包含公开首页和生产数据库重新导出的脱敏完整后台模板快照。备份与日志保存在 `/www/backup/TokEMS/<时间戳>`，容量检查直接读取这个目录实际所在的文件系统。任何资源、Git、CI、Compose、Nginx、数据保护或健康门禁失败都会终止发布。首次修改源码、环境或镜像前会持久化 `RECOVERY_REQUIRED`；数据库写冻结后把阶段更新为 `write-freeze`，完整发布通过后才归档。`pre-write` 阶段的硬中断使用保存于发布备份中的精确恢复脚本离线恢复；受保护窗口由独立的 systemd 监督单元持续守护，部署控制器退出且恢复标记仍存在时反复停止 API/Worker，再由恢复流程收集数据库迁移证据并恢复应用。数据库不可用时继续保留标记并保持 API/Worker 停止。
 
 每次标准发布都使用短暂写冻结：镜像构建后停止 API/Worker，重新生成包含构建期间新增交易的最终 dump 和业务基线。稳定业务表按主键索引逐表流式取证；带保留期自动清理的数据在只读阶段单独比对，恢复 Worker 后允许既定清理策略运行。迁移与可选规范同步完成后，以只读 API 和暂停 Worker 的状态验收，随后恢复目标 API/Worker。Worker 完成启动维护后会在容器 tmpfs 写入带构建身份的持久 ready 文件，脚本核对该身份后再复核生产主键、计数和销量。窗口内报名、支付回调、后台保存和异步任务需要依赖调用方重试，正式操作安排在业务低峰。
 

--- a/docs/production-deployment-runbook.md
+++ b/docs/production-deployment-runbook.md
@@ -323,7 +323,7 @@ sudo install -o root -g root -m 0755 \
 sudo bash /usr/local/sbin/tokems-deploy "$deploy_action" --target-sha "$target_sha"
 ```
 
-默认模板策略为自动判断。两个规范快照相对当前线上提交发生变化时，脚本强制同步规范模板；`--sync-canonical` 可在快照未变化时主动重跑幂等同步；`--skip-canonical` 只接受快照未变化的发布。指定目标提交时使用完整 SHA：
+默认模板策略为自动判断。两个规范快照相对当前线上提交发生变化时，脚本强制同步规范模板；快照未变化时，预检仍会使用只读数据库连接导出线上完整规范状态，并与目标快照逐项比较，发现存量漂移后自动触发同步。`--sync-canonical` 可主动重跑幂等同步；`--skip-canonical` 仅在 Git 快照未变化且线上完整规范状态已经匹配时通过。指定目标提交时使用完整 SHA：
 
 ```bash
 sudo /usr/local/sbin/tokems-deploy deploy \

--- a/tooling/lib/production-deploy.test.mjs
+++ b/tooling/lib/production-deploy.test.mjs
@@ -602,6 +602,59 @@ test('release verifies public recovery projection and the full canonical backend
   assert.match(source, /backend settings differ from the verified target snapshot/);
 });
 
+test('automatic canonical sync repairs pre-existing production drift', () => {
+  const decision = source.slice(
+    source.indexOf('determine_canonical_sync() {'),
+    source.indexOf('\nassert_standard_release_scope() {'),
+  );
+
+  assert.match(source, /production_canonical_snapshot_matches_target/);
+  assert.match(source, /canonical-probe\.compose/);
+  assert.match(source, /default_transaction_read_only=on/);
+  assert.match(source, /read_only_compose_file="\$previous_read_only_compose_file"/);
+  assert.match(source, /unset TOKEMS_READ_ONLY_DATABASE_URL/);
+  assert.match(decision, /production_canonical_snapshot_matches_target/);
+  assert.match(decision, /canonical_sync_required='true'/);
+  assert.match(decision, /Production canonical snapshot drift detected/);
+  assert.match(decision, /Cannot skip canonical synchronization while production is drifted/);
+});
+
+test('canonical snapshot comparator detects equality, drift, and invalid JSON', () => {
+  const match = source.match(/canonical_snapshot_files_match\(\) \{[\s\S]*?<<'PY'\n([\s\S]*?)\nPY/);
+  assert.ok(match, 'canonical snapshot comparison Python program was not found');
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-canonical-probe-'));
+  const actual = resolve(directory, 'actual.json');
+  const matching = resolve(directory, 'matching.json');
+  const drifted = resolve(directory, 'drifted.json');
+  const invalid = resolve(directory, 'invalid.json');
+  try {
+    writeFileSync(actual, '{"nested":{"value":"大会"},"items":[1,2]}\n');
+    writeFileSync(matching, '{\n  "items": [1, 2],\n  "nested": {"value": "大会"}\n}\n');
+    writeFileSync(drifted, '{"nested":{"value":"旧文案"},"items":[1,2]}\n');
+    writeFileSync(invalid, '{"nested":');
+
+    const equalResult = spawnSync('python3', ['-', actual, matching], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.equal(equalResult.status, 0, equalResult.stderr);
+
+    const driftResult = spawnSync('python3', ['-', actual, drifted], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.equal(driftResult.status, 1, driftResult.stderr);
+
+    const invalidResult = spawnSync('python3', ['-', actual, invalid], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.equal(invalidResult.status, 2, invalidResult.stderr);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test('production network calls are bounded and infrastructure reconciliation is isolated', () => {
   assert.doesNotMatch(source, /curl\s+-f/);
   assert.match(source, /readonly -a CURL_ARGS=/);

--- a/tooling/production-deploy.sh
+++ b/tooling/production-deploy.sh
@@ -108,6 +108,9 @@ recovery_marker_armed='false'
 protected_write_block_confirmed='false'
 release_write_freeze='false'
 read_only_compose_file=''
+canonical_probe_compose_file=''
+canonical_probe_target_snapshot=''
+canonical_probe_actual_snapshot=''
 backup_ready='false'
 environment_changed='false'
 images_changed='false'
@@ -149,12 +152,13 @@ Modes:
 Options:
   --target-sha <40-char-sha>    Require origin/main to equal this exact commit.
   --sync-canonical              Run the canonical template sync even when snapshots are unchanged.
-  --skip-canonical              Allowed only when canonical snapshots are unchanged.
+  --skip-canonical              Allowed only when Git snapshots and production already match.
   --resume-recovery             Allow deploy to continue a verified read-only recovery state.
   -h, --help                    Show this help.
 
-The default canonical mode is automatic. A snapshot change always enables the protected
-geo-conference/tokems26 synchronization and preserves production business data.
+The default canonical mode is automatic. A Git snapshot change or production database
+drift enables the protected geo-conference/tokems26 synchronization while preserving
+production business data.
 USAGE
 }
 
@@ -269,7 +273,24 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || die "Required command is unavailable: $1"
 }
 
+cleanup_canonical_probe() {
+  local probe_file
+  for probe_file in \
+    "$canonical_probe_compose_file" \
+    "$canonical_probe_target_snapshot" \
+    "$canonical_probe_actual_snapshot"; do
+    [[ -n "$probe_file" && -f "$probe_file" ]] || continue
+    case "$probe_file" in
+      /run/lock/tokems-production-deploy/canonical-probe.*) rm -f -- "$probe_file" ;;
+    esac
+  done
+  canonical_probe_compose_file=''
+  canonical_probe_target_snapshot=''
+  canonical_probe_actual_snapshot=''
+}
+
 cleanup_temp_script() {
+  cleanup_canonical_probe
   if [[ -f "${BASH_SOURCE[0]}" ]]; then
     case "${BASH_SOURCE[0]}" in
       /run/lock/tokems-production-deploy/bootstrap.*) rm -f -- "${BASH_SOURCE[0]}" ;;
@@ -1670,8 +1691,97 @@ capture_release_baseline() {
   release_baseline_code_migration_hash="$runtime_code_migration_hash"
 }
 
+canonical_snapshot_files_match() {
+  local actual_snapshot="$1"
+  shift
+  [[ $# -gt 0 ]] || return 2
+  python3 - "$actual_snapshot" "$@" <<'PY'
+import json
+import sys
+
+
+def load_snapshot(file_name):
+    with open(file_name, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+try:
+    actual = load_snapshot(sys.argv[1])
+    expected = [load_snapshot(file_name) for file_name in sys.argv[2:]]
+except (OSError, UnicodeError, json.JSONDecodeError):
+    raise SystemExit(2)
+
+raise SystemExit(0 if actual in expected else 1)
+PY
+}
+
+production_canonical_snapshot_matches_target() {
+  local previous_read_only_compose_file="$read_only_compose_file"
+  local read_only_url='' export_status=0 compare_status=0
+  [[ -z "$canonical_probe_compose_file" && -z "$canonical_probe_target_snapshot" && -z "$canonical_probe_actual_snapshot" ]] || {
+    die 'Canonical production probe state was already initialized.'
+  }
+
+  canonical_probe_compose_file="$(mktemp "${LOCK_DIR}/canonical-probe.compose.XXXXXX")" || return 2
+  canonical_probe_target_snapshot="$(mktemp "${LOCK_DIR}/canonical-probe.target.XXXXXX")" || {
+    cleanup_canonical_probe
+    return 2
+  }
+  canonical_probe_actual_snapshot="$(mktemp "${LOCK_DIR}/canonical-probe.actual.XXXXXX")" || {
+    cleanup_canonical_probe
+    return 2
+  }
+  if ! cat >"$canonical_probe_compose_file" <<'YAML'
+services:
+  api:
+    environment:
+      DATABASE_URL: ${TOKEMS_READ_ONLY_DATABASE_URL:?TOKEMS_READ_ONLY_DATABASE_URL is required}
+YAML
+  then
+    cleanup_canonical_probe
+    return 2
+  fi
+  git_as_owner show "${target_sha}:${CANONICAL_SNAPSHOT_PATHS[0]}" >"$canonical_probe_target_snapshot" || {
+    cleanup_canonical_probe
+    return 2
+  }
+  chmod 600 \
+    "$canonical_probe_compose_file" \
+    "$canonical_probe_target_snapshot" \
+    "$canonical_probe_actual_snapshot" || {
+    cleanup_canonical_probe
+    return 2
+  }
+
+  read_only_url="$(read_only_database_url)" || {
+    cleanup_canonical_probe
+    return 2
+  }
+  TOKEMS_READ_ONLY_DATABASE_URL="$read_only_url"
+  export TOKEMS_READ_ONLY_DATABASE_URL
+  read_only_compose_file="$canonical_probe_compose_file"
+  compose_read_only_bounded "$DB_QUERY_TIMEOUT_SECONDS" run --rm --no-deps \
+    -e CANONICAL_API_BASE_URL=http://api:4100/api/v1 \
+    -e CANONICAL_EXPORT_TRUSTED_COMPOSE_INTERNAL=true \
+    api \
+    node node_modules/@conference/database/dist/export-canonical-homepage.js --stdout \
+    >"$canonical_probe_actual_snapshot" 2>/dev/null || export_status=$?
+  read_only_compose_file="$previous_read_only_compose_file"
+  unset TOKEMS_READ_ONLY_DATABASE_URL
+  if [[ $export_status -ne 0 ]]; then
+    cleanup_canonical_probe
+    return 2
+  fi
+
+  canonical_snapshot_files_match \
+    "$canonical_probe_actual_snapshot" \
+    "$canonical_probe_target_snapshot" || compare_status=$?
+  cleanup_canonical_probe
+  return "$compare_status"
+}
+
 determine_canonical_sync() {
-  local changed='false' diff_status=0
+  local changed='false' diff_status=0 production_status=0
   if git_as_owner diff --quiet "$release_baseline_sha" "$target_sha" -- "${CANONICAL_SNAPSHOT_PATHS[@]}"; then
     changed='false'
   else
@@ -1680,16 +1790,33 @@ determine_canonical_sync() {
     changed='true'
   fi
 
-  case "$canonical_mode" in
-    always) canonical_sync_required='true' ;;
-    auto) canonical_sync_required="$changed" ;;
-    never)
-      [[ "$changed" == 'false' ]] || {
-        die 'Canonical snapshots changed; this release must run the protected canonical sync.'
-      }
-      canonical_sync_required='false'
-      ;;
-  esac
+  if [[ "$canonical_mode" == 'always' ]]; then
+    canonical_sync_required='true'
+    return 0
+  fi
+  if [[ "$changed" == 'true' ]]; then
+    [[ "$canonical_mode" != 'never' ]] || {
+      die 'Canonical snapshots changed; this release must run the protected canonical sync.'
+    }
+    canonical_sync_required='true'
+    return 0
+  fi
+
+  if production_canonical_snapshot_matches_target; then
+    canonical_sync_required='false'
+    return 0
+  else
+    production_status=$?
+  fi
+  [[ $production_status -eq 1 ]] || {
+    die 'Unable to compare the production canonical snapshot with the target; diagnose the read-only probe or rerun with --sync-canonical.'
+  }
+
+  log 'Production canonical snapshot drift detected.'
+  [[ "$canonical_mode" != 'never' ]] || {
+    die 'Cannot skip canonical synchronization while production is drifted.'
+  }
+  canonical_sync_required='true'
 }
 
 assert_standard_release_scope() {
@@ -2744,25 +2871,12 @@ verify_canonical_full_snapshot() {
     node node_modules/@conference/database/dist/export-canonical-homepage.js --stdout \
     >"$actual_snapshot"
   chmod 600 "$actual_snapshot"
-  python3 - "$expected_snapshot" "$actual_snapshot" "$alternate_expected_snapshot" <<'PY'
-import json
-import sys
-
-
-def canonical(file_name):
-    with open(file_name, encoding="utf-8") as handle:
-        return json.dumps(json.load(handle), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-
-
-actual = canonical(sys.argv[2])
-expected_files = [sys.argv[1], *([sys.argv[3]] if sys.argv[3] else [])]
-for expected_file in expected_files:
-    if canonical(expected_file) == actual:
-        print("Production canonical homepage and backend settings match a verified release snapshot")
-        break
-else:
-    raise SystemExit("production canonical homepage and backend settings differ from the verified target snapshot")
-PY
+  local -a expected_snapshots=("$expected_snapshot")
+  [[ -z "$alternate_expected_snapshot" ]] || expected_snapshots+=("$alternate_expected_snapshot")
+  canonical_snapshot_files_match "$actual_snapshot" "${expected_snapshots[@]}" || {
+    die 'production canonical homepage and backend settings differ from the verified target snapshot'
+  }
+  log 'Production canonical homepage and backend settings match a verified release snapshot'
 }
 
 verify_release() {


### PR DESCRIPTION
## Summary

- compare the live production canonical export with the target full snapshot during read-only preflight
- force protected canonical synchronization when existing production data has drifted, even when Git snapshots are unchanged
- reject `--skip-canonical` while production is drifted and clean up root-only probe artifacts
- document the updated release invariant and operator behavior

## Root cause

The previous automatic decision compared canonical files only between the running Git SHA and the target Git SHA. Production already contained an older database-backed conference release, while both commits carried the same current snapshot, so deployment skipped `SEED_DEMO_DATA=true`.

## Verification

- `node --test tooling/lib/production-deploy.test.mjs` (25 passed)
- `pnpm check`
- `pnpm audit:security`
- `pnpm canonical:check`
- `git diff --check`
- `bash -n tooling/production-deploy.sh`