### PR TITLE
fix: restore unpaid order checkout

### DIFF
--- a/apps/api/src/common/customer-account.integration.test.ts
+++ b/apps/api/src/common/customer-account.integration.test.ts
@@ -15,6 +15,7 @@ import {
   invoiceRequests,
   invoiceStateLogs,
   orders,
+  orderAccessTokens,
   organizations,
   outboxEvents,
   payments,
@@ -801,6 +802,89 @@ describePersistent('customer invoice center', () => {
     await db.delete(organizations).where(eq(organizations.id, organizationId));
     await db.delete(users).where(eq(users.id, adminUserId));
     await database.onModuleDestroy();
+  });
+
+  it('issues fresh payment access to the signed-in purchaser without requiring profile email', async () => {
+    const db = database.db!;
+    const registrationId = randomUUID();
+    const orderId = randomUUID();
+    await db.insert(registrations).values({
+      id: registrationId,
+      organizationId,
+      eventId: eventIds[0]!,
+      ticketTypeId: ticketTypeIds[0]!,
+      customerUserId: null,
+      registrationCode: `PAY-RESUME-${registrationId.slice(0, 8)}`,
+      status: 'pending_payment',
+      attendee: {
+        name: '续付验收用户',
+        mobile: '13980000098',
+        email: 'checkout-only@example.com',
+        company: '续付验收公司',
+        title: '支付负责人',
+        city: '深圳',
+      },
+      attendeeMobileE164: '+8613980000098',
+      attendeeEmailNormalized: 'checkout-only@example.com',
+      consentSnapshot: { purchaseFor: 'other', proxyAuthorizationAccepted: true },
+    });
+    await db.insert(orders).values({
+      id: orderId,
+      organizationId,
+      eventId: eventIds[0]!,
+      registrationId,
+      purchaserCustomerUserId: customerUserId,
+      purchaseIntentId: randomUUID(),
+      orderNo: `PAY-RESUME-${orderId.slice(0, 8)}`,
+      status: 'pending_payment',
+      amount: 39900,
+      currency: 'CNY',
+      pricingSnapshot: { source: 'payment-resume-test' },
+      expiresAt: new Date(Date.now() + 15 * 60_000),
+    });
+
+    const sessionWithoutEmail = {
+      ...session,
+      customer: {
+        ...session.customer,
+        profile: { ...session.customer.profile, email: null },
+      },
+    };
+
+    try {
+      const result = await account.createOrderPaymentAccess(sessionWithoutEmail, orderId);
+      expect(result).toMatchObject({
+        orderId,
+        orderAccessToken: expect.stringMatching(/^[A-Za-z0-9_-]{40,}$/),
+      });
+      const tokenHash = createHash('sha256').update(result.orderAccessToken).digest('hex');
+      const [storedToken] = await db
+        .select({ scopes: orderAccessTokens.scopes })
+        .from(orderAccessTokens)
+        .where(
+          and(
+            eq(orderAccessTokens.orderId, orderId),
+            eq(orderAccessTokens.tokenHash, tokenHash),
+          ),
+        )
+        .limit(1);
+      expect(storedToken?.scopes).toContain('order:read');
+
+      await expect(
+        account.createOrderPaymentAccess(
+          { ...sessionWithoutEmail, customerUserId: randomUUID() },
+          orderId,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+
+      await db.update(orders).set({ status: 'paid' }).where(eq(orders.id, orderId));
+      await expect(
+        account.createOrderPaymentAccess(sessionWithoutEmail, orderId),
+      ).rejects.toMatchObject({ status: 409 });
+    } finally {
+      await db.delete(orders).where(eq(orders.id, orderId));
+      await db.delete(registrations).where(eq(registrations.id, registrationId));
+    }
   });
 
   it('returns accurate categories, actions and net-paid eligibility', async () => {

--- a/apps/api/src/common/customer-account.service.ts
+++ b/apps/api/src/common/customer-account.service.ts
@@ -729,6 +729,51 @@ export class CustomerAccountService {
     };
   }
 
+  async createOrderPaymentAccess(session: AuthenticatedCustomer, orderId: string) {
+    return this.db().transaction(async (tx) => {
+      const [order] = await tx
+        .select({ id: orders.id, status: orders.status, expiresAt: orders.expiresAt })
+        .from(orders)
+        .innerJoin(registrations, eq(registrations.id, orders.registrationId))
+        .where(
+          and(
+            eq(orders.id, orderId),
+            eq(orders.organizationId, session.organizationId),
+            this.purchaserScope(session.customerUserId),
+            isNull(registrations.supersededAt),
+          ),
+        )
+        .for('update')
+        .limit(1);
+      if (!order) {
+        throw new DomainError(API_ERROR_CODES.NOT_FOUND, '订单不存在', HttpStatus.NOT_FOUND);
+      }
+      if (order.status !== 'pending_payment') {
+        throw new DomainError(
+          API_ERROR_CODES.INVALID_STATE_TRANSITION,
+          order.status === 'processing' ? '支付结果正在确认中，请稍后刷新' : '当前订单无需继续支付',
+          HttpStatus.CONFLICT,
+        );
+      }
+      if (order.expiresAt <= new Date()) {
+        throw new DomainError(
+          API_ERROR_CODES.INVALID_STATE_TRANSITION,
+          '订单保留时间已结束，请返回报名页重新提交',
+          HttpStatus.CONFLICT,
+        );
+      }
+
+      const orderAccessToken = randomBytes(32).toString('base64url');
+      await tx.insert(orderAccessTokens).values({
+        orderId: order.id,
+        tokenHash: sha256(orderAccessToken),
+        scopes: ['order:read'],
+        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60_000),
+      });
+      return { orderId: order.id, orderAccessToken };
+    });
+  }
+
   async registration(
     session: AuthenticatedCustomer,
     registrationId: string,

--- a/apps/api/src/modules/customer.module.ts
+++ b/apps/api/src/modules/customer.module.ts
@@ -203,6 +203,16 @@ class CustomerAccountController {
     return this.customerAccount.purchasedOrders(request.customerSession, input.cursor, input.limit);
   }
 
+  @Post('orders/:orderId/payment-access')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
+  createOrderPaymentAccess(
+    @Req() request: CustomerRequest,
+    @Param('orderId', ParseUUIDPipe) orderId: string,
+  ) {
+    return this.customerAccount.createOrderPaymentAccess(request.customerSession, orderId);
+  }
+
   @Patch('orders/:orderId/attendee')
   @Throttle({ default: { limit: 5, ttl: 60 * 60_000 } })
   updateOrderAttendee(

--- a/apps/web/app/composables/useCustomerSession.ts
+++ b/apps/web/app/composables/useCustomerSession.ts
@@ -165,6 +165,18 @@ export function useCustomerSession() {
     });
   }
 
+  function createOrderPaymentAccess(orderId: string) {
+    return $fetch<{ orderId: string; orderAccessToken: string }>(
+      `/customer/orders/${encodeURIComponent(orderId)}/payment-access`,
+      {
+        method: 'POST',
+        baseURL,
+        credentials: 'include',
+        headers: headers(true),
+      },
+    );
+  }
+
   function claimAttendee(input: AttendeeClaimInput) {
     return $fetch<AttendeeClaimResult>('/customer/attendee-claims', {
       method: 'POST',
@@ -405,6 +417,7 @@ export function useCustomerSession() {
     registrations,
     purchaseContext,
     purchasedOrders,
+    createOrderPaymentAccess,
     claimAttendee,
     updatePurchasedOrderAttendee,
     registration,

--- a/apps/web/app/pages/account/index.vue
+++ b/apps/web/app/pages/account/index.vue
@@ -9,7 +9,6 @@ import type {
 } from '@conference/contracts';
 import { watch } from 'vue';
 import { useCustomerSession } from '~/composables/useCustomerSession';
-import { readOrderAccessToken } from '~/composables/useOrderAccessToken';
 import { createRegistrationIntent } from '~/utils/purchase-journey';
 import { resolveAttendeeNeedsAccountState } from '~/utils/attendee-needs';
 
@@ -38,6 +37,7 @@ const nextCursor = ref<string | null>(null);
 const nextOrdersCursor = ref<string | null>(null);
 const editingOrderId = ref('');
 const attendeeSaving = ref(false);
+const resumingOrderId = ref('');
 const attendeeEdit = reactive({ name: '', mobile: '' });
 const errorMessage = ref('');
 const successMessage = ref('');
@@ -186,21 +186,18 @@ async function saveAttendee(order: CustomerPurchasedOrder) {
 }
 
 async function resumeOrder(order: CustomerPurchasedOrder) {
-  const token = readOrderAccessToken(order.id);
-  if (token) {
-    await router.push({ path: `/order/${order.id}`, query: { event: order.eventSlug } });
-    return;
-  }
-  const email = customer.session.value?.customer.profile.email;
-  if (!email) {
-    errorMessage.value = '当前浏览器没有订单访问凭证，请先在常用资料中补充邮箱以接收安全支付链接。';
-    return;
-  }
+  resumingOrderId.value = order.id;
+  errorMessage.value = '';
   try {
-    await api.requestOrderAccessLink(order.orderNo, email);
-    successMessage.value = `安全支付链接已发送至 ${email}`;
-  } catch {
-    errorMessage.value = '安全支付链接发送失败，请稍后重试。';
+    const access = await customer.createOrderPaymentAccess(order.id);
+    window.location.assign(
+      api.resolvePaymentCheckoutUrl(order.id, order.eventSlug, access.orderAccessToken),
+    );
+  } catch (error) {
+    const value = error as { data?: { message?: string } };
+    errorMessage.value = value.data?.message ?? '支付入口恢复失败，请稍后重试。';
+  } finally {
+    resumingOrderId.value = '';
   }
 }
 
@@ -790,9 +787,10 @@ useHead({ title: '个人中心' });
                       v-if="['pending_payment', 'processing'].includes(orderItem.status)"
                       class="registration-primary-action"
                       type="button"
+                      :disabled="resumingOrderId === orderItem.id"
                       @click="resumeOrder(orderItem)"
                     >
-                      {{ readOrderAccessToken(orderItem.id) ? '继续支付' : '发送安全支付链接' }}
+                      {{ resumingOrderId === orderItem.id ? '正在恢复支付…' : '继续支付' }}
                       <span aria-hidden="true">→</span>
                     </button>
                     <NuxtLink

--- a/docs/generated/project-inventory.json
+++ b/docs/generated/project-inventory.json
@@ -6,6 +6,6 @@
   "latestMigration": "0057_petite_boom_boom.sql",
   "databaseTables": 78,
   "apiControllers": 32,
-  "apiOperations": 266,
+  "apiOperations": 267,
   "testFiles": 159
 }


### PR DESCRIPTION
## What changed

用户首次下单后离开支付页时，跨域会话存储会让大会主站失去订单访问凭证。登录购票人现在可以为自己尚未支付且未过期的订单获取新的安全支付凭证，并从个人中心继续支付。服务端校验组织、购票人归属、订单状态、有效期和 CSRF，数据库仅保存令牌哈希。

## Verification

- pnpm check
- customer-account.integration.test.ts：14 tests passed
- pnpm canonical:check
- pre-push canonical guard passed

## Risk and rollout

无数据库迁移或配置变更。支付凭证沿用现有 order:read 权限和 30 天凭证有效期，订单自身的支付状态与过期时间继续作为支付门禁。

## Checklist

- [x] Tests cover the changed behavior.
- [x] Documentation and examples match the implementation.
- [x] Organization isolation and authorization remain enforced.
- [x] No secrets, private data, or generated local artifacts are included.
- [x] User-facing copy is ready for localization.