### PR TITLE
fix(payments): harden resumed payment state

### DIFF
--- a/apps/api/src/common/wechat-pay.service.test.ts
+++ b/apps/api/src/common/wechat-pay.service.test.ts
@@ -10,6 +10,7 @@ import { RedisService } from './redis.service.js';
 import {
   __wechatPayTestUtils,
   buildJsapiSignMessage,
+  isReusablePreparedPaymentCredential,
   resolveTrustedClientIp,
   WeChatPayService,
 } from './wechat-pay.service.js';
@@ -250,6 +251,14 @@ describe('WeChatPayService signed requests', () => {
     expect(value.length).toBeGreaterThanOrEqual(6);
     expect(value.length).toBeLessThanOrEqual(32);
     expect(value).toMatch(/^[A-Za-z0-9]+$/);
+  });
+
+  it('reuses prepared credentials while a payment query is still pending', () => {
+    expect(isReusablePreparedPaymentCredential('pending', true)).toBe(true);
+    expect(isReusablePreparedPaymentCredential('query_pending', true)).toBe(true);
+    expect(isReusablePreparedPaymentCredential('query_pending', false)).toBe(false);
+    expect(isReusablePreparedPaymentCredential('processing', true)).toBe(false);
+    expect(isReusablePreparedPaymentCredential('close_pending', true)).toBe(false);
   });
 
   it('appends redirect_url to H5 URLs only once', () => {

--- a/apps/api/src/common/wechat-pay.service.ts
+++ b/apps/api/src/common/wechat-pay.service.ts
@@ -127,6 +127,21 @@ type AuthorizedOrder = {
 
 type PaymentAttempt = typeof payments.$inferSelect;
 
+/**
+ * Determines whether an existing provider credential can reopen the same
+ * payment surface without creating the WeChat order again.
+ *
+ * @param status - Current local payment-attempt state
+ * @param hasCredential - Whether the channel credential is persisted
+ * @returns True when the existing credential is safe to return
+ */
+export function isReusablePreparedPaymentCredential(
+  status: PaymentAttempt['status'],
+  hasCredential: boolean,
+) {
+  return hasCredential && (status === 'pending' || status === 'query_pending');
+}
+
 type ParsedPaymentNotification = {
   inboxId: string;
   notificationId: string;
@@ -1111,7 +1126,7 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
           (channel === 'native' && typeof payload.codeUrl === 'string') ||
           (channel === 'jsapi' && typeof payload.prepayId === 'string') ||
           (channel === 'h5' && typeof payload.h5Url === 'string');
-        if (hasCredential && existing.status === 'pending') {
+        if (isReusablePreparedPaymentCredential(existing.status, hasCredential)) {
           return { attempt: existing, reusedCredential: true };
         }
         if (existing.status === 'preparing') {

--- a/apps/web/app/composables/useOrderPayment.test.ts
+++ b/apps/web/app/composables/useOrderPayment.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canInitiateOrderPayment,
+  initialOrderPaymentAction,
   interpretWeixinPayResult,
   isPaidSwitchResult,
   isTransientPaymentFailure,
@@ -57,6 +59,19 @@ describe('shouldPollOrderStatus', () => {
   });
 });
 
+describe('canInitiateOrderPayment', () => {
+  it('uses the server order state instead of the browser clock', () => {
+    const pending = {
+      ...order('pending_payment'),
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    };
+
+    expect(canInitiateOrderPayment(pending)).toBe(true);
+    expect(canInitiateOrderPayment(order('processing'))).toBe(false);
+    expect(canInitiateOrderPayment(order('paid'))).toBe(false);
+  });
+});
+
 describe('interpretWeixinPayResult', () => {
   it('treats ok as success', () => {
     expect(interpretWeixinPayResult({ err_msg: 'get_brand_wcpay_request:ok' })).toBeNull();
@@ -94,7 +109,16 @@ describe('shouldAutoPrepareWeChatPayment', () => {
   it('skips real WeChat prepare for an authorized local simulation order', () => {
     expect(shouldAutoPrepareWeChatPayment(order('pending_payment'), true)).toBe(false);
     expect(shouldAutoPrepareWeChatPayment(order('pending_payment'), false)).toBe(true);
+    expect(shouldAutoPrepareWeChatPayment(order('processing'), false)).toBe(false);
     expect(shouldAutoPrepareWeChatPayment(order('paid'), false)).toBe(false);
+  });
+});
+
+describe('initialOrderPaymentAction', () => {
+  it('polls a processing order without preparing the provider order again', () => {
+    expect(initialOrderPaymentAction(order('pending_payment'), false)).toBe('prepare');
+    expect(initialOrderPaymentAction(order('processing'), false)).toBe('poll');
+    expect(initialOrderPaymentAction(order('paid'), false)).toBe('idle');
   });
 });
 

--- a/apps/web/app/composables/useOrderPayment.ts
+++ b/apps/web/app/composables/useOrderPayment.ts
@@ -41,7 +41,6 @@ export type OrderPaymentPhase =
   | 'polling'
   | 'paid'
   | 'error'
-  | 'expired'
   | 'closed';
 
 export type WeixinPayInvokeResult = {
@@ -143,6 +142,18 @@ export function shouldPollOrderStatus(order: Order | undefined | null): boolean 
   return ['pending_payment', 'processing'].includes(order.status);
 }
 
+/**
+ * Determines whether the user may initiate or relaunch payment.
+ * The API remains authoritative for the payment deadline so browser clock skew
+ * cannot hide a valid payment action.
+ *
+ * @param order - Latest server order snapshot
+ * @returns True only while the server order state is awaiting payment
+ */
+export function canInitiateOrderPayment(order: Order | undefined | null): boolean {
+  return order?.status === 'pending_payment';
+}
+
 export function shouldAutoPrepareWeChatPayment(
   order: Order | undefined | null,
   localSimulationAllowed: boolean,
@@ -150,8 +161,17 @@ export function shouldAutoPrepareWeChatPayment(
   return Boolean(
     !localSimulationAllowed &&
       order?.paymentMethod === 'wechat' &&
-      shouldPollOrderStatus(order),
+      canInitiateOrderPayment(order),
   );
+}
+
+export function initialOrderPaymentAction(
+  order: Order | undefined | null,
+  localSimulationAllowed: boolean,
+): 'prepare' | 'poll' | 'idle' {
+  if (shouldAutoPrepareWeChatPayment(order, localSimulationAllowed)) return 'prepare';
+  if (order?.status === 'processing') return 'poll';
+  return 'idle';
 }
 
 /**
@@ -316,12 +336,7 @@ export function useOrderPayment(options: UseOrderPaymentOptions) {
   let started = false;
 
   const switchOptions = computed(() => manualSwitchChannels(signals.value, channel.value));
-  const canPay = computed(
-    () =>
-      Boolean(order.value) &&
-      shouldPollOrderStatus(order.value) &&
-      new Date(order.value!.expiresAt).getTime() > Date.now(),
-  );
+  const canPay = computed(() => canInitiateOrderPayment(order.value));
 
   /**
    * Applies a prepare API result to local channel payload state.
@@ -484,7 +499,7 @@ export function useOrderPayment(options: UseOrderPaymentOptions) {
    */
   async function preparePayment(optionsOverride: { userInitiated?: boolean } = {}) {
     if (!order.value || !accessToken.value) return;
-    if (!shouldPollOrderStatus(order.value)) return;
+    if (!canInitiateOrderPayment(order.value)) return;
     if (preparing.value || launching.value) return;
 
     clearPrepareBackoff();
@@ -561,13 +576,6 @@ export function useOrderPayment(options: UseOrderPaymentOptions) {
         stopPolling();
         burstUntilMs = 0;
         phase.value = 'closed';
-        return;
-      }
-
-      if (new Date(latest.expiresAt).getTime() <= Date.now()) {
-        stopPolling();
-        burstUntilMs = 0;
-        phase.value = 'expired';
         return;
       }
 
@@ -734,12 +742,11 @@ export function useOrderPayment(options: UseOrderPaymentOptions) {
         phase.value = 'closed';
         return;
       }
-      if (new Date(latest.expiresAt).getTime() <= Date.now()) {
-        phase.value = 'expired';
-        return;
-      }
-
-      if (shouldAutoPrepareWeChatPayment(latest, startOptions.localSimulationAllowed === true)) {
+      const initialAction = initialOrderPaymentAction(
+        latest,
+        startOptions.localSimulationAllowed === true,
+      );
+      if (initialAction === 'prepare') {
         // Reuse a server-provided native code URL when already present.
         if (channel.value === 'native' && latest.paymentUrl) {
           codeUrl.value = latest.paymentUrl;
@@ -748,6 +755,8 @@ export function useOrderPayment(options: UseOrderPaymentOptions) {
         } else {
           await preparePayment({ userInitiated: false });
         }
+      } else if (initialAction === 'poll') {
+        startPolling();
       }
     } catch (error) {
       phase.value = 'error';
@@ -782,7 +791,7 @@ export function useOrderPayment(options: UseOrderPaymentOptions) {
       return;
     }
     await refreshOrderStatus();
-    if (shouldPollOrderStatus(order.value)) {
+    if (canInitiateOrderPayment(order.value)) {
       await preparePayment({ userInitiated: true });
     }
   }

--- a/apps/web/app/pages/order/[id].vue
+++ b/apps/web/app/pages/order/[id].vue
@@ -147,7 +147,7 @@ const awaitingReview = computed(
     order.value?.status === 'pending_review' ||
     checkout.value?.registration.status === 'pending_review',
 );
-const canPay = computed(() => paymentCanPay.value && remainingSeconds.value > 0);
+const canPay = computed(() => paymentCanPay.value);
 const stateTitle = computed(() => {
   if (awaitingReview.value) return '报名已提交，等待大会审核';
   if (isProxyPurchase.value && order.value?.status === 'paid') return '代购订单已完成';
@@ -620,11 +620,11 @@ function switchChannelLabel(channel: string) {
               v-if="!localSimulationAllowed"
               class="flow-action is-full"
               type="button"
-              :disabled="paymentPreparing || !canPay"
+              :disabled="paymentPreparing"
               style="margin-top: 8px"
               @click="refreshOrderStatus({ sync: true })"
             >
-              我已完成支付
+              {{ order.status === 'processing' ? '刷新支付结果' : '我已完成支付' }}
             </button>
 
             <div

--- a/apps/web/app/utils/purchase-journey.test.ts
+++ b/apps/web/app/utils/purchase-journey.test.ts
@@ -271,12 +271,11 @@ describe('purchase journey helpers', () => {
       false,
     );
     expect(canResumePendingOrder({ ...order, status: 'processing' }, resumableContext)).toBe(false);
-    expect(
-      canResumePendingOrder(
-        { ...order, expiresAt: new Date(Date.now() - 60_000).toISOString() },
-        resumableContext,
-      ),
-    ).toBe(false);
+    const locallyExpiredOrder = {
+      ...order,
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    };
+    expect(canResumePendingOrder(locallyExpiredOrder, resumableContext)).toBe(true);
   });
 
   it('refreshes a locally closed order after the same registration becomes active elsewhere', () => {

--- a/apps/web/app/utils/purchase-journey.ts
+++ b/apps/web/app/utils/purchase-journey.ts
@@ -29,12 +29,11 @@ export function canRestartSelfOrder(
 }
 
 export function canResumePendingOrder(
-  order: Pick<CustomerPurchasedOrder, 'id' | 'status' | 'expiresAt'>,
+  order: Pick<CustomerPurchasedOrder, 'id' | 'status'>,
   context: EventPurchaseContext | null | undefined,
 ) {
   return (
     order.status === 'pending_payment' &&
-    new Date(order.expiresAt).getTime() > Date.now() &&
     context?.resumePaymentOrderId === order.id &&
     context.recommendedActions.includes('resume_payment')
   );


### PR DESCRIPTION
## Summary

- keep server order state authoritative for resume eligibility
- separate payable orders from poll-only payment-confirmation orders
- reuse persisted WeChat credentials while transaction queries remain pending
- keep processing orders polling without creating another provider order

## Regression coverage

- local browser clock skew cannot hide a server-approved resume action
- processing orders cannot initiate or auto-prepare another payment
- query-pending WeChat attempts reuse existing Native, H5, or JSAPI credentials
- processing orders start status polling on page load

## Verification

- `pnpm check`
- `pnpm audit:security`
- `pnpm canonical:check`
- focused web tests: 30 passed
- focused API tests: 10 passed