### PR TITLE
优化合作页微信联系模块布局

### DIFF
--- a/apps/web/app/pages/apply/cooperation.vue
+++ b/apps/web/app/pages/apply/cooperation.vue
@@ -4,7 +4,6 @@ import { createError, onBeforeUnmount, useAsyncData } from '#imports';
 import { copyPlainText } from '~/utils/copy-text';
 
 const organizerContact = {
-  name: '姚金刚',
   wechatId: 'laoyaoke',
   qrSrc: '/images/contacts/yao-jingang-wechat.jpg',
 } as const;
@@ -149,13 +148,23 @@ const homeHref = computed(() => publicEventHomePath(event.value!.slug));
           <p class="cooperation-scope__other">
             有其他合作想法，也欢迎直接沟通。我们会结合大会内容和现场安排一起判断可行方式。
           </p>
+
+          <section class="conversation-guide" aria-labelledby="conversation-guide-title">
+            <div class="conversation-guide__head">
+              <p class="flow-eyebrow">LET'S TALK</p>
+              <h2 id="conversation-guide-title">首次沟通建议带上</h2>
+            </div>
+            <ol>
+              <li v-for="item in conversationGuide" :key="item.no">
+                <span>{{ item.no }}</span>
+                <strong>{{ item.label }}</strong>
+                <p>{{ item.detail }}</p>
+              </li>
+            </ol>
+          </section>
         </div>
 
-        <aside class="direct-contact" aria-labelledby="direct-contact-title">
-          <p class="direct-contact__eyebrow">DIRECT CONTACT</p>
-          <h2 id="direct-contact-title">加微信，聊合作</h2>
-          <p class="direct-contact__lead">微信沟通更直接，也方便后续发送合作资料。</p>
-
+        <aside class="direct-contact" aria-label="大会合作微信">
           <figure class="direct-contact__qr">
             <img
               :src="organizerContact.qrSrc"
@@ -164,46 +173,21 @@ const homeHref = computed(() => publicEventHomePath(event.value!.slug));
               alt="姚金刚微信二维码"
               decoding="async"
             />
-            <figcaption>长按保存图片，或截图后在微信中识别</figcaption>
           </figure>
 
-          <dl class="direct-contact__details">
-            <div>
-              <dt>微信联系人</dt>
-              <dd>{{ organizerContact.name }}</dd>
-            </div>
-            <div>
-              <dt>微信号</dt>
-              <dd class="direct-contact__wechat-id">
-                <code>{{ organizerContact.wechatId }}</code>
-                <button type="button" @click="copyWechatId">
-                  {{ copyStatus === '微信号已复制' ? '已复制' : '复制' }}
-                </button>
-              </dd>
-            </div>
-          </dl>
+          <div class="direct-contact__wechat">
+            <span>微信号</span>
+            <code>{{ organizerContact.wechatId }}</code>
+            <button type="button" @click="copyWechatId">
+              {{ copyStatus === '微信号已复制' ? '已复制' : '复制' }}
+            </button>
+          </div>
 
-          <p class="direct-contact__note">
-            添加好友后，请备注「大会合作＋公司名＋姓名」，方便快速确认来意。
-          </p>
+          <p class="direct-contact__note">添加好友请备注「大会合作＋公司名＋姓名」</p>
           <p class="direct-contact__copy-status" role="status" aria-live="polite">
             {{ copyStatus }}
           </p>
         </aside>
-      </section>
-
-      <section class="conversation-guide" aria-labelledby="conversation-guide-title">
-        <div class="conversation-guide__head">
-          <p class="flow-eyebrow">LET'S TALK</p>
-          <h2 id="conversation-guide-title">沟通时带上这些信息</h2>
-        </div>
-        <ol>
-          <li v-for="item in conversationGuide" :key="item.no">
-            <span>{{ item.no }}</span>
-            <strong>{{ item.label }}</strong>
-            <p>{{ item.detail }}</p>
-          </li>
-        </ol>
       </section>
     </main>
   </div>
@@ -284,9 +268,13 @@ const homeHref = computed(() => publicEventHomePath(event.value!.slug));
 .cooperation-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 360px;
-  align-items: start;
+  align-items: stretch;
   gap: clamp(40px, 5vw, 64px);
   padding: 52px 0 56px;
+}
+
+.cooperation-scope {
+  min-width: 0;
 }
 
 .cooperation-section-head {
@@ -366,39 +354,17 @@ const homeHref = computed(() => publicEventHomePath(event.value!.slug));
 }
 
 .direct-contact {
-  padding: 34px 32px 32px;
+  display: grid;
+  align-content: center;
+  padding: 30px 32px 28px;
   border-radius: 0 0 18px 18px;
   background: #1d4ed8;
   color: #eff6ff;
 }
 
