### PR TITLE
fix: 修复未支付订单续付与闭单重报

### DIFF
--- a/apps/api/src/common/commerce-operations.service.ts
+++ b/apps/api/src/common/commerce-operations.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@conference/contracts';
 import {
   ACTIVE_WECHAT_PAYMENT_STATUSES,
+  activeInventoryReservationAt,
   auditLogs,
   events,
   inventoryReservations,
@@ -380,6 +381,9 @@ export class CommerceOperationsService {
     const releasedOrderIds: string[] = [];
     for (const candidate of candidates) {
       const released = await db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${`wechatpay:prepare:${candidate.order.id}`}, 0))`,
+        );
         const [activeWeChatPayment] = await tx
           .select({ id: payments.id })
           .from(payments)
@@ -468,7 +472,7 @@ export class CommerceOperationsService {
           ),
           isNull(inventoryReservations.releasedAt),
           isNull(inventoryReservations.convertedAt),
-          gt(inventoryReservations.expiresAt, new Date()),
+          activeInventoryReservationAt(new Date()),
         ),
       )
       .groupBy(inventoryReservations.ticketTypeId);

--- a/apps/api/src/common/conference.repository.test.ts
+++ b/apps/api/src/common/conference.repository.test.ts
@@ -126,6 +126,10 @@ describe('ConferenceRepository in-memory operational loop', () => {
 
     expect(second.order.id).toBe(first.order.id);
     expect(second.registration.id).toBe(first.registration.id);
+    expect(second.orderAccessToken).not.toBe(first.orderAccessToken);
+    await expect(repository.getOrder(second.order.id, second.orderAccessToken!)).resolves.toMatchObject(
+      { id: second.order.id, status: 'pending_payment' },
+    );
     expect(after.tickets[0]!.remaining).toBe(before.tickets[0]!.remaining - 1);
   });
 
@@ -751,11 +755,8 @@ describe('ConferenceRepository in-memory operational loop', () => {
     });
 
     const resumed = await repository.createCheckout(
-      {
-        ...registrationInput(),
-        purchaseIntentId: '73e2ddc2-c755-4a5f-a61a-c0348917942',
-      },
-      'registration-resume-second-key',
+      registrationInput(),
+      'registration-resume-first-key',
       customerActor(),
     );
 
@@ -764,6 +765,8 @@ describe('ConferenceRepository in-memory operational loop', () => {
     expect(resumed.registration.status).toBe('pending_payment');
     expect(resumed.order.status).toBe('pending_payment');
     expect(new Date(resumed.order.expiresAt).getTime()).toBeGreaterThan(Date.now());
+    expect(orders.get(first.order.id)?.status).toBe('pending_payment');
+    expect(registrations.get(first.registration.id)?.status).toBe('pending_payment');
     expect(orders).toHaveLength(11);
     expect(registrations).toHaveLength(11);
   });

--- a/apps/api/src/common/conference.repository.ts
+++ b/apps/api/src/common/conference.repository.ts
@@ -44,6 +44,7 @@ import {
 } from '@conference/contracts';
 import {
   ACTIVE_WECHAT_PAYMENT_STATUSES,
+  activeInventoryReservationAt,
   attendeeClaimTokens,
   auditLogs,
   checkinLists,
@@ -710,7 +711,7 @@ export class ConferenceRepository {
                 inArray(inventoryReservations.ticketTypeId, ticketIds),
                 isNull(inventoryReservations.convertedAt),
                 isNull(inventoryReservations.releasedAt),
-                gt(inventoryReservations.expiresAt, new Date()),
+                activeInventoryReservationAt(new Date()),
               ),
             )
             .groupBy(inventoryReservations.ticketTypeId),
@@ -1601,7 +1602,7 @@ export class ConferenceRepository {
             eq(inventoryReservations.ticketTypeId, ticket.id),
             isNull(inventoryReservations.convertedAt),
             isNull(inventoryReservations.releasedAt),
-            gt(inventoryReservations.expiresAt, new Date()),
+            activeInventoryReservationAt(new Date()),
           ),
         );
       const [offerCount] = await tx
@@ -1731,19 +1732,44 @@ export class ConferenceRepository {
       input,
       customerUserId: customer.customerUserId,
     });
-    const cached = this.memory.idempotency.get(`registration:${idempotencyKey}`) as
-      { requestHash: string; response: RegistrationCheckout } | undefined;
-    if (cached) {
-      if (cached.requestHash !== requestHash) {
-        throw new DomainError(
-          API_ERROR_CODES.IDEMPOTENCY_CONFLICT,
-          '相同幂等键对应了不同的报名内容',
-          HttpStatus.CONFLICT,
-        );
-      }
-      return cached.response;
-    }
     const db = this.database.db;
+    const memoryIdempotencyKey = `registration:${idempotencyKey}`;
+    if (!db) {
+      const cached = this.memory.idempotency.get(memoryIdempotencyKey) as
+        { requestHash: string; response: RegistrationCheckout } | undefined;
+      if (cached) {
+        if (cached.requestHash !== requestHash) {
+          throw new DomainError(
+            API_ERROR_CODES.IDEMPOTENCY_CONFLICT,
+            '相同幂等键对应了不同的报名内容',
+            HttpStatus.CONFLICT,
+          );
+        }
+        const currentRegistration = this.memory.registrations.get(cached.response.registration.id);
+        const currentOrder = this.memory.orders.get(cached.response.order.id);
+        const replayStateIsCurrent =
+          currentRegistration &&
+          currentOrder &&
+          currentRegistration.status === cached.response.registration.status &&
+          currentOrder.status === cached.response.order.status &&
+          currentOrder.expiresAt === cached.response.order.expiresAt &&
+          !(
+            currentOrder.status === 'pending_payment' &&
+            new Date(currentOrder.expiresAt) <= new Date()
+          );
+        if (replayStateIsCurrent) {
+          const orderAccessToken = randomBytes(32).toString('base64url');
+          this.memoryOrderTokens.set(currentOrder.id, this.tokenHash(orderAccessToken));
+          const response = { ...cached.response, orderAccessToken };
+          this.memory.idempotency.set(memoryIdempotencyKey, {
+            requestHash: cached.requestHash,
+            response,
+          });
+          return response;
+        }
+        this.memory.idempotency.delete(memoryIdempotencyKey);
+      }
+    }
 
     if (!db) {
       const ticket = this.demoEvent.tickets.find((item) => item.id === input.ticketTypeId);
@@ -1788,7 +1814,12 @@ export class ConferenceRepository {
         const intentRegistration = intentOrder
           ? this.memory.registrations.get(intentOrder.registrationId)
           : undefined;
-        if (intentOrder && intentRegistration) {
+        const intentOrderNeedsResume =
+          intentOrder &&
+          (intentOrder.status === 'closed' ||
+            (intentOrder.status === 'pending_payment' &&
+              new Date(intentOrder.expiresAt) <= new Date()));
+        if (intentOrder && intentRegistration && !intentOrderNeedsResume) {
           const intentTicket = [...this.memory.tickets.values()].find(
             (item) => item.registrationId === intentRegistration.id,
           );
@@ -1801,7 +1832,7 @@ export class ConferenceRepository {
             orderAccessToken,
             ...(input.purchaseFor === 'self' && intentTicket ? { ticket: intentTicket } : {}),
           };
-          this.memory.idempotency.set(`registration:${idempotencyKey}`, { requestHash, response });
+          this.memory.idempotency.set(memoryIdempotencyKey, { requestHash, response });
           return response;
         }
       }
@@ -2035,7 +2066,7 @@ export class ConferenceRepository {
             order: resumedOrder,
             orderAccessToken,
           };
-          this.memory.idempotency.set(`registration:${idempotencyKey}`, { requestHash, response });
+          this.memory.idempotency.set(memoryIdempotencyKey, { requestHash, response });
           return response;
         }
         const existingTicket = [...this.memory.tickets.values()].find(
@@ -2050,7 +2081,7 @@ export class ConferenceRepository {
           orderAccessToken,
           ...(input.purchaseFor === 'self' && existingTicket ? { ticket: existingTicket } : {}),
         };
-        this.memory.idempotency.set(`registration:${idempotencyKey}`, { requestHash, response });
+        this.memory.idempotency.set(memoryIdempotencyKey, { requestHash, response });
         return response;
       }
       const purchaserOrders = [...this.memory.orders.values()].filter(
@@ -2209,7 +2240,7 @@ export class ConferenceRepository {
         orderAccessToken,
         ...(input.purchaseFor === 'self' && issuedTicket ? { ticket: issuedTicket } : {}),
       };
-      this.memory.idempotency.set(`registration:${idempotencyKey}`, { requestHash, response });
+      this.memory.idempotency.set(memoryIdempotencyKey, { requestHash, response });
       return response;
     }
 
@@ -2310,17 +2341,41 @@ export class ConferenceRepository {
             RegistrationCheckout,
             'orderAccessToken'
           >;
-          const [activeRegistration] = await tx
-            .select({ id: registrations.id })
-            .from(registrations)
-            .where(
-              and(
-                eq(registrations.id, durableResponse.registration.id),
-                isNull(registrations.supersededAt),
-              ),
-            )
-            .limit(1);
-          if (activeRegistration) {
+          const replayStateMatches = (
+            state:
+              | {
+                  registrationStatus: Registration['status'];
+                  orderStatus: Order['status'];
+                  orderExpiresAt: Date;
+                }
+              | undefined,
+          ) =>
+            Boolean(
+              state &&
+              state.registrationStatus === durableResponse.registration.status &&
+              state.orderStatus === durableResponse.order.status &&
+              state.orderExpiresAt.toISOString() === durableResponse.order.expiresAt &&
+              !(state.orderStatus === 'pending_payment' && state.orderExpiresAt <= new Date()),
+            );
+          const replayStateQuery = () =>
+            tx
+              .select({
+                registrationStatus: registrations.status,
+                orderStatus: orders.status,
+                orderExpiresAt: orders.expiresAt,
+              })
+              .from(orders)
+              .innerJoin(registrations, eq(registrations.id, orders.registrationId))
+              .where(
+                and(
+                  eq(orders.id, durableResponse.order.id),
+                  eq(registrations.id, durableResponse.registration.id),
+                  isNull(registrations.supersededAt),
+                ),
+              );
+          const [observedReplayState] = await replayStateQuery().limit(1);
+          const replayStateIsCurrent = replayStateMatches(observedReplayState);
+          if (replayStateIsCurrent) {
             const replayAccessToken = randomBytes(32).toString('base64url');
             await tx.insert(orderAccessTokens).values({
               orderId: durableResponse.order.id,
@@ -2476,7 +2531,6 @@ export class ConferenceRepository {
               eq(orders.purchaseIntentId, input.purchaseIntentId),
             ),
           )
-          .for('update')
           .limit(1);
         if (intentOrder) {
           const intentSnapshot = intentOrder.pricingSnapshot as { purchaseRequestHash?: string };
@@ -2487,24 +2541,26 @@ export class ConferenceRepository {
               HttpStatus.CONFLICT,
             );
           }
-          const [[intentRegistration], [intentTicketType], [intentTicket]] = await Promise.all([
-            tx
-              .select()
-              .from(registrations)
-              .where(
-                and(
-                  eq(registrations.id, intentOrder.registrationId),
-                  isNull(registrations.supersededAt),
-                ),
-              )
-              .limit(1),
-            tx.select().from(ticketTypes).where(eq(ticketTypes.id, ticketRow.id)).limit(1),
-            tx
-              .select()
-              .from(tickets)
-              .where(eq(tickets.registrationId, intentOrder.registrationId))
-              .limit(1),
-          ]);
+          const [intentRegistration] = await tx
+            .select()
+            .from(registrations)
+            .where(
+              and(
+                eq(registrations.id, intentOrder.registrationId),
+                isNull(registrations.supersededAt),
+              ),
+            )
+            .limit(1);
+          const [intentTicketType] = await tx
+            .select()
+            .from(ticketTypes)
+            .where(eq(ticketTypes.id, ticketRow.id))
+            .limit(1);
+          const [intentTicket] = await tx
+            .select()
+            .from(tickets)
+            .where(eq(tickets.registrationId, intentOrder.registrationId))
+            .limit(1);
           const intentOrderNeedsResume =
             intentOrder.status === 'closed' ||
             (intentOrder.status === 'pending_payment' && intentOrder.expiresAt <= new Date());
@@ -2552,7 +2608,6 @@ export class ConferenceRepository {
             .select()
             .from(orders)
             .where(eq(orders.registrationId, settledRegistration.id))
-            .for('update')
             .limit(1);
           const [lockedSettledRegistration] = await tx
             .select()
@@ -2560,7 +2615,6 @@ export class ConferenceRepository {
             .where(
               and(eq(registrations.id, settledRegistration.id), isNull(registrations.supersededAt)),
             )
-            .for('update')
             .limit(1);
           if (!lockedSettledRegistration) {
             throw new DomainError(
@@ -2822,7 +2876,7 @@ export class ConferenceRepository {
                 eq(inventoryReservations.ticketTypeId, ticketRow.id),
                 isNull(inventoryReservations.convertedAt),
                 isNull(inventoryReservations.releasedAt),
-                gt(inventoryReservations.expiresAt, new Date()),
+                activeInventoryReservationAt(new Date()),
                 excludedOrderId
                   ? sql`${inventoryReservations.orderId} <> ${excludedOrderId}`
                   : undefined,
@@ -2877,10 +2931,25 @@ export class ConferenceRepository {
         }
         let existingRegistration = existingRegistrations[0];
         if (existingRegistration) {
+          const [observedExistingOrder] = await tx
+            .select({ id: orders.id })
+            .from(orders)
+            .where(eq(orders.registrationId, existingRegistration.id))
+            .limit(1);
+          if (observedExistingOrder) {
+            await tx.execute(
+              sql`select pg_advisory_xact_lock(hashtextextended(${`wechatpay:prepare:${observedExistingOrder.id}`}, 0))`,
+            );
+          }
           const [existingOrder] = await tx
             .select()
             .from(orders)
-            .where(eq(orders.registrationId, existingRegistration.id))
+            .where(
+              and(
+                eq(orders.registrationId, existingRegistration.id),
+                observedExistingOrder ? eq(orders.id, observedExistingOrder.id) : undefined,
+              ),
+            )
             .for('update')
             .limit(1);
           const [lockedExistingRegistration] = await tx
@@ -2971,6 +3040,12 @@ export class ConferenceRepository {
                 orderNo: orders.orderNo,
                 status: orders.status,
                 expiresAt: orders.expiresAt,
+                hasActivePayment: sql<boolean>`exists (
+                  select 1 from ${payments}
+                  where ${payments.orderId} = ${orders.id}
+                    and ${payments.provider} = 'wechatpay'
+                    and ${inArray(payments.status, [...ACTIVE_WECHAT_PAYMENT_STATUSES])}
+                )`,
               })
               .from(orders)
               .where(
@@ -2991,7 +3066,10 @@ export class ConferenceRepository {
               .for('update');
             const purchaserEvaluationAt = new Date();
             const activeOtherPurchaserOrders = otherPurchaserOrders.filter(
-              (item) => item.status !== 'pending_payment' || item.expiresAt > purchaserEvaluationAt,
+              (item) =>
+                item.status !== 'pending_payment' ||
+                item.expiresAt > purchaserEvaluationAt ||
+                item.hasActivePayment,
             );
             const otherPendingOrder = activeOtherPurchaserOrders.find((item) =>
               ['pending_review', 'pending_payment', 'processing'].includes(item.status),
@@ -3037,6 +3115,15 @@ export class ConferenceRepository {
               resumedAt.getTime() + (manualReview ? 30 * 24 * 60 * 60_000 : 15 * 60_000),
             );
             let resumedAttendeeClaimToken: string | undefined;
+            await tx
+              .update(orderAccessTokens)
+              .set({ revokedAt: resumedAt })
+              .where(
+                and(
+                  eq(orderAccessTokens.orderId, existingOrder.id),
+                  isNull(orderAccessTokens.revokedAt),
+                ),
+              );
             if (input.purchaseFor === 'other' && existingRegistration.customerUserId === null) {
               await tx
                 .update(attendeeClaimTokens)
@@ -3257,7 +3344,17 @@ export class ConferenceRepository {
           );
         }
         const purchaserOrders = await tx
-          .select({ orderNo: orders.orderNo, status: orders.status, expiresAt: orders.expiresAt })
+          .select({
+            orderNo: orders.orderNo,
+            status: orders.status,
+            expiresAt: orders.expiresAt,
+            hasActivePayment: sql<boolean>`exists (
+              select 1 from ${payments}
+              where ${payments.orderId} = ${orders.id}
+                and ${payments.provider} = 'wechatpay'
+                and ${inArray(payments.status, [...ACTIVE_WECHAT_PAYMENT_STATUSES])}
+            )`,
+          })
           .from(orders)
           .where(
             and(
@@ -3276,7 +3373,10 @@ export class ConferenceRepository {
           .for('update');
         const purchaserEvaluationAt = new Date();
         const activePurchaserOrders = purchaserOrders.filter(
-          (item) => item.status !== 'pending_payment' || item.expiresAt > purchaserEvaluationAt,
+          (item) =>
+            item.status !== 'pending_payment' ||
+            item.expiresAt > purchaserEvaluationAt ||
+            item.hasActivePayment,
         );
         const pendingPurchaserOrder = activePurchaserOrders.find((item) =>
           ['pending_review', 'pending_payment', 'processing'].includes(item.status),
@@ -4309,16 +4409,10 @@ export class ConferenceRepository {
         ['preparing', 'pending', 'processing', 'query_pending'].includes(item.status) &&
         typeof item.payload?.codeUrl === 'string',
     );
-    const anyCodeUrl = paymentRows.find(
-      (item) => typeof item.payload?.codeUrl === 'string' && item.payload.codeUrl,
-    );
     const paymentUrl =
-      (activeNative?.payload && typeof activeNative.payload.codeUrl === 'string'
+      activeNative?.payload && typeof activeNative.payload.codeUrl === 'string'
         ? activeNative.payload.codeUrl
-        : undefined) ??
-      (anyCodeUrl?.payload && typeof anyCodeUrl.payload.codeUrl === 'string'
-        ? anyCodeUrl.payload.codeUrl
-        : undefined);
+        : undefined;
     return {
       id: row.id,
       isProxyPurchase:
@@ -4555,7 +4649,7 @@ export class ConferenceRepository {
                 eq(inventoryReservations.ticketTypeId, ticketTypeRow.id),
                 isNull(inventoryReservations.convertedAt),
                 isNull(inventoryReservations.releasedAt),
-                gt(inventoryReservations.expiresAt, now),
+                activeInventoryReservationAt(now),
                 sql`${inventoryReservations.orderId} <> ${orderRow.id}`,
               ),
             );

--- a/apps/api/src/common/customer-account.service.ts
+++ b/apps/api/src/common/customer-account.service.ts
@@ -38,6 +38,7 @@ import {
   resolveCustomerAdminDisplay,
 } from '@conference/contracts';
 import {
+  ACTIVE_WECHAT_PAYMENT_STATUSES,
   attendeeClaimTokens,
   attendeeNeedQuestions,
   attendeeNeedSubmissions,
@@ -490,90 +491,141 @@ export class CustomerAccountService {
     eventId: number,
   ): Promise<EventPurchaseContext> {
     const db = this.db();
-    const [event] = await db
-      .select({ id: events.id, status: events.status, settings: events.settings })
-      .from(events)
-      .where(and(eq(events.id, eventId), eq(events.organizationId, session.organizationId)))
-      .limit(1);
-    if (!event) {
-      throw new DomainError(API_ERROR_CODES.NOT_FOUND, '大会不存在', HttpStatus.NOT_FOUND);
-    }
-    const eventSettings = event.settings as {
-      currentReleaseId?: string;
-      registration?: PublicEvent['registration'];
-    };
-    let releaseSnapshot: RegistrationReleaseSnapshot | undefined;
-    if (eventSettings.currentReleaseId) {
-      const [release] = await db
-        .select({ snapshot: eventReleases.snapshot })
-        .from(eventReleases)
-        .where(
-          and(
-            eq(eventReleases.id, eventSettings.currentReleaseId),
-            eq(eventReleases.eventId, event.id),
-          ),
-        )
-        .limit(1);
-      if (!release) {
-        throw new DomainError(
-          API_ERROR_CODES.NOT_FOUND,
-          '大会发布版本已失效',
-          HttpStatus.NOT_FOUND,
-        );
-      }
-      releaseSnapshot = release.snapshot as RegistrationReleaseSnapshot;
-    }
-    const [attendance, purchaseSummary] = await Promise.all([
-      db
-        .select({
-          registrationId: registrations.id,
-          registrationStatus: registrations.status,
-          ticketCode: tickets.code,
-          ticketStatus: tickets.status,
-        })
-        .from(registrations)
-        .leftJoin(tickets, eq(tickets.registrationId, registrations.id))
-        .where(
-          and(
-            eq(registrations.organizationId, session.organizationId),
-            eq(registrations.eventId, eventId),
-            eq(registrations.customerUserId, session.customerUserId),
-            isNull(registrations.supersededAt),
-          ),
-        )
-        .orderBy(desc(registrations.createdAt))
-        .limit(1)
-        .then((rows) => rows[0] ?? null),
-      db
-        .select({
-          paidCount: sql<number>`count(*) filter (where ${orders.status} in ('paid', 'partially_refunded'))::int`,
-          pendingCount: sql<number>`count(*) filter (where ${orders.status} in ('pending_review', 'processing') or (${orders.status} = 'pending_payment' and ${orders.expiresAt} > now()))::int`,
-          activeSeatCount: sql<number>`count(*) filter (where ${orders.status} in ('pending_review', 'processing', 'paid', 'partially_refunded') or (${orders.status} = 'pending_payment' and ${orders.expiresAt} > now()))::int`,
-          resumePaymentOrderId: sql<string | null>`(
-            array_agg(${orders.id} order by ${orders.createdAt} desc)
-            filter (where ${orders.status} = 'pending_payment' and ${orders.expiresAt} > now())
-          )[1]`,
-        })
-        .from(orders)
-        .innerJoin(registrations, eq(registrations.id, orders.registrationId))
-        .where(
-          and(
-            eq(orders.organizationId, session.organizationId),
-            eq(orders.eventId, eventId),
-            this.purchaserScope(session.customerUserId),
-            isNull(registrations.supersededAt),
-          ),
-        )
-        .then(
-          (rows) =>
-            rows[0] ?? {
-              paidCount: 0,
-              pendingCount: 0,
-              activeSeatCount: 0,
-              resumePaymentOrderId: null,
-            },
-        ),
-    ]);
+    const { event, eventSettings, releaseSnapshot, attendance, purchaseSummary } =
+      await db.transaction(
+        async (tx) => {
+          const [event] = await tx
+            .select({
+              id: events.id,
+              status: events.status,
+              settings: events.settings,
+            })
+            .from(events)
+            .where(and(eq(events.id, eventId), eq(events.organizationId, session.organizationId)))
+            .limit(1);
+          if (!event) {
+            throw new DomainError(API_ERROR_CODES.NOT_FOUND, '大会不存在', HttpStatus.NOT_FOUND);
+          }
+          const eventSettings = event.settings as {
+            currentReleaseId?: string;
+            registration?: PublicEvent['registration'];
+          };
+          let releaseSnapshot: RegistrationReleaseSnapshot | undefined;
+          if (eventSettings.currentReleaseId) {
+            const [release] = await tx
+              .select({ snapshot: eventReleases.snapshot })
+              .from(eventReleases)
+              .where(
+                and(
+                  eq(eventReleases.id, eventSettings.currentReleaseId),
+                  eq(eventReleases.eventId, event.id),
+                ),
+              )
+              .limit(1);
+            if (!release) {
+              throw new DomainError(
+                API_ERROR_CODES.NOT_FOUND,
+                '大会发布版本已失效',
+                HttpStatus.NOT_FOUND,
+              );
+            }
+            releaseSnapshot = release.snapshot as RegistrationReleaseSnapshot;
+          }
+          const attendance = await tx
+            .select({
+              registrationId: registrations.id,
+              registrationStatus: registrations.status,
+              ticketCode: tickets.code,
+              ticketStatus: tickets.status,
+              canManageOrder: this.purchaserScope(session.customerUserId),
+              orderIsActive: sql<boolean>`
+                ${orders.id} is null
+                or ${orders.status} in ('pending_review', 'processing', 'paid', 'partially_refunded')
+                or (${orders.status} = 'pending_payment' and ${orders.expiresAt} > now())
+                or exists (
+                  select 1
+                  from ${payments}
+                  where ${payments.orderId} = ${orders.id}
+                    and ${payments.provider} = 'wechatpay'
+                    and ${inArray(payments.status, [...ACTIVE_WECHAT_PAYMENT_STATUSES])}
+                )
+              `,
+            })
+            .from(registrations)
+            .leftJoin(orders, eq(orders.registrationId, registrations.id))
+            .leftJoin(tickets, eq(tickets.registrationId, registrations.id))
+            .where(
+              and(
+                eq(registrations.organizationId, session.organizationId),
+                eq(registrations.eventId, eventId),
+                eq(registrations.customerUserId, session.customerUserId),
+                isNull(registrations.supersededAt),
+              ),
+            )
+            .orderBy(desc(registrations.createdAt))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
+          const purchaseSummary = await tx
+            .select({
+              paidCount: sql<number>`count(*) filter (where ${orders.status} in ('paid', 'partially_refunded'))::int`,
+              pendingCount: sql<number>`count(*) filter (
+                where ${orders.status} in ('pending_review', 'processing')
+                  or (
+                    ${orders.status} = 'pending_payment'
+                    and (
+                      ${orders.expiresAt} > now()
+                      or exists (
+                        select 1 from ${payments}
+                        where ${payments.orderId} = ${orders.id}
+                          and ${payments.provider} = 'wechatpay'
+                          and ${inArray(payments.status, [...ACTIVE_WECHAT_PAYMENT_STATUSES])}
+                      )
+                    )
+                  )
+              )::int`,
+              activeSeatCount: sql<number>`count(*) filter (
+                where ${orders.status} in ('pending_review', 'processing', 'paid', 'partially_refunded')
+                  or (
+                    ${orders.status} = 'pending_payment'
+                    and (
+                      ${orders.expiresAt} > now()
+                      or exists (
+                        select 1 from ${payments}
+                        where ${payments.orderId} = ${orders.id}
+                          and ${payments.provider} = 'wechatpay'
+                          and ${inArray(payments.status, [...ACTIVE_WECHAT_PAYMENT_STATUSES])}
+                      )
+                    )
+                  )
+              )::int`,
+              resumePaymentOrderId: sql<string | null>`(
+                array_agg(${orders.id} order by ${orders.createdAt} desc)
+                filter (where ${orders.status} = 'pending_payment' and ${orders.expiresAt} > now())
+              )[1]`,
+            })
+            .from(orders)
+            .innerJoin(registrations, eq(registrations.id, orders.registrationId))
+            .where(
+              and(
+                eq(orders.organizationId, session.organizationId),
+                eq(orders.eventId, eventId),
+                this.purchaserScope(session.customerUserId),
+                isNull(registrations.supersededAt),
+              ),
+            )
+            .then(
+              (rows) =>
+                rows[0] ?? {
+                  paidCount: 0,
+                  pendingCount: 0,
+                  activeSeatCount: 0,
+                  resumePaymentOrderId: null,
+                },
+            );
+          return { event, eventSettings, releaseSnapshot, attendance, purchaseSummary };
+        },
+        { isolationLevel: 'repeatable read', accessMode: 'read only' },
+      );
     const registrationSettings = resolvePublishedRegistrationSettings(
       eventSettings,
       releaseSnapshot,
@@ -592,8 +644,18 @@ export class CustomerAccountService {
       additionalPurchaseEnabled &&
       pendingCount === 0 &&
       activeSeatCount < maxActiveSeatsPerPurchaser;
-    const hasActiveSelfAttendance =
-      attendance && !['draft', 'cancelled'].includes(attendance.registrationStatus);
+    const selfRegistrationState: EventPurchaseContext['selfRegistrationState'] = !attendance
+      ? 'none'
+      : !['draft', 'cancelled'].includes(attendance.registrationStatus) && attendance.orderIsActive
+        ? 'active'
+        : 'closed';
+    const hasActiveSelfAttendance = selfRegistrationState === 'active';
+    const canRegisterSelf =
+      checkoutAvailable &&
+      pendingCount === 0 &&
+      activeSeatCount < maxActiveSeatsPerPurchaser &&
+      (!attendance || attendance.canManageOrder) &&
+      !hasActiveSelfAttendance;
     const recommendedActions: EventPurchaseContext['recommendedActions'] = [];
     if (purchaseSummary.resumePaymentOrderId) {
       recommendedActions.push('resume_payment');
@@ -602,7 +664,7 @@ export class CustomerAccountService {
       recommendedActions.push('view_ticket');
     }
     if (canPurchaseAdditional) recommendedActions.push('buy_more');
-    if (checkoutAvailable && !hasActiveSelfAttendance) recommendedActions.push('register_self');
+    if (canRegisterSelf) recommendedActions.push('register_self');
     return {
       eventId,
       additionalPurchaseEnabled,
@@ -618,6 +680,7 @@ export class CustomerAccountService {
             ticketStatus: attendance.ticketStatus,
           }
         : null,
+      selfRegistrationState,
       myPurchases: { paidCount, pendingCount, activeSeatCount },
       resumePaymentOrderId: purchaseSummary.resumePaymentOrderId,
       recommendedActions,
@@ -670,6 +733,7 @@ export class CustomerAccountService {
       ticketStatus: canAccessTicket ? (row.ticket?.status ?? null) : null,
       invoiceId: row.invoice?.id ?? null,
       invoiceStatus: row.invoice?.status ?? null,
+      expiresAt: row.order.expiresAt.toISOString(),
       createdAt: row.order.createdAt.toISOString(),
     };
   }

--- a/apps/api/src/common/event-live-settings.integration.test.ts
+++ b/apps/api/src/common/event-live-settings.integration.test.ts
@@ -12,11 +12,14 @@ import {
   inventoryReservations,
   orders,
   organizations,
+  payments,
   registrations,
   ticketTypes,
 } from '@conference/database';
-import { and, eq, isNotNull, sql } from 'drizzle-orm';
+import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 import { ConferenceRepository } from './conference.repository.js';
+import { CustomerAccountService } from './customer-account.service.js';
+import type { AuthenticatedCustomer } from './customer-auth.service.js';
 import { DatabaseService } from './database.service.js';
 import { EventOperationsService } from './event-operations.service.js';
 import { EventReleaseActivationService } from './event-release-activation.service.js';
@@ -28,6 +31,7 @@ describePersistent('live event settings activation', () => {
   const activation = new EventReleaseActivationService(database);
   const operations = new EventOperationsService(database, activation);
   const repository = new ConferenceRepository(database, activation);
+  const account = new CustomerAccountService(database);
   const slug = `live-settings-${randomUUID().slice(0, 8)}`;
   let eventId: EventId;
   let organizationSlug: string;
@@ -660,7 +664,7 @@ describePersistent('live event settings activation', () => {
     );
   });
 
-  it('protects registration ownership and resumes a closed order with the same business IDs', async () => {
+  it('protects registration ownership and resumes a closed order with the same intent and business IDs', async () => {
     const currentEvent = await repository.getAdminEvent(eventId, DEMO_IDS.organization);
     if (currentEvent.status === 'configuring') {
       await repository.updateEvent(
@@ -732,9 +736,23 @@ describePersistent('live event settings activation', () => {
       formVersion: form.version,
       termsVersion: form.termsVersion,
     };
-    const owner = {
+    const owner: AuthenticatedCustomer & {
+      mobile: string;
+      profile: {
+        nickname: null;
+        realName: string;
+        email: null;
+        company: null;
+        title: null;
+        city: null;
+      };
+    } = {
+      sessionId: randomUUID(),
       customerUserId: ownerId,
       organizationId: DEMO_IDS.organization,
+      tokenHash: 'registration-owner-token-hash',
+      expiresAt: new Date(Date.now() + 60_000),
+      csrfToken: 'registration-owner-csrf-token',
       mobile: ownerMobile,
       profile: {
         nickname: null,
@@ -743,6 +761,25 @@ describePersistent('live event settings activation', () => {
         company: null,
         title: null,
         city: null,
+      },
+      customer: {
+        id: 101,
+        organizationId: DEMO_IDS.organization,
+        mobile: ownerMobile,
+        maskedMobile: ownerMobile,
+        status: 'active',
+        verifiedAt: new Date().toISOString(),
+        lastLoginAt: null,
+        createdAt: new Date().toISOString(),
+        profile: {
+          nickname: null,
+          realName: '报名归属验收用户',
+          email: null,
+          company: null,
+          title: null,
+          city: null,
+          version: 1,
+        },
       },
     };
     const otherCustomer = {
@@ -791,7 +828,88 @@ describePersistent('live event settings activation', () => {
 
       await db
         .update(orders)
-        .set({ status: 'closed', expiresAt: new Date(Date.now() - 60_000), updatedAt: new Date() })
+        .set({ expiresAt: new Date(Date.now() - 60_000), updatedAt: new Date() })
+        .where(eq(orders.id, orderId));
+      const expiredContext = await account.purchaseContext(owner, eventId);
+      expect(expiredContext).toMatchObject({
+        myAttendance: { registrationId, registrationStatus: 'pending_payment' },
+        selfRegistrationState: 'closed',
+        resumePaymentOrderId: null,
+      });
+      expect(expiredContext.recommendedActions).toContain('register_self');
+
+      const [oldPayment] = await db
+        .insert(payments)
+        .values({
+          orderId,
+          provider: 'wechatpay',
+          channel: 'native',
+          outTradeNo: `OLD${suffix}`,
+          status: 'pending',
+          amount: checkout.order.amount,
+          currency: checkout.order.currency,
+          prepayExpiresAt: new Date(Date.now() + 60_000),
+          payload: { codeUrl: `weixin://wxpay/bizpayurl?pr=closed-${suffix}` },
+        })
+        .returning({ id: payments.id });
+      const confirmingContext = await account.purchaseContext(owner, eventId);
+      expect(confirmingContext.selfRegistrationState).toBe('active');
+      expect(confirmingContext.myPurchases).toMatchObject({
+        pendingCount: 1,
+        activeSeatCount: 1,
+      });
+      expect(confirmingContext.recommendedActions).not.toContain('register_self');
+      const confirmingPublicEvent = await repository.getPublicEvent(slug, organizationSlug);
+      expect(confirmingPublicEvent.tickets.find((item) => item.id === ticket.id)?.remaining).toBe(
+        ticket.remaining - 1,
+      );
+      const [ticketInventory] = await db
+        .select({ sold: ticketTypes.sold })
+        .from(ticketTypes)
+        .where(eq(ticketTypes.id, ticket.id))
+        .limit(1);
+      await expect(
+        operations.updateTicketType(DEMO_IDS.organization, eventId, ticket.id, DEMO_IDS.adminUser, {
+          capacity: ticketInventory!.sold,
+        }),
+      ).rejects.toMatchObject({
+        response: { code: 'INVENTORY_UNAVAILABLE' },
+        status: 409,
+      });
+      await expect(
+        repository.createCheckout(
+          {
+            ...input,
+            attendee: {
+              ...input.attendee,
+              name: '延迟支付期间的代购参会人',
+              mobile: `+86137${suffix}`,
+              email: `registration-delayed-proxy-${suffix}@example.com`,
+            },
+            purchaseFor: 'other',
+            purchaseIntentId: randomUUID(),
+            proxyAuthorizationAccepted: true,
+          },
+          `registration-delayed-proxy-${suffix}`,
+          owner,
+        ),
+      ).rejects.toMatchObject({
+        response: { code: 'INVALID_STATE_TRANSITION' },
+        status: 409,
+      });
+      await db
+        .update(payments)
+        .set({
+          status: 'closed',
+          prepayExpiresAt: new Date(Date.now() - 60_000),
+          closedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(payments.id, oldPayment!.id));
+
+      await db
+        .update(orders)
+        .set({ status: 'closed', updatedAt: new Date() })
         .where(eq(orders.id, orderId));
       await db
         .update(registrations)
@@ -802,15 +920,92 @@ describePersistent('live event settings activation', () => {
         .set({ releasedAt: new Date(), updatedAt: new Date() })
         .where(eq(inventoryReservations.orderId, orderId));
 
+      const closedContext = await account.purchaseContext(owner, eventId);
+      expect(closedContext).toMatchObject({
+        myAttendance: { registrationId, registrationStatus: 'cancelled' },
+        selfRegistrationState: 'closed',
+        resumePaymentOrderId: null,
+      });
+      expect(closedContext.recommendedActions).toContain('register_self');
+      expect(closedContext.recommendedActions).not.toContain('resume_payment');
+
+      const blockingRegistrationId = randomUUID();
+      const blockingOrderId = randomUUID();
+      await db.insert(registrations).values({
+        id: blockingRegistrationId,
+        organizationId: DEMO_IDS.organization,
+        eventId,
+        ticketTypeId: ticket.id,
+        customerUserId: null,
+        registrationCode: `BLOCK-${suffix}`,
+        status: 'pending_payment',
+        attendee: {
+          name: '待支付代购参会人',
+          mobile: otherMobile,
+          email: `registration-blocking-${suffix}@example.com`,
+          company: '',
+          title: '',
+          city: '深圳',
+        },
+        attendeeMobileE164: otherMobile,
+        attendeeEmailNormalized: `registration-blocking-${suffix}@example.com`,
+        consentSnapshot: { purchaseFor: 'other' },
+      });
+      await db.insert(orders).values({
+        id: blockingOrderId,
+        organizationId: DEMO_IDS.organization,
+        eventId,
+        registrationId: blockingRegistrationId,
+        purchaserCustomerUserId: ownerId,
+        purchaseIntentId: randomUUID(),
+        orderNo: `BLOCK-${suffix}`,
+        status: 'pending_payment',
+        amount: checkout.order.amount,
+        currency: checkout.order.currency,
+        pricingSnapshot: {},
+        expiresAt: new Date(Date.now() + 15 * 60_000),
+      });
+      const blockedContext = await account.purchaseContext(owner, eventId);
+      expect(blockedContext.recommendedActions).not.toContain('register_self');
+      await db.delete(orders).where(eq(orders.id, blockingOrderId));
+      await db.delete(registrations).where(eq(registrations.id, blockingRegistrationId));
+
       const resumed = await repository.createCheckout(
         input,
-        `registration-owner-resume-${suffix}`,
+        `registration-owner-create-${suffix}-0`,
         owner,
       );
       expect(resumed.registration.id).toBe(registrationId);
       expect(resumed.order.id).toBe(orderId);
+      expect(resumed.order.orderNo).toBe(checkout.order.orderNo);
       expect(resumed.order.status).toBe('pending_payment');
       expect(new Date(resumed.order.expiresAt).getTime()).toBeGreaterThan(Date.now());
+      await expect(repository.getOrder(orderId, checkout.orderAccessToken!)).rejects.toMatchObject({
+        response: { code: 'UNAUTHORIZED' },
+        status: 401,
+      });
+      await expect(
+        repository.getOrder(orderId, resumed.orderAccessToken!),
+      ).resolves.not.toHaveProperty('paymentUrl');
+      const [activeReservationCount] = await db
+        .select({ value: sql<number>`count(*)::int` })
+        .from(inventoryReservations)
+        .where(
+          and(
+            eq(inventoryReservations.orderId, orderId),
+            isNull(inventoryReservations.releasedAt),
+            isNull(inventoryReservations.convertedAt),
+          ),
+        );
+      expect(Number(activeReservationCount?.value ?? 0)).toBe(1);
+      const resumedContext = await account.purchaseContext(owner, eventId);
+      expect(resumedContext).toMatchObject({
+        myAttendance: { registrationId, registrationStatus: 'pending_payment' },
+        selfRegistrationState: 'active',
+        resumePaymentOrderId: orderId,
+      });
+      expect(resumedContext.recommendedActions).toContain('resume_payment');
+      expect(resumedContext.recommendedActions).not.toContain('register_self');
 
       const paid = await repository.confirmMockPayment(
         orderId,
@@ -958,6 +1153,16 @@ describePersistent('live event settings activation', () => {
         .update(inventoryReservations)
         .set({ releasedAt: new Date(), updatedAt: new Date() })
         .where(eq(inventoryReservations.orderId, orderId));
+
+      const claimedAttendeeContext = await account.purchaseContext(
+        {
+          customerUserId: attendeeId,
+          organizationId: DEMO_IDS.organization,
+        } as AuthenticatedCustomer,
+        eventId,
+      );
+      expect(claimedAttendeeContext.selfRegistrationState).toBe('closed');
+      expect(claimedAttendeeContext.recommendedActions).not.toContain('register_self');
 
       const resumed = await repository.createCheckout(
         { ...input, purchaseIntentId: randomUUID() },

--- a/apps/api/src/common/event-operations.service.ts
+++ b/apps/api/src/common/event-operations.service.ts
@@ -27,6 +27,7 @@ import {
   speakerAvatarText,
 } from '@conference/contracts';
 import {
+  activeInventoryReservationAt,
   auditLogs,
   checkinLists,
   conferenceTemplates,
@@ -1585,7 +1586,7 @@ export class EventOperationsService {
                 eq(inventoryReservations.ticketTypeId, ticketTypeId),
                 isNull(inventoryReservations.convertedAt),
                 isNull(inventoryReservations.releasedAt),
-                gt(inventoryReservations.expiresAt, new Date()),
+                activeInventoryReservationAt(new Date()),
               ),
             );
           const [waitlistHeld] = await tx

--- a/apps/api/src/common/wechat-pay.service.ts
+++ b/apps/api/src/common/wechat-pay.service.ts
@@ -1037,6 +1037,7 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
    * @param orderId - Order UUID.
    * @param channel - Target channel.
    * @param order - Authorized order row.
+   * @param accessTokenHash - Hash of the token that must remain valid while the attempt is claimed.
    * @param credentialVersion - Integration key version snapshot.
    * @returns Existing reusable attempt or a freshly claimed preparing attempt.
    */
@@ -1044,12 +1045,44 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
     orderId: string,
     channel: WeChatPaymentChannel,
     order: AuthorizedOrder['order'],
+    accessTokenHash: string,
     credentialVersion: number,
   ): Promise<{ attempt: PaymentAttempt; reusedCredential: boolean }> {
     return this.db().transaction(async (tx) => {
       await tx.execute(
         sql`select pg_advisory_xact_lock(hashtextextended(${`wechatpay:prepare:${orderId}`}, 0))`,
       );
+      const [currentAuthorization] = await tx
+        .select({ order: orders, tokenScopes: orderAccessTokens.scopes })
+        .from(orders)
+        .innerJoin(
+          orderAccessTokens,
+          and(
+            eq(orderAccessTokens.orderId, orders.id),
+            eq(orderAccessTokens.tokenHash, accessTokenHash),
+            isNull(orderAccessTokens.revokedAt),
+            gt(orderAccessTokens.expiresAt, new Date()),
+          ),
+        )
+        .where(eq(orders.id, orderId))
+        .limit(1);
+      if (!currentAuthorization || !currentAuthorization.tokenScopes.includes('order:read')) {
+        throw new DomainError(
+          API_ERROR_CODES.UNAUTHORIZED,
+          '订单访问链接无效或已经过期',
+          HttpStatus.UNAUTHORIZED,
+        );
+      }
+      if (
+        currentAuthorization.order.status !== 'pending_payment' ||
+        currentAuthorization.order.expiresAt <= new Date()
+      ) {
+        throw new DomainError(
+          API_ERROR_CODES.INVALID_STATE_TRANSITION,
+          '当前订单无法发起支付',
+          HttpStatus.CONFLICT,
+        );
+      }
       const [existing] = await tx
         .select()
         .from(payments)
@@ -1248,6 +1281,7 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
       orderId,
       'native',
       authorized.order,
+      authorized.accessTokenHash,
       row.keyVersion,
     );
     if (reusedCredential) {
@@ -1353,6 +1387,7 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
       orderId,
       'jsapi',
       authorized.order,
+      authorized.accessTokenHash,
       row.keyVersion,
     );
     if (reusedCredential) {
@@ -1464,6 +1499,7 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
       orderId,
       'h5',
       authorized.order,
+      authorized.accessTokenHash,
       row.keyVersion,
     );
     if (reusedCredential) {

--- a/apps/api/src/modules/customer.module.ts
+++ b/apps/api/src/modules/customer.module.ts
@@ -34,6 +34,7 @@ import {
   CustomerCreateInvoiceSchema,
   CustomerInvoiceCenterListQuerySchema,
   CustomerRegistrationListQuerySchema,
+  CustomerPurchasedOrderListQuerySchema,
   CustomerUpdateInvoiceSchema,
   DeleteAttendeeNeedsSchema,
   RequestCustomerOtpSchema,
@@ -199,8 +200,13 @@ class CustomerAccountController {
 
   @Get('orders')
   orders(@Req() request: CustomerRequest, @Query() query: Record<string, unknown>) {
-    const input = parse(CustomerRegistrationListQuerySchema, query, '订单分页参数校验失败');
-    return this.customerAccount.purchasedOrders(request.customerSession, input.cursor, input.limit);
+    const input = parse(CustomerPurchasedOrderListQuerySchema, query, '订单分页参数校验失败');
+    return this.customerAccount.purchasedOrders(
+      request.customerSession,
+      input.cursor,
+      input.limit,
+      input.orderId,
+    );
   }
 
   @Post('orders/:orderId/payment-access')

--- a/apps/web/app/composables/useCustomerSession.ts
+++ b/apps/web/app/composables/useCustomerSession.ts
@@ -156,12 +156,12 @@ export function useCustomerSession() {
     );
   }
 
-  function purchasedOrders(cursor?: string, limit = 20) {
+  function purchasedOrders(cursor?: string, limit = 20, orderId?: string) {
     return $fetch<CustomerPurchasedOrderList>('/customer/orders', {
       baseURL,
       credentials: 'include',
       headers: headers(),
-      query: { ...(cursor ? { cursor } : {}), limit },
+      query: { ...(cursor ? { cursor } : {}), limit, ...(orderId ? { orderId } : {}) },
     });
   }
 

--- a/apps/web/app/pages/[[eventSlug]].vue
+++ b/apps/web/app/pages/[[eventSlug]].vue
@@ -42,7 +42,10 @@ import {
 import { buildPartnershipOrganizationGroups } from '~/utils/partnership-organizations';
 import { useCustomerSession } from '~/composables/useCustomerSession';
 import { readOrderAccessToken } from '~/composables/useOrderAccessToken';
-import { resolveHomeRegistrationCta } from '~/utils/purchase-journey';
+import {
+  resolveHomeRegistrationCta,
+  resolveSelfRegistrationState,
+} from '~/utils/purchase-journey';
 import {
   createPublicViewRecorder,
   formatTrackingStartDate,
@@ -211,7 +214,10 @@ const blockCopy = (nodeKey: string, key: string, fallback: string) => {
   return typeof defaultValue === 'string' ? defaultValue : fallback;
 };
 const attendeeNeedsSubmissionAction = computed(() => {
-  const registrationId = purchaseContext.value?.myAttendance?.registrationId;
+  const registrationId =
+    resolveSelfRegistrationState(purchaseContext.value) === 'active'
+      ? purchaseContext.value?.myAttendance?.registrationId
+      : undefined;
   if (registrationId) {
     return {
       href: publicEventScopedPath(

--- a/apps/web/app/pages/account/index.vue
+++ b/apps/web/app/pages/account/index.vue
@@ -9,7 +9,12 @@ import type {
 } from '@conference/contracts';
 import { watch } from 'vue';
 import { useCustomerSession } from '~/composables/useCustomerSession';
-import { createRegistrationIntent } from '~/utils/purchase-journey';
+import {
+  canRestartSelfOrder,
+  canResumePendingOrder,
+  createRegistrationIntent,
+  shouldRefreshPurchasedOrder,
+} from '~/utils/purchase-journey';
 import { resolveAttendeeNeedsAccountState } from '~/utils/attendee-needs';
 
 const customer = useCustomerSession();
@@ -18,6 +23,7 @@ const router = useRouter();
 const registrations = ref<CustomerRegistrationSummary[]>([]);
 const purchasedOrders = ref<CustomerPurchasedOrder[]>([]);
 const purchaseContexts = ref<Record<number, EventPurchaseContext>>({});
+const purchaseContextErrors = ref<Record<number, boolean>>({});
 const attendeeNeedsProfiles = ref<Record<string, AttendeeNeedsProfile>>({});
 const attendeeNeedsProfileErrors = ref<Record<string, boolean>>({});
 const attendeeNeedsProfilePending = ref<Record<string, boolean>>({});
@@ -38,6 +44,7 @@ const nextOrdersCursor = ref<string | null>(null);
 const editingOrderId = ref('');
 const attendeeSaving = ref(false);
 const resumingOrderId = ref('');
+const refreshingPurchaseContexts = ref(false);
 const attendeeEdit = reactive({ name: '', mobile: '' });
 const errorMessage = ref('');
 const successMessage = ref('');
@@ -194,11 +201,111 @@ async function resumeOrder(order: CustomerPurchasedOrder) {
       api.resolvePaymentCheckoutUrl(order.id, order.eventSlug, access.orderAccessToken),
     );
   } catch (error) {
+    await refreshOrderPurchaseState(order);
     const value = error as { data?: { message?: string } };
     errorMessage.value = value.data?.message ?? '支付入口恢复失败，请稍后重试。';
   } finally {
     resumingOrderId.value = '';
   }
+}
+
+function mergePurchasedOrder(order: CustomerPurchasedOrder | undefined) {
+  if (!order) return;
+  purchasedOrders.value = purchasedOrders.value.map((item) =>
+    item.id === order.id ? order : item,
+  );
+}
+
+async function refreshOrderPurchaseState(order: CustomerPurchasedOrder) {
+  refreshingPurchaseContexts.value = true;
+  try {
+    const [orderResult, contextResult] = await Promise.all([
+      customer.purchasedOrders(undefined, 1, order.id).catch(() => null),
+      customer.purchaseContext(order.eventId).catch(() => null),
+    ]);
+    mergePurchasedOrder(orderResult?.items[0]);
+    purchaseContextErrors.value = {
+      ...purchaseContextErrors.value,
+      [order.eventId]: !contextResult,
+    };
+    if (contextResult) {
+      purchaseContexts.value = {
+        ...purchaseContexts.value,
+        [contextResult.eventId]: contextResult,
+      };
+    }
+  } finally {
+    refreshingPurchaseContexts.value = false;
+  }
+}
+
+async function refreshPurchaseContexts(eventIds: number[]) {
+  if (!eventIds.length || refreshingPurchaseContexts.value) return;
+  refreshingPurchaseContexts.value = true;
+  try {
+    const loadedContexts = await Promise.all(
+      eventIds.map(async (eventId) => {
+        try {
+          return { eventId, context: await customer.purchaseContext(eventId) };
+        } catch {
+          return { eventId, context: null };
+        }
+      }),
+    );
+    purchaseContextErrors.value = {
+      ...purchaseContextErrors.value,
+      ...Object.fromEntries(loadedContexts.map(({ eventId, context }) => [eventId, !context])),
+    };
+    purchaseContexts.value = {
+      ...purchaseContexts.value,
+      ...Object.fromEntries(
+        loadedContexts
+          .map(({ context }) => context)
+          .filter((context): context is EventPurchaseContext => Boolean(context))
+          .map((context) => [context.eventId, context]),
+      ),
+    };
+  } finally {
+    refreshingPurchaseContexts.value = false;
+  }
+}
+
+async function retryPurchaseContext(order: CustomerPurchasedOrder) {
+  errorMessage.value = '';
+  await refreshOrderPurchaseState(order);
+  if (purchaseContextErrors.value[order.eventId]) {
+    errorMessage.value = '报名状态刷新失败，请稍后重试。';
+  }
+}
+
+async function refreshMutablePurchasedOrders() {
+  const targets = purchasedOrders.value.filter((order) =>
+    shouldRefreshPurchasedOrder(order, purchaseContexts.value[order.eventId]),
+  );
+  const results = await Promise.all(
+    targets.map((order) =>
+      customer
+        .purchasedOrders(undefined, 1, order.id)
+        .then((result) => result.items[0])
+        .catch(() => undefined),
+    ),
+  );
+  const refreshedById = new Map(
+    results.filter((order): order is CustomerPurchasedOrder => Boolean(order)).map((order) => [
+      order.id,
+      order,
+    ]),
+  );
+  if (refreshedById.size) {
+    purchasedOrders.value = purchasedOrders.value.map(
+      (order) => refreshedById.get(order.id) ?? order,
+    );
+  }
+}
+
+async function refreshVisiblePurchaseState() {
+  await refreshPurchaseContexts([...new Set(purchasedOrders.value.map((item) => item.eventId))]);
+  await refreshMutablePurchasedOrders();
 }
 
 function additionalPurchase(order: CustomerPurchasedOrder) {
@@ -208,6 +315,17 @@ function additionalPurchase(order: CustomerPurchasedOrder) {
       event: order.eventSlug,
       intent: createRegistrationIntent(),
       purchaseFor: 'other',
+    },
+  });
+}
+
+function restartClosedSelfOrder(order: CustomerPurchasedOrder) {
+  return router.push({
+    path: '/register',
+    query: {
+      event: order.eventSlug,
+      intent: createRegistrationIntent(),
+      purchaseFor: 'self',
     },
   });
 }
@@ -300,24 +418,7 @@ async function loadPurchasedOrders(append = false) {
   );
   purchasedOrders.value = append ? [...purchasedOrders.value, ...result.items] : result.items;
   nextOrdersCursor.value = result.nextCursor;
-  const missingEventIds = [
-    ...new Set(
-      result.items
-        .map((item) => item.eventId)
-        .filter((eventId) => !purchaseContexts.value[eventId]),
-    ),
-  ];
-  const loadedContexts = await Promise.all(
-    missingEventIds.map((eventId) => customer.purchaseContext(eventId).catch(() => null)),
-  );
-  purchaseContexts.value = {
-    ...purchaseContexts.value,
-    ...Object.fromEntries(
-      loadedContexts
-        .filter((context): context is EventPurchaseContext => Boolean(context))
-        .map((context) => [context.eventId, context]),
-    ),
-  };
+  await refreshPurchaseContexts([...new Set(result.items.map((item) => item.eventId))]);
 }
 
 async function loadInvoiceSummary() {
@@ -374,6 +475,7 @@ async function logout() {
   registrations.value = [];
   purchasedOrders.value = [];
   purchaseContexts.value = {};
+  purchaseContextErrors.value = {};
   invoiceHighlights.value = [];
   invoiceCounts.value = {
     all: 0,
@@ -387,7 +489,16 @@ async function logout() {
   nextOrdersCursor.value = null;
 }
 
-onMounted(initialize);
+let purchaseContextRefreshTimer: ReturnType<typeof setInterval> | undefined;
+onMounted(() => {
+  void initialize();
+  purchaseContextRefreshTimer = setInterval(() => {
+    if (customer.session.value) void refreshVisiblePurchaseState();
+  }, 30_000);
+});
+onBeforeUnmount(() => {
+  if (purchaseContextRefreshTimer) clearInterval(purchaseContextRefreshTimer);
+});
 watch(
   () => customer.session.value?.customer.id,
   (id, previous) => {
@@ -735,7 +846,15 @@ useHead({ title: '个人中心' });
                     </div>
                     <div>
                       <dt>认领状态</dt>
-                      <dd>{{ orderItem.attendeeClaimed ? '参会人已认领' : '等待参会人认领' }}</dd>
+                      <dd>
+                        {{
+                          orderItem.status === 'closed' && orderItem.attendeeClaimed
+                            ? '账号已绑定'
+                            : orderItem.attendeeClaimed
+                              ? '参会人已认领'
+                              : '等待参会人认领'
+                        }}
+                      </dd>
                     </div>
                     <div>
                       <dt>支付状态</dt>
@@ -784,7 +903,7 @@ useHead({ title: '个人中心' });
 
                   <div v-else class="registration-row__actions">
                     <button
-                      v-if="['pending_payment', 'processing'].includes(orderItem.status)"
+                      v-if="canResumePendingOrder(orderItem, purchaseContexts[orderItem.eventId])"
                       class="registration-primary-action"
                       type="button"
                       :disabled="resumingOrderId === orderItem.id"
@@ -792,6 +911,38 @@ useHead({ title: '个人中心' });
                     >
                       {{ resumingOrderId === orderItem.id ? '正在恢复支付…' : '继续支付' }}
                       <span aria-hidden="true">→</span>
+                    </button>
+                    <button
+                      v-if="canRestartSelfOrder(orderItem, purchaseContexts[orderItem.eventId])"
+                      class="registration-primary-action"
+                      type="button"
+                      @click="restartClosedSelfOrder(orderItem)"
+                    >
+                      重新报名
+                      <span aria-hidden="true">→</span>
+                    </button>
+                    <button
+                      v-if="
+                        (orderItem.status === 'pending_payment' &&
+                          !canResumePendingOrder(
+                            orderItem,
+                            purchaseContexts[orderItem.eventId],
+                          ) &&
+                          !canRestartSelfOrder(
+                            orderItem,
+                            purchaseContexts[orderItem.eventId],
+                          )) ||
+                          (orderItem.status === 'closed' &&
+                            (!purchaseContexts[orderItem.eventId] ||
+                              purchaseContextErrors[orderItem.eventId] ||
+                              purchaseContexts[orderItem.eventId]?.resumePaymentOrderId ===
+                              orderItem.id))
+                      "
+                      type="button"
+                      :disabled="refreshingPurchaseContexts"
+                      @click="retryPurchaseContext(orderItem)"
+                    >
+                      {{ refreshingPurchaseContexts ? '正在刷新…' : '刷新报名状态' }}
                     </button>
                     <NuxtLink
                       v-if="

--- a/apps/web/app/pages/register.vue
+++ b/apps/web/app/pages/register.vue
@@ -19,6 +19,7 @@ import {
   createRegistrationIntent,
   resolveCheckoutSuccessDestination,
   resolveRegistrationIntent,
+  resolveSelfRegistrationState,
 } from '~/utils/purchase-journey';
 import {
   pruneRegistrationDrafts,
@@ -125,6 +126,7 @@ const accountRequired = computed(
 );
 const verifiedMobile = computed(() => customer.session.value?.customer.maskedMobile ?? '');
 const canPurchaseAdditional = computed(() => purchaseContext.value?.canPurchaseAdditional === true);
+const selfRegistrationState = computed(() => resolveSelfRegistrationState(purchaseContext.value));
 const pendingOrderHref = computed(() => {
   const orderId = purchaseContext.value?.resumePaymentOrderId;
   if (!orderId || !event.value) return '';
@@ -716,7 +718,19 @@ async function submit() {
             purchaseContextReady &&
               customer.session.value &&
               purchaseFor === 'self' &&
-              purchaseContext?.myAttendance
+              selfRegistrationState === 'closed'
+          "
+          class="registration-state-line"
+          role="status"
+        >
+          <span>上一笔订单已关闭或超时，名额已释放。请按当前票种和报名规则重新提交。</span>
+        </div>
+        <div
+          v-else-if="
+            purchaseContextReady &&
+              customer.session.value &&
+              purchaseFor === 'self' &&
+              selfRegistrationState === 'active'
           "
           class="registration-state-line"
           role="status"

--- a/apps/web/app/utils/purchase-journey.test.ts
+++ b/apps/web/app/utils/purchase-journey.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import type { EventPurchaseContext } from '@conference/contracts';
+import type { CustomerPurchasedOrder, EventPurchaseContext } from '@conference/contracts';
 import {
+  canRestartSelfOrder,
+  canResumePendingOrder,
   createRegistrationIntent,
   customerRegistrationTicketHref,
   parseAttendeeClaimFragment,
   registrationIdempotencyKey,
   resolveRegistrationIntent,
+  resolveSelfRegistrationState,
+  shouldRefreshPurchasedOrder,
   resolveHomeRegistrationCta,
   resolveCheckoutSuccessDestination,
 } from './purchase-journey';
@@ -18,6 +22,7 @@ const context: EventPurchaseContext = {
   remainingSeatCount: 4,
   canPurchaseAdditional: true,
   myAttendance: null,
+  selfRegistrationState: 'none',
   myPurchases: { paidCount: 1, pendingCount: 0, activeSeatCount: 1 },
   resumePaymentOrderId: null,
   recommendedActions: ['buy_more', 'register_self'],
@@ -58,7 +63,7 @@ describe('purchase journey helpers', () => {
     });
   });
 
-  it('points paid purchasers to the purchases section', () => {
+  it('prioritizes self-registration for purchasers who only bought for others', () => {
     expect(
       resolveHomeRegistrationCta({
         eventSlug: 'geo-2026',
@@ -66,6 +71,29 @@ describe('purchase journey helpers', () => {
         priceLabel: '¥399',
         state: 'ready',
         context,
+      }),
+    ).toEqual({
+      kind: 'register',
+      label: '立即报名 ¥399',
+      href: '/register?event=geo-2026&ticket=ticket-1',
+    });
+  });
+
+  it('points paid purchasers at their orders when self-registration is unavailable', () => {
+    expect(
+      resolveHomeRegistrationCta({
+        eventSlug: 'geo-2026',
+        ticketId: 'ticket-1',
+        priceLabel: '¥399',
+        state: 'ready',
+        context: {
+          ...context,
+          activeSeatCount: 5,
+          remainingSeatCount: 0,
+          canPurchaseAdditional: false,
+          myPurchases: { paidCount: 1, pendingCount: 0, activeSeatCount: 5 },
+          recommendedActions: [],
+        },
       }),
     ).toEqual({
       kind: 'purchases',
@@ -89,6 +117,7 @@ describe('purchase journey helpers', () => {
             ticketCode: 'TOK-TICKET-1',
             ticketStatus: 'valid',
           },
+          selfRegistrationState: 'active',
           myPurchases: { paidCount: 0, pendingCount: 0, activeSeatCount: 0 },
           recommendedActions: ['view_ticket'],
         },
@@ -113,6 +142,7 @@ describe('purchase journey helpers', () => {
             ticketCode: null,
             ticketStatus: null,
           },
+          selfRegistrationState: 'active',
           myPurchases: { paidCount: 0, pendingCount: 0, activeSeatCount: 0 },
           recommendedActions: [],
         },
@@ -121,6 +151,186 @@ describe('purchase journey helpers', () => {
       kind: 'attendance',
       label: '查看参会名额',
       href: '/account?event=geo-2026#events',
+    });
+  });
+
+  it('allows a customer with a cancelled attendance record to register again', () => {
+    expect(
+      resolveHomeRegistrationCta({
+        eventSlug: 'geo-2026',
+        ticketId: 'ticket-1',
+        priceLabel: '¥399',
+        state: 'ready',
+        context: {
+          ...context,
+          myAttendance: {
+            registrationId: '503d251a-7a43-43e8-99c3-708d2a0f4f0d',
+            registrationStatus: 'cancelled',
+            ticketCode: null,
+            ticketStatus: null,
+          },
+          selfRegistrationState: 'closed',
+          myPurchases: { paidCount: 0, pendingCount: 0, activeSeatCount: 0 },
+          resumePaymentOrderId: null,
+          recommendedActions: ['register_self'],
+        },
+      }),
+    ).toEqual({
+      kind: 'register',
+      label: '立即报名 ¥399',
+      href: '/register?event=geo-2026&ticket=ticket-1',
+    });
+  });
+
+  it('distinguishes a recoverable closed registration from an active attendance', () => {
+    const cancelledContext: EventPurchaseContext = {
+      ...context,
+      additionalPurchaseEnabled: false,
+      canPurchaseAdditional: false,
+      activeSeatCount: 0,
+      remainingSeatCount: 5,
+      myAttendance: {
+        registrationId: '503d251a-7a43-43e8-99c3-708d2a0f4f0d',
+        registrationStatus: 'cancelled',
+        ticketCode: null,
+        ticketStatus: null,
+      },
+      selfRegistrationState: 'closed',
+      myPurchases: { paidCount: 0, pendingCount: 0, activeSeatCount: 0 },
+      recommendedActions: ['register_self'],
+    };
+    expect(resolveSelfRegistrationState(cancelledContext)).toBe('closed');
+    expect(
+      resolveSelfRegistrationState({
+        ...cancelledContext,
+        recommendedActions: [],
+      }),
+    ).toBe('closed');
+    expect(
+      resolveHomeRegistrationCta({
+        eventSlug: 'geo-2026',
+        ticketId: 'ticket-1',
+        priceLabel: '¥399',
+        state: 'ready',
+        context: { ...cancelledContext, recommendedActions: [] },
+      }),
+    ).toEqual({
+      kind: 'purchases',
+      label: '查看已关闭订单',
+      href: '/account?event=geo-2026#purchases',
+    });
+    expect(
+      resolveSelfRegistrationState({
+        ...cancelledContext,
+        myAttendance: {
+          ...cancelledContext.myAttendance!,
+          registrationStatus: 'pending_payment',
+        },
+        recommendedActions: [],
+        selfRegistrationState: 'closed',
+      } as EventPurchaseContext & { selfRegistrationState: 'closed' }),
+    ).toBe('closed');
+    expect(
+      resolveSelfRegistrationState({
+        ...cancelledContext,
+        myAttendance: { ...cancelledContext.myAttendance!, registrationStatus: 'confirmed' },
+        selfRegistrationState: 'active',
+        recommendedActions: [],
+      }),
+    ).toBe('active');
+
+    const closedSelfOrder = {
+      registrationId: cancelledContext.myAttendance!.registrationId,
+      status: 'closed',
+      isProxyPurchase: false,
+    } as Pick<CustomerPurchasedOrder, 'registrationId' | 'status' | 'isProxyPurchase'>;
+    expect(canRestartSelfOrder(closedSelfOrder, cancelledContext)).toBe(true);
+    expect(
+      canRestartSelfOrder({ ...closedSelfOrder, status: 'pending_payment' }, cancelledContext),
+    ).toBe(true);
+    expect(
+      canRestartSelfOrder({ ...closedSelfOrder, isProxyPurchase: true }, cancelledContext),
+    ).toBe(false);
+  });
+
+  it('only resumes a pending order while the server still marks it payable', () => {
+    const order = {
+      id: '6da64028-8d52-44ee-9262-9ca5922bc2d9',
+      status: 'pending_payment',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    } as Pick<CustomerPurchasedOrder, 'id' | 'status' | 'expiresAt'>;
+    const resumableContext: EventPurchaseContext = {
+      ...context,
+      myPurchases: { paidCount: 0, pendingCount: 1, activeSeatCount: 1 },
+      selfRegistrationState: 'active',
+      resumePaymentOrderId: order.id,
+      recommendedActions: ['resume_payment'],
+    };
+    expect(canResumePendingOrder(order, resumableContext)).toBe(true);
+    expect(canResumePendingOrder(order, { ...resumableContext, resumePaymentOrderId: null })).toBe(
+      false,
+    );
+    expect(canResumePendingOrder({ ...order, status: 'processing' }, resumableContext)).toBe(false);
+    expect(
+      canResumePendingOrder(
+        { ...order, expiresAt: new Date(Date.now() - 60_000).toISOString() },
+        resumableContext,
+      ),
+    ).toBe(false);
+  });
+
+  it('refreshes a locally closed order after the same registration becomes active elsewhere', () => {
+    const registrationId = '503d251a-7a43-43e8-99c3-708d2a0f4f0d';
+    const order = {
+      id: '6da64028-8d52-44ee-9262-9ca5922bc2d9',
+      registrationId,
+      status: 'closed',
+    } as Pick<CustomerPurchasedOrder, 'id' | 'registrationId' | 'status'>;
+    const activeContext: EventPurchaseContext = {
+      ...context,
+      myAttendance: {
+        registrationId,
+        registrationStatus: 'confirmed',
+        ticketCode: 'TOK-TICKET-1',
+        ticketStatus: 'valid',
+      },
+      selfRegistrationState: 'active',
+      recommendedActions: ['view_ticket'],
+    };
+
+    expect(shouldRefreshPurchasedOrder(order, activeContext)).toBe(true);
+    expect(
+      shouldRefreshPurchasedOrder(order, {
+        ...activeContext,
+        myAttendance: { ...activeContext.myAttendance!, registrationId: crypto.randomUUID() },
+      }),
+    ).toBe(false);
+  });
+
+  it('prioritizes the server self-registration action over paid proxy purchases', () => {
+    expect(
+      resolveHomeRegistrationCta({
+        eventSlug: 'geo-2026',
+        ticketId: 'ticket-1',
+        priceLabel: '¥399',
+        state: 'ready',
+        context: {
+          ...context,
+          myAttendance: {
+            registrationId: '503d251a-7a43-43e8-99c3-708d2a0f4f0d',
+            registrationStatus: 'cancelled',
+            ticketCode: null,
+            ticketStatus: null,
+          },
+          selfRegistrationState: 'closed',
+          myPurchases: { paidCount: 1, pendingCount: 0, activeSeatCount: 1 },
+          recommendedActions: ['buy_more', 'register_self'],
+        },
+      }),
+    ).toEqual({
+      kind: 'register',
+      label: '立即报名 ¥399',
+      href: '/register?event=geo-2026&ticket=ticket-1',
     });
   });
 

--- a/apps/web/app/utils/purchase-journey.ts
+++ b/apps/web/app/utils/purchase-journey.ts
@@ -1,10 +1,57 @@
-import { publicEventScopedPath, type EventPurchaseContext } from '@conference/contracts';
+import {
+  publicEventScopedPath,
+  type CustomerPurchasedOrder,
+  type EventPurchaseContext,
+} from '@conference/contracts';
 
 export type HomeRegistrationCta = {
   kind: 'loading' | 'register' | 'resume_payment' | 'purchases' | 'view_ticket' | 'attendance';
   label: string;
   href: string;
 };
+
+export function resolveSelfRegistrationState(
+  context: EventPurchaseContext | null | undefined,
+): 'none' | 'closed' | 'active' {
+  return context?.selfRegistrationState ?? 'none';
+}
+
+export function canRestartSelfOrder(
+  order: Pick<CustomerPurchasedOrder, 'registrationId' | 'status' | 'isProxyPurchase'>,
+  context: EventPurchaseContext | null | undefined,
+) {
+  return (
+    ['closed', 'pending_payment'].includes(order.status) &&
+    !order.isProxyPurchase &&
+    context?.myAttendance?.registrationId === order.registrationId &&
+    context?.recommendedActions.includes('register_self') === true
+  );
+}
+
+export function canResumePendingOrder(
+  order: Pick<CustomerPurchasedOrder, 'id' | 'status' | 'expiresAt'>,
+  context: EventPurchaseContext | null | undefined,
+) {
+  return (
+    order.status === 'pending_payment' &&
+    new Date(order.expiresAt).getTime() > Date.now() &&
+    context?.resumePaymentOrderId === order.id &&
+    context.recommendedActions.includes('resume_payment')
+  );
+}
+
+export function shouldRefreshPurchasedOrder(
+  order: Pick<CustomerPurchasedOrder, 'id' | 'registrationId' | 'status'>,
+  context: EventPurchaseContext | null | undefined,
+) {
+  return (
+    ['pending_payment', 'processing'].includes(order.status) ||
+    context?.resumePaymentOrderId === order.id ||
+    (order.status === 'closed' &&
+      context?.selfRegistrationState === 'active' &&
+      context.myAttendance?.registrationId === order.registrationId)
+  );
+}
 
 export function resolveHomeRegistrationCta(input: {
   eventSlug: string;
@@ -24,7 +71,8 @@ export function resolveHomeRegistrationCta(input: {
   }
   if (input.state !== 'ready' || !input.context) return register;
 
-  if (input.context.resumePaymentOrderId) {
+  const recommendedActions = new Set(input.context.recommendedActions);
+  if (input.context.resumePaymentOrderId && recommendedActions.has('resume_payment')) {
     return {
       kind: 'resume_payment',
       label: '继续支付',
@@ -35,24 +83,33 @@ export function resolveHomeRegistrationCta(input: {
         })}#purchases`,
     };
   }
-  if (input.context.myAttendance && input.context.myPurchases.paidCount === 0) {
+  if (recommendedActions.has('view_ticket') && input.context.myAttendance?.ticketCode) {
     const ticketCode = input.context.myAttendance.ticketCode;
-    return ticketCode
-      ? {
-          kind: 'view_ticket',
-          label: '查看电子票',
-          href: publicEventScopedPath(`/ticket/${encodeURIComponent(ticketCode)}`, input.eventSlug),
-        }
-      : {
-          kind: 'attendance',
-          label: '查看参会名额',
-          href: `${publicEventScopedPath('/account', input.eventSlug)}#events`,
-        };
+    return {
+      kind: 'view_ticket',
+      label: '查看电子票',
+      href: publicEventScopedPath(`/ticket/${encodeURIComponent(ticketCode)}`, input.eventSlug),
+    };
   }
+  if (recommendedActions.has('register_self')) return register;
   if (input.context.myPurchases.paidCount > 0) {
     return {
       kind: 'purchases',
       label: `已购 ${input.context.myPurchases.paidCount} 个名额 · 查看报名`,
+      href: `${publicEventScopedPath('/account', input.eventSlug)}#purchases`,
+    };
+  }
+  if (input.context.myAttendance && input.context.selfRegistrationState === 'active') {
+    return {
+      kind: 'attendance',
+      label: '查看参会名额',
+      href: `${publicEventScopedPath('/account', input.eventSlug)}#events`,
+    };
+  }
+  if (input.context.selfRegistrationState === 'closed') {
+    return {
+      kind: 'purchases',
+      label: '查看已关闭订单',
       href: `${publicEventScopedPath('/account', input.eventSlug)}#purchases`,
     };
   }

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -14,6 +14,7 @@ import {
 } from '@conference/contracts';
 import {
   ACTIVE_WECHAT_PAYMENT_STATUSES,
+  activeInventoryReservationAt,
   agentConnections,
   agentDeviceAuthorizations,
   agentOperations,
@@ -1490,7 +1491,7 @@ async function offerNextWaitlist(db: ConferenceDatabase, eventId: number, ticket
           eq(inventoryReservations.ticketTypeId, ticket.id),
           isNull(inventoryReservations.releasedAt),
           isNull(inventoryReservations.convertedAt),
-          gt(inventoryReservations.expiresAt, new Date()),
+          activeInventoryReservationAt(new Date()),
         ),
       );
     const [activeOffers] = await tx
@@ -3082,6 +3083,9 @@ async function releaseExpiredReservations(db: ConferenceDatabase) {
   let released = 0;
   for (const candidate of candidates) {
     const success = await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${`wechatpay:prepare:${candidate.order.id}`}, 0))`,
+      );
       const [activeWeChatPayment] = await tx
         .select({ id: payments.id })
         .from(payments)
@@ -4193,8 +4197,8 @@ async function start() {
     throw new Error('Worker consumers did not enter the running state');
   }
   await writeFile(workerReadyTempFile, `${JSON.stringify(resolveBuildInfo('worker', process.env))}\n`, {
-    encoding: 'utf8',
-    mode: 0o600,
+      encoding: 'utf8',
+      mode: 0o600,
   });
   await rename(workerReadyTempFile, workerReadyFile);
   console.info(

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2405,6 +2405,7 @@ export const EventPurchaseContextSchema = z.object({
       ticketStatus: z.enum(['valid', 'used', 'cancelled']).nullable(),
     })
     .nullable(),
+  selfRegistrationState: z.enum(['none', 'closed', 'active']),
   myPurchases: z.object({
     paidCount: z.number().int().nonnegative(),
     pendingCount: z.number().int().nonnegative(),
@@ -2521,6 +2522,7 @@ export const CustomerPurchasedOrderSchema = z.object({
   ticketStatus: z.enum(['valid', 'used', 'cancelled']).nullable(),
   invoiceId: z.string().nullable(),
   invoiceStatus: InvoiceRequestStatusSchema.nullable(),
+  expiresAt: z.string(),
   createdAt: z.string(),
 });
 
@@ -2913,6 +2915,10 @@ export const CustomerAdminExportQuerySchema = CustomerAdminListQuerySchema.pick(
 export const CustomerRegistrationListQuerySchema = z.object({
   cursor: z.string().trim().min(1).max(300).optional(),
   limit: z.coerce.number().int().min(1).max(50).default(20),
+});
+
+export const CustomerPurchasedOrderListQuerySchema = CustomerRegistrationListQuerySchema.extend({
+  orderId: z.string().uuid().optional(),
 });
 
 export const OrganizationMemberSchema = z.object({
@@ -4333,6 +4339,7 @@ export type UpdateCustomerAdmin = z.infer<typeof UpdateCustomerAdminSchema>;
 export type CustomerAdminListQuery = z.infer<typeof CustomerAdminListQuerySchema>;
 export type CustomerAdminExportQuery = z.infer<typeof CustomerAdminExportQuerySchema>;
 export type CustomerRegistrationListQuery = z.infer<typeof CustomerRegistrationListQuerySchema>;
+export type CustomerPurchasedOrderListQuery = z.infer<typeof CustomerPurchasedOrderListQuerySchema>;
 export type OrganizationMember = z.infer<typeof OrganizationMemberSchema>;
 export type AccountProfile = z.infer<typeof AccountProfileSchema>;
 export type UpdateAccountProfile = z.infer<typeof UpdateAccountProfileSchema>;

--- a/packages/contracts/src/multi-purchase.test.ts
+++ b/packages/contracts/src/multi-purchase.test.ts
@@ -81,6 +81,7 @@ describe('multi-purchase customer API contracts', () => {
           ticketCode: 'TICKET-SELF',
           ticketStatus: 'valid',
         },
+        selfRegistrationState: 'active',
         myPurchases: { paidCount: 1, pendingCount: 1, activeSeatCount: 2 },
         resumePaymentOrderId: '44444444-4444-4444-8444-444444444444',
         recommendedActions: ['view_ticket', 'resume_payment', 'buy_more'],
@@ -88,6 +89,7 @@ describe('multi-purchase customer API contracts', () => {
     ).toMatchObject({
       activeSeatCount: 2,
       remainingSeatCount: 3,
+      selfRegistrationState: 'active',
       myPurchases: { paidCount: 1, pendingCount: 1 },
       resumePaymentOrderId: '44444444-4444-4444-8444-444444444444',
     });
@@ -157,6 +159,7 @@ describe('multi-purchase customer API contracts', () => {
             ticketStatus: 'valid',
             invoiceId: null,
             invoiceStatus: null,
+            expiresAt: '2026-08-15T01:15:00.000Z',
             createdAt: '2026-08-15T01:00:00.000Z',
           },
         ],

--- a/packages/database/src/feishu-digest.ts
+++ b/packages/database/src/feishu-digest.ts
@@ -20,6 +20,7 @@ import {
   ticketTypes,
   waitlistEntries,
 } from './schema.js';
+import { activeInventoryReservationAt } from './inventory-reservation-policy.js';
 
 export class FeishuDigestEventNotFoundError extends Error {
   constructor() {
@@ -85,7 +86,7 @@ export async function loadFeishuDigestSnapshot(
         where ${inventoryReservations.ticketTypeId} = ${ticketTypes.id}
           and ${inventoryReservations.convertedAt} is null
           and ${inventoryReservations.releasedAt} is null
-          and ${inventoryReservations.expiresAt} > ${generatedAt}
+          and (${activeInventoryReservationAt(generatedAt)})
       ), 0)
       - coalesce((
         select count(*)

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -25,3 +25,4 @@ export function createDatabase(databaseUrl = process.env.DATABASE_URL) {
 export * from './schema.js';
 export * from './migration-status.js';
 export * from './feishu-digest.js';
+export * from './inventory-reservation-policy.js';

--- a/packages/database/src/inventory-reservation-policy.ts
+++ b/packages/database/src/inventory-reservation-policy.ts
@@ -1,0 +1,15 @@
+import { gt, inArray, or, sql } from 'drizzle-orm';
+import { ACTIVE_WECHAT_PAYMENT_STATUSES, inventoryReservations, payments } from './schema.js';
+
+export function activeInventoryReservationAt(evaluatedAt: Date) {
+  return or(
+    gt(inventoryReservations.expiresAt, evaluatedAt),
+    sql<boolean>`exists (
+      select 1
+      from ${payments}
+      where ${payments.orderId} = ${inventoryReservations.orderId}
+        and ${payments.provider} = 'wechatpay'
+        and ${inArray(payments.status, [...ACTIVE_WECHAT_PAYMENT_STATUSES])}
+    )`,
+  );
+}

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -10,6 +10,7 @@ import {
 } from '@conference/contracts';
 import { CANONICAL_HOMEPAGE_SNAPSHOT } from '@conference/contracts/canonical-homepage';
 import { createDatabase } from './index.js';
+import { activeInventoryReservationAt } from './inventory-reservation-policy.js';
 import { remapCanonicalReferences } from './canonical-homepage-remap.js';
 import {
   validateCanonicalHomepageSnapshot,
@@ -944,7 +945,7 @@ try {
                 eq(inventoryReservations.ticketTypeId, target.targetId),
                 isNull(inventoryReservations.convertedAt),
                 isNull(inventoryReservations.releasedAt),
-                gt(inventoryReservations.expiresAt, new Date()),
+                activeInventoryReservationAt(new Date()),
               ),
             );
           const [waitlistHeld] = await tx


### PR DESCRIPTION
## 修复内容

- 待支付订单在 15 分钟窗口内可重新签发访问凭证并继续支付
- 已关闭或已超时订单复用原订单与报名记录，重新占用一次库存并开启新支付窗口
- 统一报名、支付准备、超时闭单的并发锁顺序和活跃支付判定
- 首页、报名页和个人中心按服务端购买上下文展示续付、重新报名和电子票入口
- 个人中心定时精确刷新订单，覆盖跨标签页恢复与支付完成

## 验证

- pnpm check
- pnpm audit:security
- pnpm canonical:check
- PostgreSQL API 集成测试：29 项通过
- Web 支付旅程与全量测试：150 项通过
- 三轮独立安全、架构与级联状态复核通过

无需数据库迁移，规范大会快照无变更。