### PR TITLE
fix(deploy): normalize sanitized binding revision

### DIFF
--- a/tooling/lib/production-deploy.test.mjs
+++ b/tooling/lib/production-deploy.test.mjs
@@ -701,6 +701,31 @@ test('canonical snapshot comparator detects equality, drift, and invalid JSON', 
   }
 });
 
+test('public homepage verifier treats an omitted binding revision as sanitized metadata', () => {
+  const match = source.match(/verify_homepage_file\(\) \{[\s\S]*?<<'PY'\n([\s\S]*?)\nPY/);
+  assert.ok(match, 'public homepage verification Python program was not found');
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-homepage-verifier-'));
+  const actual = resolve(directory, 'actual.json');
+  const expected = resolve(directory, 'expected.json');
+  const publicEvent = {
+    slug: 'tokems26',
+    publicMetrics: null,
+    experience: { template: { id: 'template-current' } },
+    tickets: [],
+  };
+  try {
+    writeFileSync(actual, JSON.stringify(publicEvent));
+    writeFileSync(expected, JSON.stringify({ publicEvent }));
+    const result = spawnSync('python3', ['-', actual, expected, 'tokems26'], {
+      encoding: 'utf8',
+      input: match[1],
+    });
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test('production network calls are bounded and infrastructure reconciliation is isolated', () => {
   assert.doesNotMatch(source, /curl\s+-f/);
   assert.match(source, /readonly -a CURL_ARGS=/);

--- a/tooling/production-deploy.sh
+++ b/tooling/production-deploy.sh
@@ -2927,7 +2927,9 @@ if expected_experience.get("overrideRevisions") is None and actual_experience.ge
     actual_experience["overrideRevisions"] = None
 expected_template = expected_experience.get("template") or {}
 actual_template = actual_experience.get("template") or {}
-if expected_template.get("bindingRevision") is None:
+if "bindingRevision" not in expected_template:
+    actual_template.pop("bindingRevision", None)
+elif expected_template.get("bindingRevision") is None:
     actual_template["bindingRevision"] = None
 
 expected_tickets = {item.get("id"): item for item in expected.get("tickets", [])}


### PR DESCRIPTION
## 变更

- 修正规范首页验收器对已脱敏 `bindingRevision` 字段的归一化
- 目标和线上都省略该字段时保持结构一致
- 增加回归测试，防止规范同步成功后在最终验收阶段误报失败

## 验证

- 线上公开首页与规范公开快照完整匹配
- `pnpm canonical:check`
- `pnpm check`
- `bash -n tooling/production-deploy.sh`
- `node --test tooling/lib/production-deploy.test.mjs`
- `/check`：无阻断问题