-.direct-contact__eyebrow {
-  margin: 0 0 9px;
-  color: #bfdbfe;
-  font-family: var(--conference-font-mono);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.13em;
-}
-
-.direct-contact h2 {
-  margin: 0;
-  color: #f8fafc;
-  font-size: 28px;
-  line-height: 1.2;
-  text-wrap: balance;
-}
-
-.direct-contact__lead {
-  margin: 10px 0 24px;
-  color: rgb(239 246 255 / 76%);
-  font-size: 13px;
-  line-height: 1.7;
-}
-
 .direct-contact__qr {
-  width: min(100%, 248px);
-  margin: 0 auto 25px;
+  width: min(100%, 236px);
+  margin: 0 auto 24px;
   overflow: hidden;
   border-radius: 8px;
   outline: 1px solid rgb(23 23 23 / 10%);
@@ -413,59 +379,31 @@ const homeHref = computed(() => publicEventHomePath(event.value!.slug));
   background: #fff;
 }
 
-.direct-contact__qr figcaption {
-  padding: 10px 12px 11px;
-  color: #64748b;
-  font-size: 10px;
-  line-height: 1.5;
-  text-align: center;
-}
-
-.direct-contact__details {
-  margin: 0;
+.direct-contact__wechat {
+  display: grid;
+  min-height: 52px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
   border-top: 1px solid rgb(239 246 255 / 24%);
   border-bottom: 1px solid rgb(239 246 255 / 24%);
 }
 
-.direct-contact__details > div {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 18px;
-  padding: 12px 0;
-}
-
-.direct-contact__details > div + div {
-  border-top: 1px solid rgb(239 246 255 / 18%);
-}
-
-.direct-contact__details dt {
+.direct-contact__wechat > span {
   color: rgb(239 246 255 / 58%);
   font-size: 11px;
   letter-spacing: 0.05em;
 }
 
-.direct-contact__details dd {
-  margin: 0;
+.direct-contact__wechat code {
   color: #f8fafc;
-  font-size: 15px;
-  font-weight: 750;
-}
-
-.direct-contact__wechat-id {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.direct-contact__wechat-id code {
-  color: inherit;
   font-family: var(--conference-font-mono);
   font-size: 14px;
+  font-weight: 750;
   user-select: all;
 }
 
-.direct-contact__wechat-id button {
+.direct-contact__wechat button {
   min-height: 32px;
   padding: 0 10px;
   border: 1px solid rgb(239 246 255 / 36%);
@@ -478,18 +416,18 @@ const homeHref = computed(() => publicEventHomePath(event.value!.slug));
     transform 120ms ease;
 }
 
-.direct-contact__wechat-id button:hover {
+.direct-contact__wechat button:hover {
   background: rgb(239 246 255 / 12%);
 }
 
-.direct-contact__wechat-id button:active {
+.direct-contact__wechat button:active {
   transform: scale(0.96);
 }
 
 .direct-contact__note {
-  margin: 18px 0 0;
+  margin: 16px 0 0;
   color: rgb(239 246 255 / 72%);
-  font-size: 12px;
+  font-size: 11px;
   line-height: 1.7;
   text-align: center;
 }
@@ -505,10 +443,16 @@ const homeHref = computed(() => publicEventHomePath(event.value!.slug));
 
 .conversation-guide {
   display: grid;
-  grid-template-columns: minmax(220px, 0.8fr) minmax(0, 2.2fr);
-  gap: clamp(40px, 6vw, 76px);
-  padding: 42px 0 0;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: clamp(28px, 4vw, 46px);
+  margin-top: 28px;
+  padding: 28px 0 0;
   border-top: 1px solid var(--line);
+}
+
+.conversation-guide__head h2 {
+  font-size: 20px;
+  line-height: 1.4;
 }
 
 .conversation-guide ol {
@@ -569,7 +513,17 @@ const homeHref = computed(() => publicEventHomePath(event.value!.slug));
 
   .conversation-guide {
     grid-template-columns: 1fr;
-    gap: 28px;
+    gap: 20px;
+  }
+
+  .conversation-guide ol {
+    grid-template-columns: 1fr 1fr;
+    row-gap: 20px;
+  }
+
+  .conversation-guide li:nth-child(3) {
+    padding-left: 0;
+    border-left: 0;
   }
 }
 
@@ -603,18 +557,14 @@ const homeHref = computed(() => publicEventHomePath(event.value!.slug));
 
   .direct-contact {
     order: -1;
-    padding: 30px 22px 27px;
-  }
-
-  .direct-contact h2 {
-    font-size: 27px;
+    padding: 26px 22px 24px;
   }
 
   .direct-contact__qr {
-    width: min(100%, 236px);
+    width: min(100%, 224px);
   }
 
-  .direct-contact__wechat-id button {
+  .direct-contact__wechat button {
     min-height: 44px;
   }
 


### PR DESCRIPTION
## 变更

- 精简蓝色联系卡，仅保留二维码、微信号、复制按钮与好友备注提示
- 将首次沟通建议收进左侧内容区，补足原有留白
- 桌面端左右模块等高，移动端保持单列与无横向溢出

## 验证

- `pnpm check`
- `pnpm canonical:check`
- Playwright 桌面端 1440px 与移动端 375px 视觉验证
- 微信号复制成功态验证