### PR TITLE
feat(account): 优化个人中心移动端体验

### DIFF
--- a/apps/web/app/assets/css/main.css
+++ b/apps/web/app/assets/css/main.css
@@ -46,12 +46,18 @@
 
 .flow-brand {
   display: inline-flex;
+  min-height: 44px;
   align-items: center;
   gap: 10px;
   color: var(--conference-ink);
   font-weight: 760;
   letter-spacing: -0.01em;
   text-decoration: none;
+  transition: transform 110ms ease;
+}
+
+.flow-brand:active {
+  transform: scale(0.98);
 }
 
 .flow-brand__mark {
@@ -112,10 +118,76 @@
 }
 
 .flow-stepper {
+  margin: 38px 0 32px;
+}
+
+.flow-stepper__steps {
   display: flex;
   gap: 0;
-  margin: 38px 0 32px;
   overflow-x: auto;
+}
+
+.flow-stepper__mobile {
+  display: none;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: baseline;
+  gap: 6px 14px;
+  padding: 15px 16px;
+  border: 1px solid var(--conference-line);
+  border-radius: 9px;
+  background: #fff;
+}
+
+.flow-stepper__mobile span {
+  color: var(--conference-primary);
+  font-family: var(--conference-font-mono);
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.07em;
+}
+
+.flow-stepper__mobile strong {
+  min-width: 0;
+  color: var(--conference-ink);
+  font-size: 13px;
+  font-weight: 760;
+  text-align: right;
+}
+
+.flow-stepper__mobile i {
+  position: relative;
+  height: 3px;
+  grid-column: 1 / -1;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--conference-line);
+}
+
+.flow-stepper__mobile i::after {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--flow-progress);
+  border-radius: inherit;
+  background: var(--conference-primary);
+  content: '';
+}
+
+.flow-stepper.is-compact .flow-stepper__mobile,
+.flow-stepper.is-minimal .flow-stepper__mobile {
+  display: grid;
+}
+
+.flow-stepper.is-compact .flow-stepper__steps,
+.flow-stepper.is-minimal .flow-stepper__steps {
+  display: none;
+}
+
+.flow-stepper.is-minimal .flow-stepper__mobile strong {
+  display: none;
+}
+
+.flow-stepper.is-minimal .flow-stepper__mobile span {
+  grid-column: 1 / -1;
 }
 
 .flow-step {
@@ -349,12 +421,17 @@
   cursor: pointer;
   transition:
     background 160ms ease,
-    border-color 160ms ease;
+    border-color 160ms ease,
+    transform 110ms ease;
 }
 
 .flow-action:hover {
   border-color: var(--conference-primary-dark);
   background: var(--conference-primary-dark);
+}
+
+.flow-action:active:not(:disabled) {
+  transform: scale(0.98);
 }
 
 .flow-action:disabled {
@@ -966,6 +1043,11 @@
   font-weight: 750;
 }
 
+.ticket-status[data-status='cancelled'] {
+  background: #fff1f2;
+  color: #be123c;
+}
+
 .ticket-paper h1 {
   max-width: 420px;
   margin: 22px 0 34px;
@@ -997,6 +1079,7 @@
   color: var(--conference-ink-muted);
   font-family: var(--conference-font-mono);
   font-size: 11px;
+  overflow-wrap: anywhere;
 }
 
 .ticket-qr {
@@ -1127,20 +1210,15 @@
   }
 
   .flow-shell {
-    padding-block: 38px 56px;
+    padding-block: 30px calc(56px + env(safe-area-inset-bottom));
   }
 
