### PR TITLE
fix: serve organizer QR through internal storage

### DIFF
--- a/apps/api/src/common/attendee-service-hub.service.test.ts
+++ b/apps/api/src/common/attendee-service-hub.service.test.ts
@@ -124,4 +124,37 @@ describe('organizer QR asset isolation', () => {
       templates.publicAssetUrl('30000000-0000-4000-8000-000000000001'),
     ).rejects.toMatchObject({ status: 404 });
   });
+
+  it('returns an internal storage URL for server-side private asset reads', async () => {
+    vi.stubEnv('S3_ENDPOINT', 'http://minio:9000');
+    vi.stubEnv('S3_PUBLIC_ENDPOINT', 'http://localhost:19000');
+    vi.stubEnv('S3_ACCESS_KEY', 'test-access');
+    vi.stubEnv('S3_SECRET_KEY', 'test-secret');
+    vi.stubEnv('S3_BUCKET', 'tokems');
+
+    const limit = vi.fn().mockResolvedValue([
+      { storageKey: 'attendee-organizer-qr/org-1/organizer-wechat.png' },
+    ]);
+    const database = {
+      db: {
+        select: vi.fn(() => ({
+          from: vi.fn(() => ({
+            where: vi.fn(() => ({ limit })),
+          })),
+        })),
+      },
+    };
+    const templates = new TemplateOperationsService(database as never);
+
+    try {
+      const url = await templates.protectedAssetUrl(
+        '10000000-0000-4000-8000-000000000001',
+        '30000000-0000-4000-8000-000000000001',
+      );
+
+      expect(new URL(url).origin).toBe('http://minio:9000');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
 });

--- a/apps/api/src/common/template-operations.service.ts
+++ b/apps/api/src/common/template-operations.service.ts
@@ -1540,7 +1540,7 @@ export class TemplateOperationsService {
     if (!asset) {
       throw new DomainError(API_ERROR_CODES.NOT_FOUND, '模板图片不存在', HttpStatus.NOT_FOUND);
     }
-    const url = this.s3Presigned(asset.storageKey, 'GET');
+    const url = this.s3Presigned(asset.storageKey, 'GET', undefined, process.env.S3_ENDPOINT);
     if (!url) {
       throw new DomainError(
         API_ERROR_CODES.INVALID_STATE_TRANSITION,


### PR DESCRIPTION
## Summary
- generate private organizer QR read URLs with the internal object-storage endpoint
- keep browser-facing upload and public preview URLs unchanged
- add a regression test for split internal/public S3 endpoints

## Verification
- pnpm check
- pnpm --filter @conference/api typecheck
- pnpm --filter @conference/api test