-  .flow-step {
-    min-width: auto;
-  }
-
-  .flow-step:not(:last-child)::after {
-    width: 24px;
-    margin-inline: 10px;
-  }
-
-  .flow-step span:last-child {
+  .flow-stepper__steps {
     display: none;
+  }
+
+  .flow-stepper__mobile {
+    display: grid;
   }
 
   .flow-card__head,
@@ -1166,6 +1244,59 @@
 
   .ticket-actions {
     flex-direction: column;
+  }
+
+  .ticket-actions .flow-action {
+    width: 100%;
+  }
+
+  .state-icon {
+    width: 52px;
+    height: 52px;
+    margin-bottom: 16px;
+    font-size: 21px;
+  }
+
+  .state-panel h1 {
+    font-size: 30px;
+  }
+
+  .state-panel > p {
+    margin-bottom: 22px;
+    font-size: 14px;
+  }
+
+  .ticket-paper {
+    border-top: 4px solid var(--conference-primary);
+    border-radius: 10px;
+  }
+
+  .ticket-paper__aside {
+    min-height: 248px;
+    grid-row: 1;
+    padding: 24px;
+    border-top: 0;
+    border-bottom: 1px dashed #d4d4d8;
+  }
+
+  .ticket-paper__aside::before,
+  .ticket-paper__aside::after {
+    display: none;
+  }
+
+  .ticket-paper__main {
+    grid-row: 2;
+    border-left: 0;
+  }
+
+  .ticket-paper h1 {
+    margin: 18px 0 26px;
+    font-size: 28px;
+  }
+
+  .ticket-qr {
+    width: 184px;
+    height: 184px;
   }
 
   .invoice-form-actions {

--- a/apps/web/app/components/AttendeeNeedsSuccessDialog.vue
+++ b/apps/web/app/components/AttendeeNeedsSuccessDialog.vue
@@ -372,17 +372,25 @@ onBeforeUnmount(() => {
 
 @media (max-width: 520px) {
   .needs-success-dialog {
-    padding: 16px;
+    align-items: end;
+    padding: 0;
   }
 
   .needs-success-dialog__panel {
-    max-height: calc(100dvh - 32px);
-    padding: 28px 20px 22px;
+    width: 100%;
+    max-height: 85dvh;
+    padding: 28px 20px calc(22px + env(safe-area-inset-bottom));
+    border-radius: 16px 16px 0 0;
   }
 
   .needs-success-dialog h2 {
     max-width: 280px;
     font-size: 24px;
+  }
+
+  .needs-success-dialog__close {
+    width: 44px;
+    height: 44px;
   }
 
   .needs-success-dialog__summary {

--- a/apps/web/app/components/AttendeeShowcaseValidationDialog.vue
+++ b/apps/web/app/components/AttendeeShowcaseValidationDialog.vue
@@ -322,15 +322,22 @@ onBeforeUnmount(() => {
 }
 @media (max-width: 520px) {
   .validation-dialog {
-    padding: 16px;
+    align-items: end;
+    padding: 0;
   }
   .validation-dialog__panel {
-    max-height: calc(100dvh - 32px);
-    padding: 26px 20px 22px;
+    width: 100%;
+    max-height: 85dvh;
+    padding: 26px 20px calc(22px + env(safe-area-inset-bottom));
+    border-radius: 16px 16px 0 0;
   }
   .validation-dialog h2 {
     max-width: 280px;
     font-size: 22px;
+  }
+  .validation-dialog__close {
+    width: 44px;
+    height: 44px;
   }
   .validation-dialog__issues button {
     grid-template-columns: 28px minmax(0, 1fr);

--- a/apps/web/app/components/CustomerAccountAction.vue
+++ b/apps/web/app/components/CustomerAccountAction.vue
@@ -50,7 +50,7 @@ const customer = useCustomerSession();
 <style scoped>
 .customer-account-action {
   display: inline-flex;
-  min-height: 40px;
+  min-height: 44px;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
@@ -91,6 +91,13 @@ const customer = useCustomerSession();
     border-color: var(--conference-primary, #2563eb);
     background: var(--conference-primary-soft, #eff6ff);
     color: var(--conference-primary, #2563eb);
+  }
+}
+@media (max-width: 640px) {
+  .customer-account-action {
+    min-height: 44px;
+    padding-inline: 11px;
+    font-size: 12.5px;
   }
 }
 </style>

--- a/apps/web/app/components/CustomerAuthDialog.vue
+++ b/apps/web/app/components/CustomerAuthDialog.vue
@@ -544,12 +544,21 @@ onBeforeUnmount(() => {
     padding: 0;
   }
   .auth-dialog__panel {
+    width: 100%;
+    min-height: 100dvh;
     max-height: 100dvh;
-    padding: 28px 22px calc(24px + env(safe-area-inset-bottom));
-    border-radius: 16px 16px 0 0;
+    padding: calc(28px + env(safe-area-inset-top)) 22px calc(24px + env(safe-area-inset-bottom));
+    border-radius: 0;
   }
   .auth-code-actions {
     grid-template-columns: 1fr;
+  }
+  .auth-dialog__close {
+    width: 44px;
+    height: 44px;
+  }
+  .auth-mobile-input input {
+    font-size: 16px;
   }
 }
 @media (max-height: 520px) {
@@ -558,6 +567,7 @@ onBeforeUnmount(() => {
     padding: 12px;
   }
   .auth-dialog__panel {
+    min-height: 0;
     max-height: calc(100dvh - 24px);
     padding: 24px 22px;
     border-radius: 12px;

--- a/apps/web/app/components/FlowHeader.vue
+++ b/apps/web/app/components/FlowHeader.vue
@@ -22,14 +22,10 @@ const homeHref = computed(() => {
 <template>
   <header class="flow-header">
     <div class="flow-header__inner">
-      <a v-if="paymentSurface" class="flow-brand" :href="homeHref">
+      <a class="flow-brand" :href="homeHref">
         <span class="flow-brand__mark">G</span>
         <span>{{ siteConfiguration?.website.siteName ?? '大会报名中心' }}</span>
       </a>
-      <NuxtLink v-else class="flow-brand" :to="homeHref">
-        <span class="flow-brand__mark">G</span>
-        <span>{{ siteConfiguration?.website.siteName ?? '大会报名中心' }}</span>
-      </NuxtLink>
       <div class="flow-header__actions">
         <span class="flow-header__meta">
           {{ paymentSurface ? '安全支付通道 · 信息加密传输' : '安全报名通道 · 信息加密传输' }}
@@ -47,11 +43,30 @@ const homeHref = computed(() => {
   gap: 16px;
 }
 @media (max-width: 640px) {
+  .flow-header {
+    height: calc(64px + env(safe-area-inset-top));
+    box-sizing: border-box;
+    padding-top: env(safe-area-inset-top);
+  }
   .flow-header__meta {
     display: none;
   }
   .flow-header__inner {
     width: min(100% - 28px, 1160px);
+    gap: 12px;
+  }
+  .flow-brand {
+    min-width: 0;
+    min-height: 44px;
+    font-size: 14px;
+  }
+  .flow-brand > span:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .flow-header__actions {
+    flex: 0 0 auto;
   }
 }
 </style>

--- a/apps/web/app/components/FlowStepper.vue
+++ b/apps/web/app/components/FlowStepper.vue
@@ -15,26 +15,52 @@ const props = withDefaults(
 
 const resolvedSteps = computed(
   () =>
-    props.steps ?? [
+    (props.steps?.length ? props.steps : undefined) ?? [
       '填写报名信息',
       props.paymentRequired ? '确认订单并支付' : '确认报名',
       '获取电子票',
     ],
 );
+const resolvedStepCount = computed(() => Math.max(resolvedSteps.value.length, 1));
+const resolvedActive = computed(() => Math.min(Math.max(props.active, 1), resolvedStepCount.value));
+const currentStepTitle = computed(
+  () => resolvedSteps.value[resolvedActive.value - 1] ?? '当前步骤',
+);
+const progress = computed(() => Math.round((resolvedActive.value / resolvedStepCount.value) * 100));
 </script>
 
 <template>
-  <div class="flow-stepper" :class="[`is-${variant}`]" aria-label="报名进度">
+  <div
+    class="flow-stepper"
+    :class="[`is-${variant}`]"
+    role="group"
+    :aria-label="`报名进度：第 ${resolvedActive} 步，共 ${resolvedStepCount} 步，${currentStepTitle}`"
+  >
     <div
-      v-for="(step, index) in resolvedSteps"
-      :key="step"
-      class="flow-step"
-      :class="{ 'is-active': active === index + 1, 'is-done': active > index + 1 }"
+      class="flow-stepper__mobile"
+      :style="{ '--flow-progress': `${progress}%` }"
+      aria-hidden="true"
     >
-      <span class="flow-step__number">{{
-        active > index + 1 ? '✓' : String(index + 1).padStart(2, '0')
-      }}</span>
-      <span>{{ step }}</span>
+      <span>第 {{ resolvedActive }} / {{ resolvedStepCount }} 步</span>
+      <strong>{{ currentStepTitle }}</strong>
+      <i></i>
+    </div>
+    <div class="flow-stepper__steps">
+      <div
+        v-for="(step, index) in resolvedSteps"
+        :key="step"
+        class="flow-step"
+        :class="{
+          'is-active': resolvedActive === index + 1,
+          'is-done': resolvedActive > index + 1,
+        }"
+        :aria-current="resolvedActive === index + 1 ? 'step' : undefined"
+      >
+        <span class="flow-step__number">{{
+          resolvedActive > index + 1 ? '✓' : String(index + 1).padStart(2, '0')
+        }}</span>
+        <span>{{ step }}</span>
+      </div>
     </div>
   </div>
 </template>

--- a/apps/web/app/pages/account/attendee-claim.vue
+++ b/apps/web/app/pages/account/attendee-claim.vue
@@ -112,7 +112,9 @@ useHead({
     <main id="main-content" class="claim-shell">
       <p class="flow-eyebrow">ATTENDEE CLAIM</p>
       <h1>把参会名额保存到你的账户</h1>
-      <p class="claim-lead">认领后可查看本人报名、电子票和参会名片。订单金额与发票仍由购票人管理。</p>
+      <p class="claim-lead">
+        认领后可查看本人报名、电子票和参会名片。订单金额与发票仍由购票人管理。
+      </p>
 
       <p v-if="loading" class="claim-status" role="status">正在确认登录状态…</p>
       <section v-else-if="claimedRegistrationId" class="claim-result" role="status">
@@ -149,11 +151,7 @@ useHead({
         <p v-if="errorMessage" class="form-error" role="alert">{{ errorMessage }}</p>
         <button class="flow-action" type="button" :disabled="claiming" @click="claim">
           {{
-            customer.session.value
-              ? claiming
-                ? '正在认领…'
-                : '确认认领参会名额'
-              : '登录后继续'
+            customer.session.value ? (claiming ? '正在认领…' : '确认认领参会名额') : '登录后继续'
           }}
         </button>
         <NuxtLink class="claim-back" to="/account">返回个人中心</NuxtLink>
@@ -200,11 +198,18 @@ useHead({
   justify-self: start;
 }
 .claim-back {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
   justify-self: start;
   color: #616b7b;
   font-size: 13px;
   text-decoration: underline;
   text-underline-offset: 3px;
+  transition: transform 110ms ease;
+}
+.claim-back:active {
+  transform: scale(0.98);
 }
 .claim-result {
   display: grid;
@@ -235,7 +240,27 @@ useHead({
 @media (max-width: 520px) {
   .claim-shell {
     width: min(100% - 24px, 680px);
-    padding-top: 80px;
+    padding: 40px 0 calc(64px + env(safe-area-inset-bottom));
+  }
+  .claim-shell h1 {
+    font-size: 31px;
+    line-height: 1.1;
+  }
+  .claim-lead {
+    margin-bottom: 28px;
+    font-size: 14px;
+    line-height: 1.7;
+  }
+  .claim-action .flow-action {
+    width: 100%;
+  }
+  .claim-result {
+    grid-template-columns: 40px minmax(0, 1fr);
+    gap: 13px;
+  }
+  .claim-result > span {
+    width: 40px;
+    height: 40px;
   }
 }
 </style>

--- a/apps/web/app/pages/account/index.vue
+++ b/apps/web/app/pages/account/index.vue
@@ -365,6 +365,7 @@ function selectAccountSection(sectionId: (typeof accountSections)[number]['id'])
 
 async function selectMobileAccountSection(sectionId: (typeof accountSections)[number]['id']) {
   selectAccountSection(sectionId);
+  mobileNavigationTrigger.value?.focus({ preventScroll: true });
   await router.push({ query: route.query, hash: `#${sectionId}` });
   await nextTick();
   mobileNavigationTrigger.value?.focus({ preventScroll: true });

--- a/apps/web/app/pages/account/index.vue
+++ b/apps/web/app/pages/account/index.vue
@@ -19,10 +19,7 @@ import {
   shouldRefreshPurchasedOrder,
 } from '~/utils/purchase-journey';
 import { resolveAttendeeNeedsAccountState } from '~/utils/attendee-needs';
-import {
-  selectFeaturedAccountContext,
-  visibleServiceHubItems,
-} from '~/utils/account-service-hub';
+import { selectFeaturedAccountContext, visibleServiceHubItems } from '~/utils/account-service-hub';
 import AccountServiceHubIcon from '~/components/AccountServiceHubIcon.vue';
 
 const customer = useCustomerSession();
@@ -159,6 +156,24 @@ const serviceStateLabels: Record<CustomerServiceHubItem['state'], string> = {
   attention: '需处理',
   unavailable: '未开放',
 };
+const accountSections = [
+  { id: 'overview', index: '01', label: '大会服务台' },
+  { id: 'events', index: '02', label: '我的参会名额' },
+  { id: 'purchases', index: '03', label: '我购买的订单' },
+  { id: 'showcases', index: '04', label: '参会资料' },
+  { id: 'invoices', index: '05', label: '发票中心' },
+  { id: 'profile', index: '06', label: '常用资料' },
+  { id: 'security', index: '07', label: '账户安全' },
+] as const;
+const mobileNavigationOpen = ref(false);
+const mobileNavigationRoot = ref<HTMLElement | null>(null);
+const mobileNavigationTrigger = ref<HTMLButtonElement | null>(null);
+const activeAccountSection = ref<(typeof accountSections)[number]['id']>('overview');
+const activeAccountSectionLabel = computed(
+  () =>
+    accountSections.find((section) => section.id === activeAccountSection.value)?.label ??
+    '大会服务台',
+);
 
 const money = (amount: number, currency: string) =>
   new Intl.NumberFormat('zh-CN', {
@@ -277,12 +292,11 @@ const fallbackServiceHubItems = computed<CustomerServiceHubItem[]>(() => {
     },
   ];
 });
-const serviceHubItems = computed(
-  () =>
-    visibleServiceHubItems(
-      featuredServiceHub.value?.items ?? fallbackServiceHubItems.value,
-      Boolean(featuredRegistration.value?.canManageOrder),
-    ),
+const serviceHubItems = computed(() =>
+  visibleServiceHubItems(
+    featuredServiceHub.value?.items ?? fallbackServiceHubItems.value,
+    Boolean(featuredRegistration.value?.canManageOrder),
+  ),
 );
 const featuredTicketServiceItem = computed(() =>
   serviceHubItems.value.find((item) => item.code === 'ticket'),
@@ -328,10 +342,8 @@ async function openServiceHubItem(item: CustomerServiceHubItem) {
     return;
   }
   const routes: Record<Exclude<CustomerServiceHubItem['code'], 'organizer_contact'>, string> = {
-    ticket: primaryRegistrationAction(
-      registration,
-      featuredServiceHub.value?.latestPaymentStatus,
-    ).to,
+    ticket: primaryRegistrationAction(registration, featuredServiceHub.value?.latestPaymentStatus)
+      .to,
     poster: `/account/registrations/${registration.id}/showcase?event=${encodeURIComponent(registration.eventSlug)}#showcase-poster`,
     showcase: `/account/registrations/${registration.id}/showcase?event=${encodeURIComponent(registration.eventSlug)}#showcase-profile-editor`,
     needs: `/account/registrations/${registration.id}/needs?event=${encodeURIComponent(registration.eventSlug)}`,
@@ -344,6 +356,35 @@ function selectEvent(event: Event) {
   const eventSlug = (event.target as HTMLSelectElement).value;
   organizerPanelOpen.value = false;
   void router.replace({ query: { ...route.query, event: eventSlug } });
+}
+
+function selectAccountSection(sectionId: (typeof accountSections)[number]['id']) {
+  activeAccountSection.value = sectionId;
+  mobileNavigationOpen.value = false;
+}
+
+async function selectMobileAccountSection(sectionId: (typeof accountSections)[number]['id']) {
+  selectAccountSection(sectionId);
+  await router.push({ query: route.query, hash: `#${sectionId}` });
+  await nextTick();
+  mobileNavigationTrigger.value?.focus({ preventScroll: true });
+}
+
+async function closeMobileNavigationFromKeyboard() {
+  mobileNavigationOpen.value = false;
+  await nextTick();
+  mobileNavigationTrigger.value?.focus({ preventScroll: true });
+}
+
+function closeMobileNavigationFromOutside(event: PointerEvent) {
+  const target = event.target;
+  if (
+    mobileNavigationOpen.value &&
+    target instanceof Node &&
+    !mobileNavigationRoot.value?.contains(target)
+  ) {
+    mobileNavigationOpen.value = false;
+  }
 }
 
 async function loadServiceHub(registrationId: string) {
@@ -503,10 +544,9 @@ async function refreshMutablePurchasedOrders() {
     ),
   );
   const refreshedById = new Map(
-    results.filter((order): order is CustomerPurchasedOrder => Boolean(order)).map((order) => [
-      order.id,
-      order,
-    ]),
+    results
+      .filter((order): order is CustomerPurchasedOrder => Boolean(order))
+      .map((order) => [order.id, order]),
   );
   if (refreshedById.size) {
     purchasedOrders.value = purchasedOrders.value.map(
@@ -701,18 +741,51 @@ async function logout() {
   nextOrdersCursor.value = null;
   serviceHubs.value = {};
   organizerPanelOpen.value = false;
+  mobileNavigationOpen.value = false;
+  activeAccountSection.value = 'overview';
 }
 
 let purchaseContextRefreshTimer: ReturnType<typeof setInterval> | undefined;
+let accountSectionObserver: IntersectionObserver | undefined;
+
+async function observeAccountSections() {
+  accountSectionObserver?.disconnect();
+  if (!customer.session.value || loading.value) return;
+  await nextTick();
+  const sectionElements = accountSections
+    .map((section) => document.getElementById(section.id))
+    .filter((element): element is HTMLElement => Boolean(element));
+  accountSectionObserver = new IntersectionObserver(
+    (entries) => {
+      const visibleEntry = entries
+        .filter((entry) => entry.isIntersecting)
+        .sort((left, right) => right.intersectionRatio - left.intersectionRatio)[0];
+      if (visibleEntry) {
+        activeAccountSection.value = visibleEntry.target
+          .id as (typeof accountSections)[number]['id'];
+      }
+    },
+    { rootMargin: '-18% 0px -68% 0px', threshold: [0, 0.1, 0.4] },
+  );
+  sectionElements.forEach((section) => accountSectionObserver?.observe(section));
+}
+
 onMounted(() => {
   void initialize();
+  document.addEventListener('pointerdown', closeMobileNavigationFromOutside);
   purchaseContextRefreshTimer = setInterval(() => {
     if (customer.session.value) void refreshVisiblePurchaseState();
   }, 30_000);
 });
 onBeforeUnmount(() => {
   if (purchaseContextRefreshTimer) clearInterval(purchaseContextRefreshTimer);
+  accountSectionObserver?.disconnect();
+  document.removeEventListener('pointerdown', closeMobileNavigationFromOutside);
 });
+watch(
+  () => [loading.value, customer.session.value?.customer.id] as const,
+  () => void observeAccountSections(),
+);
 watch(
   () => customer.session.value?.customer.id,
   (id, previous) => {
@@ -802,14 +875,15 @@ useHead({ title: '个人中心' });
             <p class="account-rail__mobile">
               {{ customer.session.value.customer.maskedMobile }}
             </p>
-            <nav class="account-nav" aria-label="个人中心模块">
-              <a href="#overview"><span>01</span> 总览</a>
-              <a href="#events"><span>02</span> 我的参会名额</a>
-              <a href="#purchases"><span>03</span> 我购买的订单</a>
-              <a href="#showcases"><span>04</span> 参会资料</a>
-              <a href="#invoices"><span>05</span> 发票中心</a>
-              <a href="#profile"><span>06</span> 常用资料</a>
-              <a href="#security"><span>07</span> 账户安全</a>
+            <nav class="account-nav account-nav--desktop" aria-label="个人中心模块">
+              <a
+                v-for="section in accountSections"
+                :key="section.id"
+                :href="`#${section.id}`"
+                @click="selectAccountSection(section.id)"
+              >
+                <span>{{ section.index }}</span> {{ section.label }}
+              </a>
             </nav>
             <div class="account-rail__completion">
               <div>
@@ -831,6 +905,47 @@ useHead({ title: '个人中心' });
               <span>最近登录</span>
               <strong>{{ formatDateTime(customer.session.value.customer.lastLoginAt) }}</strong>
               <button type="button" @click="logout">退出登录</button>
+            </div>
+            <div
+              ref="mobileNavigationRoot"
+              class="account-mobile-navigation"
+              @keydown.esc.prevent.stop="closeMobileNavigationFromKeyboard"
+            >
+              <button
+                ref="mobileNavigationTrigger"
+                class="account-mobile-navigation__trigger"
+                type="button"
+                aria-controls="account-mobile-navigation-panel"
+                :aria-expanded="mobileNavigationOpen"
+                @click="mobileNavigationOpen = !mobileNavigationOpen"
+              >
+                <span>页面导航</span>
+                <strong>{{ activeAccountSectionLabel }}</strong>
+                <i aria-hidden="true">{{ mobileNavigationOpen ? '−' : '＋' }}</i>
+              </button>
+              <div
+                v-show="mobileNavigationOpen"
+                id="account-mobile-navigation-panel"
+                class="account-mobile-navigation__panel"
+              >
+                <nav class="account-mobile-navigation__links" aria-label="个人中心移动端模块">
+                  <a
+                    v-for="section in accountSections"
+                    :key="section.id"
+                    :href="`#${section.id}`"
+                    :aria-current="activeAccountSection === section.id ? 'location' : undefined"
+                    @click.prevent="selectMobileAccountSection(section.id)"
+                  >
+                    <span>{{ section.index }}</span>
+                    {{ section.label }}
+                  </a>
+                </nav>
+                <div class="account-mobile-navigation__meta">
+                  <span>{{ customer.session.value.customer.maskedMobile }}</span>
+                  <strong>资料完整度 {{ profileCompletion }}%</strong>
+                  <button type="button" @click="logout">退出登录</button>
+                </div>
+              </div>
             </div>
           </aside>
 
@@ -888,8 +1003,14 @@ useHead({ title: '个人中心' });
                 <div class="account-pass__main">
                   <div class="account-pass__topline">
                     <span>TOKEMS CONFERENCE · ATTENDEE PASS</span>
-                    <span class="account-pass__status" :data-state="featuredTicketServiceItem?.state">
-                      {{ featuredTicketServiceItem?.label ?? statusLabel(featuredRegistration.registrationStatus) }}
+                    <span
+                      class="account-pass__status"
+                      :data-state="featuredTicketServiceItem?.state"
+                    >
+                      {{
+                        featuredTicketServiceItem?.label ??
+                          statusLabel(featuredRegistration.registrationStatus)
+                      }}
                     </span>
                   </div>
                   <h3>{{ featuredRegistration.eventName }}</h3>
@@ -1354,14 +1475,8 @@ useHead({ title: '个人中心' });
                     <button
                       v-if="
                         (orderItem.status === 'pending_payment' &&
-                          !canResumePendingOrder(
-                            orderItem,
-                            purchaseContexts[orderItem.eventId],
-                          ) &&
-                          !canRestartSelfOrder(
-                            orderItem,
-                            purchaseContexts[orderItem.eventId],
-                          )) ||
+                          !canResumePendingOrder(orderItem, purchaseContexts[orderItem.eventId]) &&
+                          !canRestartSelfOrder(orderItem, purchaseContexts[orderItem.eventId])) ||
                           (orderItem.status === 'closed' &&
                             (!purchaseContexts[orderItem.eventId] ||
                               purchaseContextErrors[orderItem.eventId] ||
@@ -1625,7 +1740,7 @@ useHead({ title: '个人中心' });
             <section id="security" class="account-section" aria-labelledby="security-title">
               <div class="account-section__heading">
                 <div>
-                  <span class="account-section__index">06 / SECURITY</span>
+                  <span class="account-section__index">07 / SECURITY</span>
                   <h2 id="security-title">账户与安全</h2>
                 </div>
                 <p>手机号验证保护你的参会凭证与订单信息。</p>
@@ -2062,6 +2177,10 @@ useHead({ title: '个人中心' });
   color: var(--account-muted);
   font-size: 11px;
   font-weight: 650;
+}
+
+.account-mobile-navigation {
+  display: none;
 }
 
 .account-content {
@@ -3429,59 +3548,193 @@ useHead({ title: '个人中心' });
     grid-template-columns: 1fr;
   }
   .account-rail {
-    position: static;
+    position: sticky;
+    z-index: 20;
+    top: max(8px, env(safe-area-inset-top));
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
     align-items: center;
+    overflow: visible;
+    box-shadow: 0 8px 24px rgb(15 23 42 / 7%);
   }
   .account-rail__identity {
-    padding-bottom: 22px;
+    padding: 14px 16px 12px;
   }
   .account-rail__mobile {
     display: none;
   }
-  .account-nav {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-    border-bottom: 0;
+  .account-nav--desktop {
+    display: none;
   }
   .account-rail__completion {
-    min-width: 220px;
+    display: none;
   }
   .account-rail__footer {
     display: none;
+  }
+  .account-mobile-navigation {
+    position: relative;
+    display: block;
+    border-top: 1px solid var(--account-line-soft);
+  }
+  .account-mobile-navigation__trigger {
+    display: grid;
+    width: 100%;
+    min-height: 48px;
+    grid-template-columns: auto minmax(0, 1fr) 24px;
+    align-items: center;
+    gap: 12px;
+    padding: 0 16px;
+    color: var(--account-ink);
+    text-align: left;
+    transition: transform 110ms ease;
+  }
+  .account-mobile-navigation__trigger > span {
+    color: var(--conference-primary);
+    font: 720 9px/1 var(--conference-font-mono);
+    letter-spacing: 0.08em;
+  }
+  .account-mobile-navigation__trigger strong {
+    min-width: 0;
+    font-size: 12px;
+    font-weight: 720;
+  }
+  .account-mobile-navigation__trigger i {
+    display: grid;
+    width: 24px;
+    height: 24px;
+    place-items: center;
+    color: var(--account-muted);
+    font-size: 15px;
+    font-style: normal;
+  }
+  .account-mobile-navigation__panel {
+    position: absolute;
+    z-index: 2;
+    top: calc(100% + 6px);
+    right: -1px;
+    left: -1px;
+    overflow: hidden;
+    border: 1px solid var(--account-line);
+    border-radius: 9px;
+    background: #fff;
+    box-shadow: 0 18px 38px rgb(15 23 42 / 15%);
+  }
+  .account-mobile-navigation__links {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    padding: 8px;
+  }
+  .account-mobile-navigation__links a {
+    display: grid;
+    min-width: 0;
+    min-height: 48px;
+    grid-template-columns: 24px minmax(0, 1fr);
+    align-items: center;
+    gap: 7px;
+    padding: 0 9px;
+    border-radius: 6px;
+    color: #44474f;
+    font-size: 12px;
+    font-weight: 650;
+    line-height: 1.35;
+    text-decoration: none;
+    transition:
+      background-color 110ms ease,
+      color 110ms ease,
+      transform 110ms ease;
+  }
+  .account-mobile-navigation__links a[aria-current='location'] {
+    background: #eff5ff;
+    color: var(--conference-primary);
+  }
+  .account-mobile-navigation__links a span {
+    color: #9da3ae;
+    font: 650 9px/1 var(--conference-font-mono);
+  }
+  .account-mobile-navigation__meta {
+    display: flex;
+    min-height: 48px;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 16px;
+    border-top: 1px solid var(--account-line-soft);
+    background: #fafbfc;
+    color: var(--account-muted);
+    font-size: 10px;
+  }
+  .account-mobile-navigation__meta span {
+    font-family: var(--conference-font-mono);
+  }
+  .account-mobile-navigation__meta strong {
+    margin-left: auto;
+    color: #575b64;
+    font-weight: 680;
+  }
+  .account-mobile-navigation__meta button {
+    min-height: 44px;
+    padding-inline: 8px;
+    color: #9f2736;
+    font-size: 10px;
+    font-weight: 700;
+    transition: transform 110ms ease;
+  }
+  .account-mobile-navigation__trigger:active,
+  .account-mobile-navigation__links a:active,
+  .account-mobile-navigation__meta button:active {
+    transform: scale(0.98);
+  }
+  .service-hub-heading__tools select,
+  .account-form input,
+  .purchase-attendee-edit input {
+    font-size: 16px;
+  }
+  .purchase-attendee-edit input,
+  .registration-row__actions a,
+  .registration-row__actions button,
+  .purchase-attendee-edit button,
+  .account-security__action button {
+    min-height: 44px;
+  }
+  .account-section {
+    scroll-margin-top: 142px;
   }
 }
 
 @media (max-width: 760px) {
   .account-shell {
     width: min(100% - 28px, 1180px);
-    padding: 38px 0 72px;
+    padding: 26px 0 calc(72px + env(safe-area-inset-bottom));
   }
   .account-heading {
     align-items: flex-start;
-    margin-bottom: 32px;
+    margin-bottom: 20px;
   }
   .account-heading h1 {
     font-size: 32px;
   }
   .account-heading > div > p:last-child {
     max-width: 30ch;
+    margin-top: 12px;
     font-size: 12px;
   }
-  .account-back-link {
-    font-size: 0;
+  .account-rail__identity {
+    display: none;
   }
-  .account-back-link span {
-    display: grid;
-    width: 40px;
-    height: 40px;
-    place-items: center;
+  .account-mobile-navigation {
+    border-top: 0;
+  }
+  .account-back-link {
+    min-height: 44px;
+    gap: 6px;
+    padding: 0 12px;
     border: 1px solid var(--account-line);
     border-radius: 7px;
     background: #fff;
-    font-size: 15px;
+    font-size: 11px;
+  }
+  .account-back-link span {
+    font-size: 13px;
   }
   .account-login {
     grid-template-columns: 1fr;
@@ -3492,24 +3745,10 @@ useHead({ title: '个人中心' });
     min-height: 280px;
   }
   .account-workspace {
-    gap: 28px;
-  }
-  .account-rail {
-    grid-template-columns: 1fr;
-  }
-  .account-rail__completion {
-    display: none;
-  }
-  .account-nav {
-    overflow-x: auto;
-  }
-  .account-nav a {
-    min-width: 108px;
-    justify-content: center;
-    padding-inline: 8px;
+    gap: 20px;
   }
   .account-content {
-    gap: 56px;
+    gap: 48px;
   }
   .account-section__heading {
     align-items: flex-start;
@@ -3539,12 +3778,12 @@ useHead({ title: '个人中心' });
     overflow-wrap: anywhere;
   }
   .account-pass__stub {
-    min-height: 100px;
+    min-height: 68px;
     grid-template-columns: auto auto 1fr;
     align-content: center;
     justify-items: start;
     gap: 12px;
-    padding: 0 28px;
+    padding: 0 22px;
     border-top: 1px dashed #b7c7e1;
     border-left: 0;
     text-align: left;
@@ -3563,7 +3802,7 @@ useHead({ title: '个人中心' });
   }
   .account-pass__stub strong {
     margin: 0;
-    font-size: 30px;
+    font-size: 26px;
   }
   .account-pass__stub small {
     justify-self: end;
@@ -3612,18 +3851,31 @@ useHead({ title: '个人中心' });
     flex-direction: column;
   }
   .service-hub-heading__tools select {
+    min-height: 44px;
     width: 100%;
     max-width: none;
   }
   .account-pass__main {
-    padding: 25px 22px;
+    padding: 22px 20px;
   }
   .account-pass__topline {
     align-items: flex-start;
   }
   .account-pass h3 {
-    margin-top: 28px;
+    margin-top: 22px;
     font-size: 24px;
+  }
+  .account-pass__actions {
+    width: 100%;
+    gap: 10px 16px;
+    padding-top: 20px;
+  }
+  .account-pass__actions a,
+  .account-pass__actions button {
+    min-height: 44px;
+  }
+  .account-pass__actions .account-pass__primary {
+    justify-content: space-between;
   }
   .account-summary > div {
     padding-block: 17px;
@@ -3709,6 +3961,16 @@ useHead({ title: '个人中心' });
     height: auto;
     aspect-ratio: 1;
   }
+  .organizer-contact-panel > header button,
+  .organizer-contact-panel__confirm {
+    min-height: 44px;
+  }
+  .organizer-contact-panel__confirm {
+    width: 100%;
+  }
+  .organizer-contact-panel__body dd {
+    overflow-wrap: anywhere;
+  }
 }
 
 @media (max-width: 400px) {
@@ -3717,15 +3979,6 @@ useHead({ title: '个人中心' });
   }
   .account-heading h1 {
     font-size: 30px;
-  }
-  .account-nav {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    overflow: visible;
-  }
-  .account-nav a {
-    min-width: 0;
-    justify-content: flex-start;
-    padding-inline: 12px;
   }
   .account-pass__topline > span:first-child {
     max-width: 180px;
@@ -3794,6 +4047,17 @@ useHead({ title: '个人中心' });
   .account-security__action {
     align-items: flex-start;
     flex-direction: column;
+  }
+}
+
+@media (max-width: 340px) {
+  .service-hub-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .service-hub-grid > .service-hub-card,
+  .service-hub-grid[data-count='5'] > .service-hub-card:nth-last-child(-n + 2),
+  .service-hub-grid[data-count='5'] > .service-hub-card:last-child {
+    grid-column: span 1;
   }
 }
 

--- a/apps/web/app/pages/account/invoices/[orderId].vue
+++ b/apps/web/app/pages/account/invoices/[orderId].vue
@@ -557,7 +557,7 @@ useHead({ title: computed(() => (existingInvoice.value ? '发票详情' : '申�
 
 .invoice-back {
   display: inline-flex;
-  min-height: 42px;
+  min-height: 44px;
   align-items: center;
   gap: 9px;
   color: var(--invoice-muted);
@@ -1258,7 +1258,7 @@ useHead({ title: computed(() => (existingInvoice.value ? '发票详情' : '申�
 @media (max-width: 640px) {
   .invoice-shell {
     width: min(100% - 28px, 1120px);
-    padding-top: 24px;
+    padding: 24px 0 calc(72px + env(safe-area-inset-bottom));
   }
 
   .invoice-heading {
@@ -1297,12 +1297,23 @@ useHead({ title: computed(() => (existingInvoice.value ? '发票详情' : '申�
     grid-column: auto;
   }
 
+  .invoice-form-grid input {
+    font-size: 16px;
+  }
+
   .invoice-form-action {
     display: grid;
   }
 
   .invoice-form-buttons {
+    display: grid;
+    width: 100%;
     justify-content: flex-start;
+  }
+
+  .invoice-form-buttons .invoice-primary,
+  .invoice-form-buttons .invoice-secondary {
+    width: 100%;
   }
 
   .invoice-details,

--- a/apps/web/app/pages/account/invoices/index.vue
+++ b/apps/web/app/pages/account/invoices/index.vue
@@ -89,6 +89,10 @@ async function selectCategory(value: CustomerInvoiceCenterCategory) {
   await load();
 }
 
+function selectCategoryFromEvent(event: Event) {
+  void selectCategory((event.target as HTMLSelectElement).value as CustomerInvoiceCenterCategory);
+}
+
 onMounted(() => void load());
 watch(
   () => customer.session.value?.customer.id,
@@ -186,6 +190,18 @@ useHead({ title: '发票中心' });
               <span>{{ counts[option.countKey] }}</span>
             </button>
           </nav>
+          <label class="invoice-center-mobile-filter">
+            <span>记录分类</span>
+            <select :value="category" @change="selectCategoryFromEvent">
+              <option
+                v-for="option in customerInvoiceCategories"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}（{{ counts[option.countKey] }}）
+              </option>
+            </select>
+          </label>
 
           <div v-if="items.length" class="invoice-center-list">
             <article v-for="item in items" :key="item.orderId" class="invoice-center-row">
@@ -293,7 +309,7 @@ useHead({ title: '发票中心' });
 .invoice-center-back,
 .invoice-center-event-link {
   display: inline-flex;
-  min-height: 42px;
+  min-height: 44px;
   align-items: center;
   gap: 9px;
   color: #6f737c;
@@ -502,6 +518,10 @@ useHead({ title: '发票中心' });
   font-family: var(--conference-font-mono);
   font-size: 8px;
   text-align: center;
+}
+
+.invoice-center-mobile-filter {
+  display: none;
 }
 
 .invoice-center-list {
@@ -795,7 +815,7 @@ useHead({ title: '发票中心' });
 @media (max-width: 560px) {
   .invoice-center-shell {
     width: min(100% - 28px, 1120px);
-    padding-top: 24px;
+    padding: 24px 0 calc(72px + env(safe-area-inset-bottom));
   }
 
   .invoice-center-heading {
@@ -818,6 +838,33 @@ useHead({ title: '发票中心' });
   .invoice-center-section-head,
   .invoice-center-list {
     padding-inline: 18px;
+  }
+
+  .invoice-center-tabs {
+    display: none;
+  }
+
+  .invoice-center-mobile-filter {
+    display: grid;
+    gap: 7px;
+    padding: 14px 18px 16px;
+    border-top: 1px solid #eceef2;
+    border-bottom: 1px solid #dfe3e9;
+    color: #6f737c;
+    font-size: 10px;
+    font-weight: 680;
+  }
+
+  .invoice-center-mobile-filter select {
+    width: 100%;
+    min-height: 44px;
+    padding: 0 34px 0 12px;
+    border: 1px solid #d9dee6;
+    border-radius: 7px;
+    background: #fff;
+    color: #17191d;
+    font-size: 16px;
+    font-weight: 680;
   }
 
   .invoice-center-row {
@@ -849,6 +896,12 @@ useHead({ title: '发票中心' });
   .invoice-center-row__action {
     display: grid;
     justify-content: start;
+  }
+
+  .invoice-center-row__action a,
+  .invoice-center-empty button,
+  .invoice-center-more {
+    min-height: 44px;
   }
 
   .invoice-center-empty {

--- a/apps/web/app/pages/account/registrations/[id].vue
+++ b/apps/web/app/pages/account/registrations/[id].vue
@@ -11,6 +11,46 @@ const attendeeNeeds = ref<AttendeeNeedsProfile | null>(null);
 const loading = ref(true);
 const errorMessage = ref('');
 const rendersChildPage = computed(() => /\/(showcase|needs)\/?$/u.test(route.path));
+const registrationStatusLabels: Record<string, string> = {
+  draft: '草稿',
+  pending_review: '待审核',
+  pending_payment: '待支付',
+  confirmed: '已确认',
+  cancelled: '已取消',
+  checked_in: '已签到',
+  completed: '已完成',
+};
+const orderStatusLabels: Record<string, string> = {
+  pending_review: '待审核',
+  pending_payment: '待支付',
+  processing: '处理中',
+  paid: '已支付',
+  partially_refunded: '部分退款',
+  refunded: '已退款',
+  closed: '已关闭',
+};
+const canOpenShowcase = computed(() =>
+  ['confirmed', 'checked_in'].includes(detail.value?.registrationStatus ?? ''),
+);
+const canEditNeeds = computed(() => Boolean(attendeeNeeds.value?.id || attendeeNeeds.value?.canCreate));
+const canOpenTicket = computed(() => Boolean(detail.value?.ticketCode));
+const detailTicketHref = computed(() => {
+  const value = detail.value;
+  return value?.ticketCode
+    ? customerRegistrationTicketHref(value.ticketCode, value.eventSlug)
+    : '/account';
+});
+const canOpenInvoice = computed(() => {
+  const value = detail.value;
+  return Boolean(
+    value?.canManageOrder &&
+      value.amount > 0 &&
+      ['paid', 'partially_refunded'].includes(value.orderStatus),
+  );
+});
+const hasDetailActions = computed(
+  () => canOpenShowcase.value || canEditNeeds.value || canOpenTicket.value || canOpenInvoice.value,
+);
 
 const money = (amount: number) =>
   amount === 0 ? '免费' : `¥${(amount / 100).toLocaleString('zh-CN')}`;
@@ -88,11 +128,13 @@ useHead({ title: '报名详情' });
           </div>
           <div>
             <dt>报名状态</dt>
-            <dd>{{ detail.registrationStatus }}</dd>
+            <dd>
+              {{ registrationStatusLabels[detail.registrationStatus] ?? detail.registrationStatus }}
+            </dd>
           </div>
           <div v-if="detail.canManageOrder">
             <dt>订单状态</dt>
-            <dd>{{ detail.orderStatus }}</dd>
+            <dd>{{ orderStatusLabels[detail.orderStatus] ?? detail.orderStatus }}</dd>
           </div>
           <div>
             <dt>公司</dt>
@@ -103,34 +145,30 @@ useHead({ title: '报名详情' });
             <dd>{{ detail.attendee.email || '未填写' }}</dd>
           </div>
         </dl>
-        <footer>
+        <footer v-if="hasDetailActions">
           <NuxtLink
-            v-if="['confirmed', 'checked_in'].includes(detail.registrationStatus)"
+            v-if="canOpenShowcase"
             class="detail-primary"
             :to="`/account/registrations/${detail.id}/showcase?event=${encodeURIComponent(detail.eventSlug)}`"
           >
             完善参会名片
           </NuxtLink>
           <NuxtLink
-            v-if="attendeeNeeds?.id || attendeeNeeds?.canCreate"
+            v-if="canEditNeeds"
             class="detail-secondary"
             :to="`/account/registrations/${detail.id}/needs?event=${encodeURIComponent(detail.eventSlug)}`"
           >
             编辑参会需求
           </NuxtLink>
           <NuxtLink
-            v-if="detail.ticketCode"
+            v-if="canOpenTicket"
             class="detail-secondary"
-            :to="customerRegistrationTicketHref(detail.ticketCode, detail.eventSlug)"
+            :to="detailTicketHref"
           >
             查看电子票
           </NuxtLink>
           <NuxtLink
-            v-if="
-              detail.canManageOrder &&
-                detail.amount > 0 &&
-                ['paid', 'partially_refunded'].includes(detail.orderStatus)
-            "
+            v-if="canOpenInvoice"
             class="detail-secondary"
             :to="`/account/invoices/${detail.orderId}`"
           >
@@ -150,10 +188,14 @@ useHead({ title: '报名详情' });
 }
 .detail-back {
   display: inline-flex;
-  min-height: 40px;
+  min-height: 44px;
   align-items: center;
   color: var(--conference-ink-muted);
   font-size: 13px;
+  transition: transform 110ms ease;
+}
+.detail-back:active {
+  transform: scale(0.98);
 }
 .detail-panel {
   margin-top: 18px;
@@ -173,9 +215,12 @@ useHead({ title: '报名详情' });
   border-bottom: 1px solid var(--conference-line);
 }
 .detail-panel h1 {
+  max-width: 20ch;
   margin: 0;
   font-size: clamp(26px, 4vw, 38px);
   letter-spacing: -0.03em;
+  line-height: 1.18;
+  text-wrap: balance;
 }
 .detail-panel header p:last-child {
   margin: 10px 0 0;
@@ -183,12 +228,14 @@ useHead({ title: '报名详情' });
   font-size: 13px;
 }
 .detail-panel header > span {
+  max-width: 100%;
   padding: 6px 9px;
   border-radius: 6px;
   background: #f4f4f5;
   color: #52525b;
   font-family: var(--conference-font-mono);
   font-size: 11px;
+  overflow-wrap: anywhere;
 }
 .detail-grid {
   display: grid;
@@ -212,6 +259,7 @@ useHead({ title: '报名详情' });
   color: var(--conference-ink);
   font-size: 14px;
   font-weight: 650;
+  overflow-wrap: anywhere;
 }
 .detail-panel footer {
   display: flex;
@@ -236,6 +284,10 @@ useHead({ title: '报名详情' });
 .detail-secondary {
   background: #e4e4e7;
   color: #27272a;
+}
+.detail-primary:active,
+.detail-secondary:active {
+  transform: scale(0.98);
 }
 .detail-state {
   padding: 64px 0;
@@ -265,7 +317,26 @@ useHead({ title: '报名详情' });
     border-bottom: 1px solid var(--conference-line);
   }
   .detail-panel footer {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     padding: 18px 20px;
+  }
+  .detail-primary,
+  .detail-secondary {
+    min-height: 44px;
+    justify-content: center;
+    text-align: center;
+  }
+  .detail-primary {
+    grid-column: 1 / -1;
+  }
+}
+@media (max-width: 380px) {
+  .detail-panel footer {
+    grid-template-columns: 1fr;
+  }
+  .detail-primary {
+    grid-column: auto;
   }
 }
 </style>

--- a/apps/web/app/pages/account/registrations/[id]/needs.vue
+++ b/apps/web/app/pages/account/registrations/[id]/needs.vue
@@ -639,7 +639,7 @@ useHead(() => ({
 
 .topic-grid label {
   display: inline-flex;
-  min-height: 40px;
+  min-height: 44px;
   align-items: center;
   padding: 8px 13px;
   border: 1px solid #d5ddec;
@@ -685,7 +685,7 @@ useHead(() => ({
 
 .quiet-action,
 .add-question {
-  min-height: 40px;
+  min-height: 44px;
   border: 0;
   background: transparent;
   color: #356be8;
@@ -848,7 +848,7 @@ useHead(() => ({
 }
 
 .text-action {
-  min-height: 40px;
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
   color: #356be8;
@@ -858,7 +858,7 @@ useHead(() => ({
 @media (max-width: 640px) {
   .needs-shell {
     width: min(100% - 24px, 980px);
-    padding: 46px 0 72px;
+    padding: 30px 0 calc(72px + env(safe-area-inset-bottom));
   }
 
   .question-section,
@@ -868,7 +868,17 @@ useHead(() => ({
   }
 
   .needs-intro h1 {
-    font-size: 36px;
+    font-size: 31px;
+    line-height: 1.12;
+  }
+
+  .needs-intro > p:last-child {
+    font-size: 15px;
+    line-height: 1.7;
+  }
+
+  .needs-stepper {
+    margin: 26px 0;
   }
 
   .question-meta {
@@ -876,7 +886,26 @@ useHead(() => ({
   }
 
   .needs-actions {
-    align-items: flex-start;
+    display: grid;
+    align-items: stretch;
+  }
+
+  .needs-actions .primary-action,
+  .needs-actions .secondary-action {
+    width: 100%;
+  }
+
+  .choice-row {
+    min-height: 64px;
+  }
+
+  .question-index .quiet-action {
+    flex: 0 0 auto;
+  }
+
+  .question-editor textarea,
+  .attribution-field input {
+    font-size: 16px;
   }
 }
 

--- a/apps/web/app/pages/account/registrations/[id]/showcase.vue
+++ b/apps/web/app/pages/account/registrations/[id]/showcase.vue
@@ -1073,7 +1073,7 @@ useHead(() => ({
 }
 .upload-action {
   display: inline-flex;
-  min-height: 38px;
+  min-height: 44px;
   align-items: center;
   padding: 0 14px;
   border: 1px solid #ccd6e6;
@@ -1097,6 +1097,7 @@ useHead(() => ({
   line-height: 1.6;
 }
 .text-action {
+  min-height: 44px;
   border: 0;
   background: transparent;
   color: #3166cf;
@@ -1108,6 +1109,7 @@ useHead(() => ({
 }
 .visibility-toggle {
   display: flex;
+  min-height: 44px;
   align-items: center;
   gap: 7px;
   color: #596579;
@@ -1185,6 +1187,7 @@ useHead(() => ({
 }
 .field-block small {
   display: flex;
+  min-height: 44px;
   align-items: center;
   gap: 6px;
   color: #788497;
@@ -1203,6 +1206,7 @@ useHead(() => ({
 }
 .publish-choice > label {
   display: flex;
+  min-height: 64px;
   align-items: flex-start;
   gap: 12px;
   cursor: pointer;
@@ -1357,7 +1361,21 @@ useHead(() => ({
 @media (max-width: 640px) {
   .showcase-shell {
     width: min(100% - 24px, 1240px);
-    padding-top: 36px;
+    padding: 30px 0 calc(72px + env(safe-area-inset-bottom));
+  }
+  .showcase-intro {
+    margin-bottom: 26px;
+  }
+  .showcase-intro h1 {
+    font-size: 31px;
+    line-height: 1.12;
+  }
+  .showcase-intro > p:last-child {
+    font-size: 15px;
+    line-height: 1.7;
+  }
+  .showcase-stepper {
+    margin: 0 0 26px;
   }
   .editor-section,
   .publish-choice {
@@ -1375,6 +1393,11 @@ useHead(() => ({
   }
   .visibility-toggle {
     grid-column: 1 / -1;
+  }
+  .field-block input:not([type='checkbox']),
+  .field-block select,
+  .field-block textarea {
+    font-size: 16px;
   }
   .editor-actions {
     padding: 20px 18px;

--- a/apps/web/app/pages/ticket/[id].vue
+++ b/apps/web/app/pages/ticket/[id].vue
@@ -27,9 +27,7 @@ const dateRange = computed(() => {
   });
   return `${format.format(new Date(event.value.startsAt))} 至 ${format.format(new Date(event.value.endsAt))}`;
 });
-const homeHref = computed(() =>
-  api.resolveConferenceUrl(publicEventHomePath(event.value.slug)),
-);
+const homeHref = computed(() => api.resolveConferenceUrl(publicEventHomePath(event.value.slug)));
 const paymentSurface = computed(() => api.isPaymentSurface());
 const paymentRequired = computed(
   () => checkout.value?.order.amount !== 0 && checkout.value?.order.paymentMethod !== 'free',
@@ -94,7 +92,7 @@ function printTicket() {
 
       <article v-if="ticket" class="ticket-paper">
         <section class="ticket-paper__main">
-          <span class="ticket-status">{{ ticketStatus }}</span>
+          <span class="ticket-status" :data-status="ticket.status">{{ ticketStatus }}</span>
           <h1>{{ ticket.eventName }}</h1>
           <dl class="ticket-meta">
             <div>
@@ -118,7 +116,7 @@ function printTicket() {
         </section>
         <aside class="ticket-paper__aside">
           <div>
-            <QrcodeVue class="ticket-qr" :value="ticket.qrPayload" :size="142" level="H" />
+            <QrcodeVue class="ticket-qr" :value="ticket.qrPayload" :size="184" level="H" />
             <strong>现场扫码签到</strong>
             <small style="color: var(--conference-ink-muted)">一人一码 · 仅限使用一次</small>
           </div>

--- a/tooling/visual-smoke.mjs
+++ b/tooling/visual-smoke.mjs
@@ -45,6 +45,34 @@ async function runVisualSmoke() {
     });
   }
 
+  async function mockNativePaymentPreparation(page) {
+    await page.route('**/payments/wechat/*/native', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      const pathname = new URL(route.request().url()).pathname;
+      const orderId = pathname.match(/\/payments\/wechat\/([^/]+)\/native$/u)?.[1];
+      if (!orderId) {
+        await route.continue();
+        return;
+      }
+      const attemptId = `visual-${Date.now()}`;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          orderId,
+          channel: 'native',
+          attemptId,
+          outTradeNo: attemptId,
+          codeUrl: 'weixin://wxpay/bizpayurl?pr=tokems-visual-smoke',
+          expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        }),
+      });
+    });
+  }
+
   async function assertNoHorizontalOverflow(page, label) {
     const sizes = await page.evaluate(() => ({
       viewport: document.documentElement.clientWidth,
@@ -711,6 +739,7 @@ async function runVisualSmoke() {
     reducedMotion: 'reduce',
   });
   const page = await desktop.newPage();
+  await mockNativePaymentPreparation(page);
   watch(page, 'desktop');
   let speakerDetailUrl;
   let visualCustomerMobile = '';

--- a/tooling/visual-smoke.mjs
+++ b/tooling/visual-smoke.mjs
@@ -550,6 +550,161 @@ async function runVisualSmoke() {
     checked.push(label);
   }
 
+  async function loginCustomer(page, mobileNumber) {
+    await page.goto(`${webBase}/account`, { waitUntil: 'networkidle' });
+    const loginButton = page.getByRole('button', { name: '登录个人中心' });
+    if (!(await loginButton.count())) return;
+    await loginButton.click();
+    const authPanel = page.locator('.auth-dialog__panel');
+    await authPanel.waitFor();
+    await page.getByPlaceholder('请输入 11 位手机号').fill(mobileNumber);
+    await page.getByRole('button', { name: '获取验证码' }).click();
+    const codeText = await page.locator('.auth-development-code strong').textContent();
+    const code = codeText?.match(/\d{6}/u)?.[0];
+    if (!code) throw new Error('个人中心手机端: 演示环境未返回可用验证码');
+    await page.getByPlaceholder('6 位验证码').fill(code);
+    await page.locator('.auth-consent input').check();
+    await page.getByRole('button', { name: '验证并继续' }).click();
+    await page.locator('.auth-dialog').waitFor({ state: 'detached' });
+    await page.getByRole('heading', { name: '个人中心', level: 1 }).waitFor();
+  }
+
+  async function captureCustomerLoginMobile(page) {
+    await page.goto(`${webBase}/account`, { waitUntil: 'networkidle' });
+    await page.getByRole('button', { name: '登录个人中心' }).click();
+    await page.locator('.auth-dialog__panel').waitFor();
+    await page.waitForTimeout(220);
+    const authMetrics = await page.evaluate(() => {
+      const panel = document.querySelector('.auth-dialog__panel');
+      const close = document.querySelector('.auth-dialog__close');
+      const input = document.querySelector('.auth-mobile-input input');
+      const panelRect = panel?.getBoundingClientRect();
+      const closeRect = close?.getBoundingClientRect();
+      return {
+        panelTop: panelRect?.top ?? -1,
+        panelBottom: panelRect?.bottom ?? Number.POSITIVE_INFINITY,
+        closeSize: closeRect ? Math.min(closeRect.width, closeRect.height) : 0,
+        inputFontSize: input ? Number.parseFloat(getComputedStyle(input).fontSize) : 0,
+        viewportHeight: window.innerHeight,
+      };
+    });
+    if (authMetrics.panelTop < 0 || authMetrics.panelBottom > authMetrics.viewportHeight) {
+      issues.push('个人中心登录手机端: 登录面板超出可视区域');
+    }
+    if (authMetrics.closeSize < 44) {
+      issues.push(`个人中心登录手机端: 关闭按钮触控尺寸仅 ${authMetrics.closeSize}px`);
+    }
+    if (authMetrics.inputFontSize < 16) {
+      issues.push(`个人中心登录手机端: 手机号输入字号仅 ${authMetrics.inputFontSize}px`);
+    }
+    await page.screenshot({
+      path: resolve(output, 'web-account-login-mobile.png'),
+      fullPage: false,
+    });
+    await page.locator('.auth-dialog__close').click();
+    await page.locator('.auth-dialog').waitFor({ state: 'detached' });
+  }
+
+  async function assertAccountMobileBaseline(page, label) {
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.locator('#overview').waitFor();
+    await assertNoHorizontalOverflow(page, label);
+    const layout = await page.evaluate(() => {
+      const trigger = document.querySelector('.account-mobile-navigation__trigger');
+      const desktopNavigation = document.querySelector('.account-nav--desktop');
+      const mobileIdentity = document.querySelector('.account-rail__identity');
+      const primary = document.querySelector('.account-pass__primary');
+      const rect = (element) => {
+        const value = element?.getBoundingClientRect();
+        return value
+          ? {
+              top: Math.round(value.top),
+              bottom: Math.round(value.bottom),
+              height: Math.round(value.height),
+            }
+          : null;
+      };
+      return {
+        viewportHeight: window.innerHeight,
+        trigger: rect(trigger),
+        primary: rect(primary),
+        mobileIdentityDisplay: mobileIdentity ? getComputedStyle(mobileIdentity).display : null,
+        desktopNavigationDisplay: desktopNavigation
+          ? getComputedStyle(desktopNavigation).display
+          : null,
+        zoomProneControlCount: [
+          ...document.querySelectorAll(
+            'input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]), select, textarea',
+          ),
+        ].filter((element) => {
+          const style = getComputedStyle(element);
+          const rectValue = element.getBoundingClientRect();
+          return (
+            style.display !== 'none' &&
+            style.visibility !== 'hidden' &&
+            rectValue.width > 0 &&
+            rectValue.height > 0 &&
+            Number.parseFloat(style.fontSize) < 16
+          );
+        }).length,
+      };
+    });
+    if (!layout.trigger || layout.trigger.height < 44) {
+      issues.push(`${label}: 模块导航触控高度不足 44px`);
+    }
+    if (layout.desktopNavigationDisplay !== 'none') {
+      issues.push(`${label}: 桌面账户导航仍在移动端显示`);
+    }
+    if (page.viewportSize()?.width <= 760 && layout.mobileIdentityDisplay !== 'none') {
+      issues.push(`${label}: 重复的账户身份卡仍在手机端显示`);
+    }
+    if (layout.zoomProneControlCount) {
+      issues.push(`${label}: 存在 ${layout.zoomProneControlCount} 个小于 16px 的表单控件`);
+    }
+    if (!layout.primary || layout.primary.bottom > layout.viewportHeight) {
+      issues.push(
+        `${label}: 大会主操作未进入首屏（按钮底部 ${layout.primary?.bottom ?? '缺失'}px，视口 ${layout.viewportHeight}px）`,
+      );
+    }
+
+    const trigger = page.locator('.account-mobile-navigation__trigger');
+    await trigger.click();
+    const links = page.locator('.account-mobile-navigation__links a');
+    if ((await links.count()) !== 7) {
+      issues.push(`${label}: 模块导航预期 7 个入口，实际为 ${await links.count()} 个`);
+    }
+    const undersizedLinks = await links.evaluateAll((elements) =>
+      elements
+        .map((element) => Math.round(element.getBoundingClientRect().height))
+        .filter((height) => height < 44),
+    );
+    if (undersizedLinks.length) {
+      issues.push(`${label}: 模块导航存在小于 44px 的入口`);
+    }
+    const logoutButton = page.locator('.account-mobile-navigation__meta button');
+    if ((await logoutButton.count()) && (await logoutButton.evaluate((element) => element.offsetHeight)) < 44) {
+      issues.push(`${label}: 导航内退出按钮触控高度不足 44px`);
+    }
+    await page.keyboard.press('Escape');
+    if (await page.locator('#account-mobile-navigation-panel').isVisible()) {
+      issues.push(`${label}: Escape 后模块导航仍然展开`);
+    }
+    if (!(await trigger.evaluate((element) => document.activeElement === element))) {
+      issues.push(`${label}: Escape 关闭导航后焦点没有回到触发按钮`);
+    }
+    await trigger.click();
+    await links.first().focus();
+    await page.keyboard.press('Enter');
+    await page.waitForFunction(() => {
+      const panel = document.querySelector('#account-mobile-navigation-panel');
+      return panel && getComputedStyle(panel).display === 'none';
+    });
+    if (!(await trigger.evaluate((element) => document.activeElement === element))) {
+      issues.push(`${label}: 选择模块后焦点没有回到导航触发按钮`);
+    }
+    checked.push(label);
+  }
+
   const desktop = await browser.newContext({
     viewport: { width: 1440, height: 1000 },
     deviceScaleFactor: 1,
@@ -558,6 +713,9 @@ async function runVisualSmoke() {
   const page = await desktop.newPage();
   watch(page, 'desktop');
   let speakerDetailUrl;
+  let visualCustomerMobile = '';
+  let visualTicketUrl = '';
+  let visualCustomerStorageState;
 
   if (includeWeb) {
     await page.goto(webBase, { waitUntil: 'networkidle' });
@@ -578,21 +736,30 @@ async function runVisualSmoke() {
     await page.locator('.faq-page').waitFor();
     await screenshot(page, 'web-faq-desktop.png', 'FAQ 独立页桌面端');
     await page.goto(`${webBase}/register`, { waitUntil: 'networkidle' });
-    const freeRegistrationButton = page.getByRole('button', { name: '免费报名并领取电子票' });
-    if (
-      (await page.locator('#registration-name').count()) &&
-      (await freeRegistrationButton.count())
-    ) {
-      await page.locator('#registration-name').fill('视觉测试员');
+    const registrationSubmitButton = page.locator('form.flow-card button[type="submit"]');
+    if ((await page.locator('#registration-name').count()) && (await registrationSubmitButton.count())) {
       const visualRunId = Date.now().toString();
-      await page.locator('#registration-mobile').fill(`139${visualRunId.slice(-8)}`);
+      visualCustomerMobile = `139${visualRunId.slice(-8)}`;
+      const registrationMobile = page.locator('#registration-mobile');
+      if (!(await registrationMobile.isEditable())) {
+        await loginCustomer(page, visualCustomerMobile);
+        await page.goto(`${webBase}/register`, { waitUntil: 'networkidle' });
+      }
+      await page.locator('#registration-name').fill('视觉测试员');
+      const verifiedMobile = await page.locator('#registration-mobile').inputValue();
+      if (await page.locator('#registration-mobile').isEditable()) {
+        await page.locator('#registration-mobile').fill(visualCustomerMobile);
+      } else if (!verifiedMobile.endsWith(visualCustomerMobile)) {
+        throw new Error(`报名页登录手机号未正确回填，实际为 ${verifiedMobile || '空'}`);
+      }
       await page.locator('#registration-email').fill(`visual-${visualRunId}@example.com`);
       await page.locator('#registration-city').fill('深圳');
       await page.locator('#registration-company').fill('大会视觉实验室');
       await page.locator('#registration-title').fill('质量负责人');
       await page.getByText('我已阅读并同意').click();
-      await freeRegistrationButton.click();
+      await page.locator('form.flow-card button[type="submit"]').click();
       await page.waitForURL(/\/(order|ticket)\//);
+      visualCustomerStorageState = await desktop.storageState();
       if (new URL(page.url()).pathname.startsWith('/order/')) {
         await screenshot(page, 'web-order-desktop.png', '订单页桌面端');
       } else {
@@ -809,6 +976,102 @@ async function runVisualSmoke() {
     await mobile.goto(`${webBase}/faq`, { waitUntil: 'networkidle' });
     await mobile.locator('.faq-page').waitFor();
     await screenshot(mobile, 'web-faq-mobile.png', 'FAQ 独立页手机端');
+
+    if (visualCustomerMobile) {
+      await captureCustomerLoginMobile(mobile);
+      if (visualCustomerStorageState?.cookies.length) {
+        await mobileContext.addCookies(visualCustomerStorageState.cookies);
+      }
+      await mobile.goto(`${webBase}/account`, { waitUntil: 'networkidle' });
+      await mobile.getByRole('heading', { name: '个人中心', level: 1 }).waitFor();
+      await assertAccountMobileBaseline(mobile, '个人中心手机端');
+      const ticketHref = await mobile.locator('.account-pass__primary').getAttribute('href');
+      if (ticketHref?.startsWith('/ticket/')) {
+        visualTicketUrl = new URL(ticketHref, webBase).toString();
+      }
+      await screenshot(mobile, 'web-account-mobile.png', '个人中心手机端');
+
+      await mobile.setViewportSize({ width: 430, height: 932 });
+      await mobile.goto(`${webBase}/account`, { waitUntil: 'networkidle' });
+      await assertAccountMobileBaseline(mobile, '个人中心 430px 手机端');
+      await screenshot(mobile, 'web-account-mobile-430.png', '个人中心 430px 手机端');
+      await mobile.setViewportSize({ width: 375, height: 667 });
+      await mobile.goto(`${webBase}/account`, { waitUntil: 'networkidle' });
+      await assertAccountMobileBaseline(mobile, '个人中心 375px 紧凑手机端');
+      await screenshot(mobile, 'web-account-mobile-375.png', '个人中心 375px 紧凑手机端');
+      await mobile.setViewportSize({ width: 768, height: 1024 });
+      await mobile.goto(`${webBase}/account`, { waitUntil: 'networkidle' });
+      await assertAccountMobileBaseline(mobile, '个人中心 768px 平板端');
+      await screenshot(mobile, 'web-account-tablet-768.png', '个人中心 768px 平板端');
+      await mobile.setViewportSize({ width: 390, height: 844 });
+      await mobile.goto(`${webBase}/account`, { waitUntil: 'networkidle' });
+
+      const registrationDetailHref = await mobile
+        .getByRole('link', { name: '报名详情' })
+        .first()
+        .getAttribute('href');
+      if (registrationDetailHref) {
+        await mobile.goto(new URL(registrationDetailHref, webBase).toString(), {
+          waitUntil: 'networkidle',
+        });
+        await mobile.locator('.detail-panel').waitFor();
+        const emptyDetailFooter = await mobile
+          .locator('.detail-panel footer')
+          .evaluateAll((elements) =>
+            elements.some(
+              (element) =>
+                getComputedStyle(element).display !== 'none' && element.children.length === 0,
+            ),
+          );
+        if (emptyDetailFooter) {
+          issues.push('报名详情手机端: 无可用操作时仍显示空白操作栏');
+        }
+        await screenshot(mobile, 'web-account-registration-mobile.png', '报名详情手机端');
+
+        const showcaseLink = mobile.getByRole('link', { name: '完善参会名片' });
+        const showcaseHref = (await showcaseLink.count())
+          ? await showcaseLink.getAttribute('href')
+          : null;
+        if (showcaseHref) {
+          await mobile.goto(new URL(showcaseHref, webBase).toString(), {
+            waitUntil: 'domcontentloaded',
+          });
+          await mobile.locator('.profile-editor').waitFor();
+          await screenshot(mobile, 'web-account-showcase-mobile.png', '参会名片手机端');
+        }
+
+        await mobile.goto(new URL(registrationDetailHref, webBase).toString(), {
+          waitUntil: 'networkidle',
+        });
+        const needsLink = mobile.getByRole('link', { name: '编辑参会需求' });
+        const needsHref = (await needsLink.count()) ? await needsLink.getAttribute('href') : null;
+        if (needsHref) {
+          await mobile.goto(new URL(needsHref, webBase).toString(), {
+            waitUntil: 'networkidle',
+          });
+          await mobile.locator('.needs-editor').waitFor();
+          await screenshot(mobile, 'web-account-needs-mobile.png', '参会需求手机端');
+        }
+      } else {
+        issues.push('个人中心手机端: 缺少可用于二级页面验收的报名详情入口');
+      }
+
+      await mobile.goto(`${webBase}/account/attendee-claim`, { waitUntil: 'networkidle' });
+      await mobile.getByRole('heading', { name: '认领链接不完整', level: 2 }).waitFor();
+      await screenshot(mobile, 'web-account-claim-mobile.png', '参会名额认领手机端');
+
+      await mobile.goto(`${webBase}/account/invoices`, { waitUntil: 'networkidle' });
+      await mobile.getByRole('heading', { name: '发票中心', level: 1 }).waitFor();
+      await screenshot(mobile, 'web-account-invoices-mobile.png', '发票中心手机端');
+
+      if (visualTicketUrl) {
+        await mobile.goto(visualTicketUrl, { waitUntil: 'networkidle' });
+        await mobile.getByText('现场扫码签到').waitFor();
+        await screenshot(mobile, 'web-ticket-mobile.png', '电子票手机端');
+      }
+    } else {
+      issues.push('个人中心手机端: 免费报名流程没有生成可登录的演示账号');
+    }
   }
 
   const mobileAdmin = await mobileContext.newPage();


### PR DESCRIPTION
## 变更概览

- 优化个人中心首屏和大会服务台在 320px 至 768px 屏幕下的响应式布局。
- 统一报名详情、参会需求、个人名片、票券和发票页面的移动端字号、触控区域与操作反馈。
- 补齐移动导航的键盘关闭、焦点恢复和查询参数切换行为。
- 修复待支付报名详情空白操作栏、步骤条空数据和移动端重复账户卡片。
- 加固视觉质检脚本对付费票、登录态、验证码频控和多视口场景的覆盖。
- 保持账户敏感区域进入大会官网时的整页导航和统计隔离。

## 质检

- pnpm lint
- pnpm turbo run typecheck test build --force
- pnpm canonical:check
- git diff --check

## 移动端验收

- 覆盖 320、360、375、390、430 和 768px 宽度。
- 验证无横向溢出、16px 可编辑输入字号、44px 触控区域和首屏主操作。
- 验证移动菜单 Escape 关闭、键盘选择和焦点恢复。
- 验证登录弹窗、报名详情和发票中心的移动端布局。