### PR TITLE
feat: add verified low-memory production releases

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,455 @@
+name: tokems-image-publish
+
+on:
+  workflow_run:
+    workflows: [tokems-ci]
+    types: [completed]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: tokems-image-publish-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+env:
+  GHCR_PACKAGE: ghcr.io/yaojingang/tokems
+
+jobs:
+  guard:
+    name: Verify CI source and release identity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      target_sha: ${{ steps.identity.outputs.target_sha }}
+      build_time: ${{ steps.identity.outputs.build_time }}
+      migration: ${{ steps.identity.outputs.migration }}
+      migration_hash: ${{ steps.identity.outputs.migration_hash }}
+      platform: ${{ steps.identity.outputs.platform }}
+      reuse: ${{ steps.existing.outputs.reuse }}
+    env:
+      PRODUCTION_PLATFORM: ${{ vars.PRODUCTION_PLATFORM }}
+      TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+      WORKFLOW_SHA: ${{ github.sha }}
+    steps:
+      - name: Validate completed workflow provenance
+        id: verify
+        env:
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          WORKFLOW_RUN_JSON: ${{ toJson(github.event.workflow_run) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          from types import SimpleNamespace
+
+          workflow_run = json.loads(
+              os.environ['WORKFLOW_RUN_JSON'],
+              object_hook=lambda value: SimpleNamespace(**value),
+          )
+          expected_repository = os.environ['EXPECTED_REPOSITORY']
+          if workflow_run.event != 'push':
+              raise SystemExit('image publication accepts only a main push CI run')
+          if workflow_run.head_branch != 'main':
+              raise SystemExit('image publication accepts only the main branch')
+          if workflow_run.status != 'completed':
+              raise SystemExit('upstream CI has not completed')
+          if workflow_run.conclusion != 'success':
+              raise SystemExit('upstream CI did not succeed')
+          if workflow_run.repository.full_name != expected_repository:
+              raise SystemExit('workflow repository does not match the official repository')
+          if workflow_run.head_repository.full_name != expected_repository:
+              raise SystemExit('workflow head repository does not match the official repository')
+          if not re.fullmatch(r'[0-9a-f]{40}', workflow_run.head_sha):
+              raise SystemExit('upstream CI did not provide a full lowercase commit SHA')
+          if workflow_run.head_sha != os.environ['TARGET_SHA']:
+              raise SystemExit('workflow payload and target SHA differ')
+          if os.environ.get('WORKFLOW_SHA') != workflow_run.head_sha:
+              raise SystemExit('default branch advanced before image publication; only the latest SHA may publish')
+          platform = os.environ.get('PRODUCTION_PLATFORM', '')
+          if platform not in {'linux/amd64', 'linux/arm64'}:
+              raise SystemExit('repository variable PRODUCTION_PLATFORM must be linux/amd64 or linux/arm64')
+          PY
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 1
+      - name: Derive one build identity
+        id: identity
+        run: |
+          set -Eeuo pipefail
+          migration="$(find packages/database/drizzle -maxdepth 1 -type f -name '[0-9][0-9][0-9][0-9]_*.sql' -print | sort | tail -n 1)"
+          test -n "$migration"
+          migration="$(basename "$migration")"
+          migration_hash="$(sha256sum "packages/database/drizzle/$migration" | awk '{print $1}')"
+          build_time="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+          {
+            echo "target_sha=$TARGET_SHA"
+            echo "build_time=$build_time"
+            echo "migration=$migration"
+            echo "migration_hash=$migration_hash"
+            echo "platform=$PRODUCTION_PLATFORM"
+          } >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Reuse a previously completed immutable release
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_TIME: ${{ steps.identity.outputs.build_time }}
+          BUILD_MIGRATION: ${{ steps.identity.outputs.migration }}
+          BUILD_MIGRATION_HASH: ${{ steps.identity.outputs.migration_hash }}
+        run: |
+          set -Eeuo pipefail
+          package_error="$RUNNER_TEMP/package-visibility.err"
+          package_visibility=''
+          if ! package_visibility="$(gh api /users/yaojingang/packages/container/tokems --jq .visibility 2>"$package_error")"; then
+            if ! grep -Eq 'HTTP 404|Not Found' "$package_error"; then
+              cat "$package_error" >&2
+              echo 'Unable to establish TokEMS GHCR package visibility before publication.' >&2
+              exit 1
+            fi
+          fi
+          if [[ -n "$package_visibility" && "$package_visibility" != private ]]; then
+            echo 'The TokEMS GHCR package must remain private.' >&2
+            exit 1
+          fi
+          release_ref="${GHCR_PACKAGE}:release-${TARGET_SHA}"
+          labels_file="$RUNNER_TEMP/release-labels.json"
+          inspect_error="$RUNNER_TEMP/release-inspect.err"
+          set +e
+          descriptor_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$release_ref" 2> "$inspect_error")"
+          inspect_status=$?
+          set -e
+          if [[ $inspect_status -ne 0 ]]; then
+            if grep -Eiq 'manifest unknown|not found|no such manifest' "$inspect_error"; then
+              echo 'reuse=false' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            cat "$inspect_error" >&2
+            exit "$inspect_status"
+          fi
+          [[ "$package_visibility" == private ]] || {
+            echo 'Unable to confirm that the existing TokEMS GHCR package is private.' >&2
+            exit 1
+          }
+          [[ "$descriptor_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          descriptor_ref="${GHCR_PACKAGE}@${descriptor_digest}"
+          docker buildx imagetools inspect --format '{{json .Image.Config.Labels}}' "$descriptor_ref" > "$labels_file"
+
+          records_file="$RUNNER_TEMP/release-records.tsv"
+          python3 tooling/release-descriptor.py verify-descriptor \
+            --labels-file "$labels_file" \
+            --target-sha "$TARGET_SHA" \
+            --platform "$PRODUCTION_PLATFORM" \
+            --records-output "$records_file"
+          gh attestation verify "oci://${GHCR_PACKAGE}@${descriptor_digest}" \
+            --repo yaojingang/TokEMS \
+            --signer-workflow yaojingang/TokEMS/.github/workflows/publish-images.yml \
+            --source-digest "$TARGET_SHA" \
+            --source-ref refs/heads/main \
+            --deny-self-hosted-runners >/dev/null
+
+          source_bundle_hash="$(awk -F '\t' '$1 == "release" && $2 == "source-bundle-sha256" {print $3}' "$records_file")"
+          verifier_hash="$(awk -F '\t' '$1 == "release" && $2 == "verifier-sha256" {print $3}' "$records_file")"
+          payload_dir="$RUNNER_TEMP/reused-descriptor-payload"
+          mkdir -p "$payload_dir"
+          docker pull --platform "$PRODUCTION_PLATFORM" "$descriptor_ref" >/dev/null
+          descriptor_container="$(docker create "$descriptor_ref" /release/source.bundle)"
+          cleanup_descriptor_container() {
+            if [[ -n "${descriptor_container:-}" ]]; then
+              docker rm -f "$descriptor_container" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup_descriptor_container EXIT
+          docker cp "${descriptor_container}:/release/source.bundle" "$payload_dir/source.bundle"
+          docker cp "${descriptor_container}:/release/release-descriptor.py" "$payload_dir/release-descriptor.py"
+          cleanup_descriptor_container
+          descriptor_container=''
+          [[ "$(sha256sum "$payload_dir/source.bundle" | awk '{print $1}')" == "$source_bundle_hash" ]]
+          [[ "$(sha256sum "$payload_dir/release-descriptor.py" | awk '{print $1}')" == "$verifier_hash" ]]
+          [[ "$(sha256sum tooling/release-descriptor.py | awk '{print $1}')" == "$verifier_hash" ]]
+          python3 tooling/release-descriptor.py verify-source-bundle \
+            --bundle-file "$payload_dir/source.bundle" \
+            --target-sha "$TARGET_SHA"
+          trap - EXIT
+
+          build_time="$(awk -F '\t' '$1 == "build" && $2 == "time" {print $3}' "$records_file")"
+          migration="$(awk -F '\t' '$1 == "build" && $2 == "migration" {print $3}' "$records_file")"
+          migration_hash="$(awk -F '\t' '$1 == "build" && $2 == "migration-hash" {print $3}' "$records_file")"
+          while IFS=$'\t' read -r record_type service image_ref; do
+            [[ "$record_type" == image ]] || continue
+            metadata_file="$RUNNER_TEMP/image-${service}.json"
+            docker buildx imagetools inspect --format '{{json .Image}}' "$image_ref" > "$metadata_file"
+            python3 tooling/release-descriptor.py verify-service \
+              --metadata-file "$metadata_file" \
+              --service "$service" \
+              --target-sha "$TARGET_SHA" \
+              --build-time "$build_time" \
+              --migration "$migration" \
+              --migration-hash "$migration_hash" \
+              --platform "$PRODUCTION_PLATFORM"
+            gh attestation verify "oci://${image_ref}" \
+              --repo yaojingang/TokEMS \
+              --signer-workflow yaojingang/TokEMS/.github/workflows/publish-images.yml \
+              --source-digest "$TARGET_SHA" \
+              --source-ref refs/heads/main \
+              --deny-self-hosted-runners >/dev/null
+          done < "$records_file"
+          echo 'reuse=true' >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.service }}
+    needs: guard
+    if: needs.guard.outputs.reuse == 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - api
+          - worker
+          - web
+          - admin
+          - gateway
+          - notification-sink
+    env:
+      TARGET_SHA: ${{ needs.guard.outputs.target_sha }}
+      BUILD_TIME: ${{ needs.guard.outputs.build_time }}
+      BUILD_MIGRATION: ${{ needs.guard.outputs.migration }}
+      BUILD_MIGRATION_HASH: ${{ needs.guard.outputs.migration_hash }}
+      PRODUCTION_PLATFORM: ${{ needs.guard.outputs.platform }}
+      SERVICE: ${{ matrix.service }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.guard.outputs.target_sha }}
+          fetch-depth: 1
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Build and push immutable service image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          target: ${{ matrix.service }}
+          platforms: ${{ needs.guard.outputs.platform }}
+          push: true
+          provenance: false
+          tags: ${{ env.GHCR_PACKAGE }}:${{ matrix.service }}-${{ needs.guard.outputs.target_sha }}-${{ github.run_id }}
+          build-args: |
+            BUILD_SHA=${{ needs.guard.outputs.target_sha }}
+            BUILD_TIME=${{ needs.guard.outputs.build_time }}
+            BUILD_MIGRATION=${{ needs.guard.outputs.migration }}
+            BUILD_MIGRATION_HASH=${{ needs.guard.outputs.migration_hash }}
+            NUXT_PUBLIC_API_BASE=/api/v1
+            NUXT_PUBLIC_ORGANIZATION_SLUG=geo-conference
+            VITE_API_BASE=/api/v1
+            VITE_ADMIN_BASE=/admin/
+            VITE_SIMPLE_AUTH=false
+          cache-from: type=gha,scope=tokems-${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=tokems-${{ matrix.service }}
+      - name: Attest service image provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.GHCR_PACKAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+      - name: Save service digest
+        run: |
+          set -Eeuo pipefail
+          mkdir -p "$RUNNER_TEMP/tokems-digest"
+          printf '%s\n' '${{ steps.build.outputs.digest }}' > "$RUNNER_TEMP/tokems-digest/${SERVICE}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tokems-digest-${{ matrix.service }}
+          path: ${{ runner.temp }}/tokems-digest/${{ matrix.service }}
+          if-no-files-found: error
+          retention-days: 1
+
+  descriptor:
+    name: Publish atomic release descriptor
+    needs: [guard, build]
+    if: ${{ always() && needs.guard.result == 'success' && needs.guard.outputs.reuse == 'false' && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TARGET_SHA: ${{ needs.guard.outputs.target_sha }}
+      BUILD_TIME: ${{ needs.guard.outputs.build_time }}
+      BUILD_MIGRATION: ${{ needs.guard.outputs.migration }}
+      BUILD_MIGRATION_HASH: ${{ needs.guard.outputs.migration_hash }}
+      PRODUCTION_PLATFORM: ${{ needs.guard.outputs.platform }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.guard.outputs.target_sha }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: tokems-digest-*
+          path: ${{ runner.temp }}/tokems-digests
+          merge-multiple: true
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Resolve the six digest-pinned image references
+        id: images
+        run: |
+          set -Eeuo pipefail
+          for service in api worker web admin gateway notification-sink; do
+            digest_file="$RUNNER_TEMP/tokems-digests/$service"
+            test -s "$digest_file"
+            digest="$(cat "$digest_file")"
+            [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+            output_name="${service//-/_}_image"
+            echo "${output_name}=${GHCR_PACKAGE}@${digest}" >> "$GITHUB_OUTPUT"
+          done
+      - name: Require a private GHCR package
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          visibility="$(gh api /users/yaojingang/packages/container/tokems --jq .visibility)"
+          [[ "$visibility" == private ]] || {
+            echo 'The TokEMS GHCR package must remain private.' >&2
+            exit 1
+          }
+      - name: Build and verify the exact source bundle
+        id: source
+        run: |
+          set -Eeuo pipefail
+          source_ref='refs/heads/tokems-release-source'
+          source_dir="$RUNNER_TEMP/tokems-release-context"
+          bundle_file="$source_dir/source.bundle"
+          mkdir -p "$source_dir"
+          if git show-ref --verify --quiet "$source_ref"; then
+            echo "Temporary source bundle ref already exists: ${source_ref}" >&2
+            exit 1
+          fi
+          cleanup_source_ref() {
+            git update-ref -d "$source_ref" >/dev/null 2>&1 || true
+          }
+          trap cleanup_source_ref EXIT
+          git update-ref "$source_ref" "$TARGET_SHA"
+          git bundle create "$bundle_file" "$source_ref"
+          git bundle verify "$bundle_file"
+          [[ "$(git bundle list-heads "$bundle_file" "$source_ref")" == "$TARGET_SHA $source_ref" ]]
+          bundle_sha256="$(sha256sum "$bundle_file" | awk '{print $1}')"
+          verifier_sha256="$(sha256sum tooling/release-descriptor.py | awk '{print $1}')"
+          [[ "$bundle_sha256" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$verifier_sha256" =~ ^[0-9a-f]{64}$ ]]
+          {
+            echo "bundle_sha256=$bundle_sha256"
+            echo "verifier_sha256=$verifier_sha256"
+          } >> "$GITHUB_OUTPUT"
+          cleanup_source_ref
+          trap - EXIT
+      - name: Build the release descriptor candidate
+        id: descriptor
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          build-contexts: |
+            release=${{ runner.temp }}/tokems-release-context
+          file: tooling/release-descriptor.Dockerfile
+          platforms: ${{ needs.guard.outputs.platform }}
+          push: true
+          provenance: false
+          tags: ${{ env.GHCR_PACKAGE }}:descriptor-${{ needs.guard.outputs.target_sha }}-${{ github.run_id }}
+          build-args: |
+            BUILD_SHA=${{ needs.guard.outputs.target_sha }}
+            BUILD_TIME=${{ needs.guard.outputs.build_time }}
+            BUILD_MIGRATION=${{ needs.guard.outputs.migration }}
+            BUILD_MIGRATION_HASH=${{ needs.guard.outputs.migration_hash }}
+            RELEASE_PLATFORM=${{ needs.guard.outputs.platform }}
+            SOURCE_BUNDLE_SHA256=${{ steps.source.outputs.bundle_sha256 }}
+            VERIFIER_SHA256=${{ steps.source.outputs.verifier_sha256 }}
+            API_IMAGE=${{ steps.images.outputs.api_image }}
+            WORKER_IMAGE=${{ steps.images.outputs.worker_image }}
+            WEB_IMAGE=${{ steps.images.outputs.web_image }}
+            ADMIN_IMAGE=${{ steps.images.outputs.admin_image }}
+            GATEWAY_IMAGE=${{ steps.images.outputs.gateway_image }}
+            NOTIFICATION_SINK_IMAGE=${{ steps.images.outputs.notification_sink_image }}
+      - name: Attest release descriptor provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.GHCR_PACKAGE }}
+          subject-digest: ${{ steps.descriptor.outputs.digest }}
+          push-to-registry: true
+      - name: Verify the descriptor payload before publication
+        env:
+          SOURCE_BUNDLE_SHA256: ${{ steps.source.outputs.bundle_sha256 }}
+          VERIFIER_SHA256: ${{ steps.source.outputs.verifier_sha256 }}
+        run: |
+          set -Eeuo pipefail
+          payload_dir="$RUNNER_TEMP/candidate-descriptor-payload"
+          mkdir -p "$payload_dir"
+          descriptor_ref="${GHCR_PACKAGE}@${{ steps.descriptor.outputs.digest }}"
+          docker pull --platform "$PRODUCTION_PLATFORM" "$descriptor_ref" >/dev/null
+          descriptor_container="$(docker create "$descriptor_ref" /release/source.bundle)"
+          cleanup_descriptor_container() {
+            if [[ -n "${descriptor_container:-}" ]]; then
+              docker rm -f "$descriptor_container" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup_descriptor_container EXIT
+          docker cp "${descriptor_container}:/release/source.bundle" "$payload_dir/source.bundle"
+          docker cp "${descriptor_container}:/release/release-descriptor.py" "$payload_dir/release-descriptor.py"
+          cleanup_descriptor_container
+          descriptor_container=''
+          [[ "$(sha256sum "$payload_dir/source.bundle" | awk '{print $1}')" == "$SOURCE_BUNDLE_SHA256" ]]
+          [[ "$(sha256sum "$payload_dir/release-descriptor.py" | awk '{print $1}')" == "$VERIFIER_SHA256" ]]
+          [[ "$(sha256sum tooling/release-descriptor.py | awk '{print $1}')" == "$VERIFIER_SHA256" ]]
+          python3 tooling/release-descriptor.py verify-source-bundle \
+            --bundle-file "$payload_dir/source.bundle" \
+            --target-sha "$TARGET_SHA"
+          trap - EXIT
+      - name: Verify the descriptor proof before publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify "oci://${GHCR_PACKAGE}@${{ steps.descriptor.outputs.digest }}" \
+            --repo yaojingang/TokEMS \
+            --signer-workflow yaojingang/TokEMS/.github/workflows/publish-images.yml \
+            --source-digest "$TARGET_SHA" \
+            --source-ref refs/heads/main \
+            --deny-self-hosted-runners >/dev/null
+      - name: Publish the immutable release descriptor last
+        run: |
+          set -Eeuo pipefail
+          release_ref="${GHCR_PACKAGE}:release-${TARGET_SHA}"
+          error_file="$RUNNER_TEMP/descriptor-final-check.err"
+          if docker buildx imagetools inspect "$release_ref" >/dev/null 2> "$error_file"; then
+            echo 'Refusing to overwrite the immutable release descriptor.' >&2
+            exit 1
+          fi
+          grep -Eiq 'manifest unknown|not found|no such manifest' "$error_file" || {
+            cat "$error_file" >&2
+            exit 1
+          }
+          docker buildx imagetools create \
+            --prefer-index=false \
+            --tag "$release_ref" \
+            "${GHCR_PACKAGE}@${{ steps.descriptor.outputs.digest }}"
+          final_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$release_ref")"
+          [[ "$final_digest" == '${{ steps.descriptor.outputs.digest }}' ]] || {
+            echo 'Final descriptor digest differs from the verified candidate digest.' >&2
+            exit 1
+          }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,12 @@
 - 服务器分支 `production` 跟踪 `origin/main`。发布前确认工作区干净，并确认服务器 `HEAD` 与 `origin/main` 完全一致。
 - 每次生产变更都要先创建数据库备份、记录当前提交和容器状态，并为当前应用镜像添加 `rollback-<时间戳>` 标签。
 - Docker 构建和运行必须使用同一组 `BUILD_SHA`、`BUILD_TIME`、`BUILD_MIGRATION`、`BUILD_MIGRATION_HASH`。任何值为 `unknown` 时禁止切换生产流量。
+- 标准生产发布使用 `.github/workflows/publish-images.yml` 产出的私有 GHCR 预构建镜像。`release-<SHA>` descriptor 必须最后发布，并固定目标平台、四项 `BUILD_*` 和六个服务 digest；生产机验证 GitHub provenance 后才能更新 `tokems-*:local`。
+- Release descriptor schema 2 同时携带目标提交的完整 Git Bundle 和 descriptor verifier，并固定两者 SHA-256。生产机只允许在 descriptor provenance、Bundle 目标 ref、目标 SHA 和 Fast-forward 历史全部通过后更新 `refs/remotes/origin/main`；标准发布不得依赖生产机直连 `github.com` Git Smart HTTP。
+- `/etc/tokems/ghcr-read-token` 仅保存 `read:packages` PAT classic，权限固定为 `root:root 0600`。临时 Docker 登录目录只允许位于 `/run/lock/tokems-production-deploy`，发布日志和证据不得包含 Token。
+- `--build-on-host` 只作为人工应急入口，继续执行 10 GiB 构建内存门禁。自动化受限入口不得传入该参数。
 - 常规发布固定使用 `SEED_DEMO_DATA=false`。只有已确认需要同步仓库规范模板时，才允许按 Runbook 的“规范模板同步”流程临时运行 `SEED_DEMO_DATA=true`。
-- 自动检测到规范漂移或显式执行 `deploy --sync-canonical` 时，目标规范快照与当前运行提交完全一致，且目标差异仅包含部署脚本、部署测试、协作文档或运维文档，脚本允许复用当前已验证镜像完成规范同步。该流程仍要执行数据库备份、写冻结、生产数据保护和完整验收；其余目标继续执行标准镜像构建与 10 GiB 内存门禁。
+- 自动检测到规范漂移或显式执行 `deploy --sync-canonical` 时，目标规范快照与当前运行提交完全一致，且目标差异仅包含部署脚本、部署测试、协作文档或运维文档，脚本允许复用当前已验证镜像完成规范同步。该流程仍要执行数据库备份、写冻结、生产数据保护和完整验收；其余目标使用通过证明的预构建镜像。
 - 自动发布预检必须以只读数据库连接导出生产完整规范快照并与目标提交比较；Git 快照变化或生产状态漂移时都要启用规范同步，`--skip-canonical` 不得跳过漂移修复。
 - 规范模板的组织 slug 为 `geo-conference`，大会 slug 为 `tokems26`。线上报名、订单、票、发票、库存销量和用户数据必须保留。
 - 本地 `http://127.0.0.1:8088/` 当前实际展示的 `geo-conference` / `tokems26` 是唯一规范大会模板。首页文案或关联后台设置发生任何变化后，推送 GitHub 前必须运行 `pnpm canonical:export`，并提交完整规范快照 `packages/contracts/src/canonical-homepage.snapshot.json` 及前台派生快照 `packages/contracts/src/canonical-homepage.public.json`。

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,20 @@ RUN --mount=type=cache,id=tokems-pnpm-store,target=/pnpm/store \
 
 FROM ${NODE_IMAGE} AS api
 
+ARG BUILD_SHA=unknown
+ARG BUILD_TIME=unknown
+ARG BUILD_MIGRATION=unknown
+ARG BUILD_MIGRATION_HASH=unknown
+
+LABEL org.opencontainers.image.source="https://github.com/yaojingang/TokEMS" \
+      org.opencontainers.image.revision="${BUILD_SHA}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      com.tokems.service="api" \
+      com.tokems.build.sha="${BUILD_SHA}" \
+      com.tokems.build.time="${BUILD_TIME}" \
+      com.tokems.build.migration="${BUILD_MIGRATION}" \
+      com.tokems.build.migration-hash="${BUILD_MIGRATION_HASH}"
+
 ENV NODE_ENV=production
 ENV API_PORT=4100
 
@@ -77,6 +91,20 @@ CMD ["node", "dist/main.js"]
 
 FROM ${NODE_IMAGE} AS worker
 
+ARG BUILD_SHA=unknown
+ARG BUILD_TIME=unknown
+ARG BUILD_MIGRATION=unknown
+ARG BUILD_MIGRATION_HASH=unknown
+
+LABEL org.opencontainers.image.source="https://github.com/yaojingang/TokEMS" \
+      org.opencontainers.image.revision="${BUILD_SHA}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      com.tokems.service="worker" \
+      com.tokems.build.sha="${BUILD_SHA}" \
+      com.tokems.build.time="${BUILD_TIME}" \
+      com.tokems.build.migration="${BUILD_MIGRATION}" \
+      com.tokems.build.migration-hash="${BUILD_MIGRATION_HASH}"
+
 ENV NODE_ENV=production
 LABEL com.tokems.worker-ready-protocol="1"
 
@@ -89,6 +117,20 @@ USER node
 CMD ["node", "dist/main.js"]
 
 FROM ${NODE_IMAGE} AS web
+
+ARG BUILD_SHA=unknown
+ARG BUILD_TIME=unknown
+ARG BUILD_MIGRATION=unknown
+ARG BUILD_MIGRATION_HASH=unknown
+
+LABEL org.opencontainers.image.source="https://github.com/yaojingang/TokEMS" \
+      org.opencontainers.image.revision="${BUILD_SHA}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      com.tokems.service="web" \
+      com.tokems.build.sha="${BUILD_SHA}" \
+      com.tokems.build.time="${BUILD_TIME}" \
+      com.tokems.build.migration="${BUILD_MIGRATION}" \
+      com.tokems.build.migration-hash="${BUILD_MIGRATION_HASH}"
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
@@ -106,6 +148,20 @@ CMD ["node", "server/index.mjs"]
 
 FROM nginx:1.31-alpine AS admin
 
+ARG BUILD_SHA=unknown
+ARG BUILD_TIME=unknown
+ARG BUILD_MIGRATION=unknown
+ARG BUILD_MIGRATION_HASH=unknown
+
+LABEL org.opencontainers.image.source="https://github.com/yaojingang/TokEMS" \
+      org.opencontainers.image.revision="${BUILD_SHA}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      com.tokems.service="admin" \
+      com.tokems.build.sha="${BUILD_SHA}" \
+      com.tokems.build.time="${BUILD_TIME}" \
+      com.tokems.build.migration="${BUILD_MIGRATION}" \
+      com.tokems.build.migration-hash="${BUILD_MIGRATION_HASH}"
+
 COPY docker/admin.nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=workspace /workspace/apps/admin/dist/ /usr/share/nginx/html/
 COPY --from=workspace /workspace/.build-info/admin/version.json /usr/share/nginx/html/version.json
@@ -116,6 +172,20 @@ CMD ["nginx", "-g", "daemon off;"]
 
 FROM nginx:1.31-alpine AS gateway
 
+ARG BUILD_SHA=unknown
+ARG BUILD_TIME=unknown
+ARG BUILD_MIGRATION=unknown
+ARG BUILD_MIGRATION_HASH=unknown
+
+LABEL org.opencontainers.image.source="https://github.com/yaojingang/TokEMS" \
+      org.opencontainers.image.revision="${BUILD_SHA}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      com.tokems.service="gateway" \
+      com.tokems.build.sha="${BUILD_SHA}" \
+      com.tokems.build.time="${BUILD_TIME}" \
+      com.tokems.build.migration="${BUILD_MIGRATION}" \
+      com.tokems.build.migration-hash="${BUILD_MIGRATION_HASH}"
+
 COPY docker/gateway.nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=workspace /workspace/.build-info/gateway/version.json /usr/share/nginx/html/version.json
 
@@ -124,6 +194,20 @@ EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]
 
 FROM ${NODE_IMAGE} AS notification-sink
+
+ARG BUILD_SHA=unknown
+ARG BUILD_TIME=unknown
+ARG BUILD_MIGRATION=unknown
+ARG BUILD_MIGRATION_HASH=unknown
+
+LABEL org.opencontainers.image.source="https://github.com/yaojingang/TokEMS" \
+      org.opencontainers.image.revision="${BUILD_SHA}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      com.tokems.service="notification-sink" \
+      com.tokems.build.sha="${BUILD_SHA}" \
+      com.tokems.build.time="${BUILD_TIME}" \
+      com.tokems.build.migration="${BUILD_MIGRATION}" \
+      com.tokems.build.migration-hash="${BUILD_MIGRATION_HASH}"
 
 ENV NODE_ENV=production
 ENV NOTIFICATION_SINK_PORT=4080

--- a/apps/worker/src/notification-access-token-policy.test.ts
+++ b/apps/worker/src/notification-access-token-policy.test.ts
@@ -10,6 +10,7 @@ const persistedToken = {
   sealedToken: 'sealed-token-1',
   expiresAt: new Date('2026-09-01T00:00:00.000Z'),
 };
+const activeTokenNow = new Date('2026-08-16T00:00:00.000Z');
 
 describe('notification access token policy', () => {
   it.each(['queued', 'retrying', 'claimed', 'sending', 'unknown'])(
@@ -19,6 +20,7 @@ describe('notification access token policy', () => {
         planNotificationAccessToken({
           deliveryStatus: status,
           hasPayloadToken: false,
+          now: activeTokenNow,
           persistedToken,
         }),
       ).toBe('reuse');

--- a/docs/generated/project-inventory.json
+++ b/docs/generated/project-inventory.json
@@ -7,5 +7,5 @@
   "databaseTables": 80,
   "apiControllers": 32,
   "apiOperations": 274,
-  "testFiles": 167
+  "testFiles": 169
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,7 +11,7 @@ sudo /usr/local/sbin/tokems-deploy check
 sudo /usr/local/sbin/tokems-deploy deploy
 ```
 
-首次启用前，把现有生产环境文件一次性安装到 `/etc/tokems/production.env`，目录权限为 `root:root 0700`，文件权限为 `root:root 0600`。脚本会为每次运行固定 root-only 环境快照，并从目标 Git 提交创建 root-only 构建上下文；服务器工作区仍由 `ecs-user` 管理，运行与构建均不读取工作区中的实时 `.env`。
+首次启用前，把现有生产环境文件一次性安装到 `/etc/tokems/production.env`，目录权限为 `root:root 0700`，文件权限为 `root:root 0600`。同时把仅有 `read:packages` 权限的 GHCR PAT classic 安装到 `/etc/tokems/ghcr-read-token`，保持 `root:root 0600`。脚本会为每次运行固定 root-only 环境快照，并在 `/run` 中使用临时 Docker 登录目录；服务器工作区仍由 `ecs-user` 管理，运行过程不读取工作区中的实时 `.env`。
 
 历史失败发布导致 `.env` 构建身份与健康运行容器不一致时，先运行 `repair-identity`。该模式验证五类服务和数据库后备份并修正四项 `BUILD_*`，不会重启容器：
 
@@ -27,11 +27,11 @@ sudo /usr/local/sbin/tokems-deploy deploy --resume-recovery
 sudo /usr/local/sbin/tokems-deploy resolve-recovery
 ```
 
-脚本不依赖宿主机 Node.js 或 pnpm。它会验证目标提交来自已合并 PR 且官方 main push 的 `quality-and-flows` 成功，证明运行 API、目标 Compose 和备份操作使用同一个 PostgreSQL 实例，并通过只读导出核对线上完整规范状态与目标快照。Git 快照发生变化或线上已存在漂移时，规范同步会自动启用。标准发布依次执行构建开始备份、镜像回滚标签、root-only 源码与环境快照、Fast-forward、串行镜像构建、写冻结后的最终数据库备份、迁移、规范模板同步、应用容器切换和完整验收。自动检测到规范漂移或显式执行 `deploy --sync-canonical` 时，目标规范快照与运行提交一致、差异仅限部署控制和文档，脚本会复用当前镜像，并执行两轮数据库备份、写冻结、规范同步、数据保护和完整验收。验收包含公开首页和生产数据库重新导出的脱敏完整后台模板快照。备份与日志保存在 `/www/backup/TokEMS/<时间戳>`，容量检查直接读取这个目录实际所在的文件系统。任何资源、Git、CI、Compose、Nginx、数据保护或健康门禁失败都会终止发布。首次修改源码、环境或镜像前会持久化 `RECOVERY_REQUIRED`；数据库写冻结后把阶段更新为 `write-freeze`，完整发布通过后才归档。`pre-write` 阶段的硬中断使用保存于发布备份中的精确恢复脚本离线恢复；受保护窗口由独立的 systemd 监督单元持续守护，部署控制器退出且恢复标记仍存在时反复停止 API/Worker，再由恢复流程收集数据库迁移证据并恢复应用。数据库不可用时继续保留标记并保持 API/Worker 停止。
+脚本不依赖宿主机 Node.js 或 pnpm。它会验证目标提交来自已合并 PR，官方 main push 的 `quality-and-flows` 成功，独立 `tokems-image-publish` 工作流成功，并验证 `release-<SHA>` descriptor 及六个服务镜像的 GitHub provenance。schema 2 descriptor 固定 Git Bundle、verifier、构建时间、最高迁移、迁移哈希、目标平台和六个镜像 digest；服务器验证两份 payload 的 SHA-256、Bundle 固定 ref、精确目标 SHA 和 Fast-forward 历史后更新 `origin/main`，标准路径不依赖 `github.com` Git Smart HTTP。六个候选镜像全部拉取并验证完成后才更新 `tokems-*:local`。随后脚本证明运行 API、目标 Compose 和备份操作使用同一个 PostgreSQL 实例，并通过只读导出核对线上完整规范状态与目标快照。Git 快照发生变化或线上已存在漂移时，规范同步会自动启用。标准发布依次执行源码证明与导入、构建开始备份、镜像回滚标签、root-only 源码与环境快照、Fast-forward、digest 镜像拉取、写冻结后的最终数据库备份、迁移、规范模板同步、应用容器切换和完整验收。自动检测到规范漂移或显式执行 `deploy --sync-canonical` 时，目标规范快照与运行提交一致、差异仅限部署控制和文档，脚本会复用当前镜像，并执行两轮数据库备份、写冻结、规范同步、数据保护和完整验收。验收包含公开首页和生产数据库重新导出的脱敏完整后台模板快照。备份与日志保存在 `/www/backup/TokEMS/<时间戳>`，容量检查直接读取这个目录实际所在的文件系统。任何资源、Git、CI、镜像证明、Compose、Nginx、数据保护或健康门禁失败都会终止发布。首次修改源码、环境或镜像前会持久化 `RECOVERY_REQUIRED`；数据库写冻结后把阶段更新为 `write-freeze`，完整发布通过后才归档。`pre-write` 阶段的硬中断使用保存于发布备份中的精确恢复脚本离线恢复；受保护窗口由独立的 systemd 监督单元持续守护，部署控制器退出且恢复标记仍存在时反复停止 API/Worker，再由恢复流程收集数据库迁移证据并恢复应用。数据库不可用时继续保留标记并保持 API/Worker 停止。
 
-每次标准发布都使用短暂写冻结：镜像构建后停止 API/Worker，重新生成包含构建期间新增交易的最终 dump 和业务基线。稳定业务表按主键索引逐表流式取证；带保留期自动清理的数据在只读阶段单独比对，恢复 Worker 后允许既定清理策略运行。迁移与可选规范同步完成后，以只读 API 和暂停 Worker 的状态验收，随后恢复目标 API/Worker。Worker 完成启动维护后会在容器 tmpfs 写入带构建身份的持久 ready 文件，脚本核对该身份后再复核生产主键、计数和销量。窗口内报名、支付回调、后台保存和异步任务需要依赖调用方重试，正式操作安排在业务低峰。
+每次标准发布都使用短暂写冻结：候选镜像拉取并验证完成后停止 API/Worker，重新生成包含准备期间新增交易的最终 dump 和业务基线。稳定业务表按主键索引逐表流式取证；带保留期自动清理的数据在只读阶段单独比对，恢复 Worker 后允许既定清理策略运行。迁移与可选规范同步完成后，以只读 API 和暂停 Worker 的状态验收，随后恢复目标 API/Worker。Worker 完成启动维护后会在容器 tmpfs 写入带构建身份的持久 ready 文件，脚本核对该身份后再复核生产主键、计数和销量。窗口内报名、支付回调、后台保存和异步任务需要依赖调用方重试，正式操作安排在业务低峰。
 
-生产主机构建至少需要 10 GiB 的 `MemAvailable + SwapFree`，源码文件系统和 Docker 实际数据目录各需要 12 GiB 可用空间。符合兼容条件的 `--sync-canonical` 规范修复不构建镜像，因此跳过构建资源门禁；备份盘、数据库证明、数据保护和验收门禁保持启用。备份盘预检按四倍当前数据库体积加 4 GiB 保留空间计算；构建开始的主键证据生成后，脚本会用实测文件大小重新预算最终备份、只读验收和恢复写入后的证据，并在每个大文件阶段前复核。数据库证明、查询、dump 和迁移均有超时上限。标准入口会拒绝 Compose 基础设施变更；此类发布使用单独维护窗口。需要构建镜像的发布资源不足时先扩容或改用外部预构建镜像。脚本保留历史备份与回滚镜像，清理策略由运维在恢复验证和观察期后单独执行。完整首次安装命令、手工等价步骤和数据库恢复边界见生产 Runbook。
+4 核 8G 生产机的默认发布路径只拉取预构建镜像，跳过 10 GiB 构建内存门禁，继续执行 Docker 磁盘、备份盘、数据库证明、数据保护和验收门禁。人工应急时可显式运行 `check --build-on-host` 与 `deploy --build-on-host`；该路径仍要求至少 10 GiB 的 `MemAvailable + SwapFree`，且源码文件系统和 Docker 数据目录各有 12 GiB 可用空间。符合兼容条件的 `--sync-canonical` 规范修复复用当前镜像。备份盘预检按四倍当前数据库体积加 4 GiB 保留空间计算；构建开始的主键证据生成后，脚本会用实测文件大小重新预算最终备份、只读验收和恢复写入后的证据，并在每个大文件阶段前复核。数据库证明、查询、dump 和迁移均有超时上限。标准入口会拒绝 Compose 基础设施变更；此类发布使用单独维护窗口。脚本保留历史备份与回滚镜像，清理策略由运维在恢复验证和观察期后单独执行。完整首次安装命令、手工等价步骤和数据库恢复边界见生产 Runbook。
 
 ## 本地 Docker 完整部署
 

--- a/docs/production-deployment-runbook.md
+++ b/docs/production-deployment-runbook.md
@@ -42,6 +42,8 @@ TokEMS 使用根目录多阶段 `Dockerfile` 构建以下应用镜像：
 
 长期基础服务包括 PostgreSQL、Redis、MinIO 和 Mailpit。一次性任务 `db-init`、`minio-init` 正常结束状态为 `Exited (0)`。
 
+标准生产镜像由 `.github/workflows/publish-images.yml` 在官方 `main push` 的 `tokems-ci` 成功完成后构建，统一写入私有包 `ghcr.io/yaojingang/tokems`。六个服务镜像全部完成并生成 GitHub provenance 后，工作流最后发布 `release-<SHA>` descriptor。schema 2 descriptor 固定四项构建身份、生产平台、六个 digest，以及目标提交的完整 Git Bundle 和 verifier SHA-256，是完整可部署版本的唯一标志。生产机通过 GitHub API 核对 `main`、PR 和 CI，通过 GHCR 获取并证明源码与镜像；标准路径不要求生产机直连 `github.com` Git Smart HTTP。
+
 持久数据卷为：
 
 - `tokems-postgres`
@@ -55,10 +57,10 @@ TokEMS 使用根目录多阶段 `Dockerfile` 构建以下应用镜像：
 | 动作         | 结果                                                               | 何时使用                                           |
 | ------------ | ------------------------------------------------------------------ | -------------------------------------------------- |
 | 源码推送     | 校验本地规范大会快照后，本地分支通过 PR 合并到 GitHub `main`       | 所有代码、文档、规范快照、模板种子和迁移变更       |
-| 应用发布     | 服务器拉取 `origin/main`，构建镜像，迁移并切换容器                 | GitHub 主分支需要进入生产运行时                    |
+| 应用发布     | Actions 构建镜像；服务器拉取 digest，迁移并切换容器                | GitHub 主分支需要进入生产运行时                    |
 | 规范模板同步 | 把仓库中的 `geo-conference`、`tokems26` 规范模板幂等写入生产数据库 | 仓库模板、前台文案、大会设置或规范发布快照发生变化 |
 
-代码变更进入 `main` 后不会自动出现在当前服务器。当前环境使用仓库内 `tooling/production-deploy.sh` 作为服务器单命令发布入口，尚未配置 GitHub Actions 自动部署。
+代码变更进入 `main` 后不会自动出现在当前服务器。当前阶段使用仓库内 `tooling/production-deploy.sh` 作为服务器单命令发布入口；GitHub Actions 负责镜像构建和证明。带 Production Environment 审批的 SSH 自动部署会在三个不同 SHA 的预构建生产发布成功后进入独立 PR。
 
 后台直接修改默认大会时，保存操作会生成新的不可变发布快照并切换公开版本。修改完成后必须运行 `pnpm canonical:export` 回写仓库规范快照；最迟在下一次 GitHub 推送前完成。生产后台发生独立修改时，先同步回本地规范大会并确认公开页面，再更新仓库快照。
 
@@ -66,7 +68,7 @@ TokEMS 使用根目录多阶段 `Dockerfile` 构建以下应用镜像：
 
 1. **唯一来源**：生产只使用 `yaojingang/TokEMS` 的 `origin/main`。`majin72/TokEMS` 仅保留为历史 fork，不再接收生产推送。
 2. **PR 先行**：功能分支使用 `codex/*` 或项目约定的功能分支，经 PR、评审和 CI 后合并。服务器禁止直接部署未合并提交。
-3. **干净构建**：本地和服务器发布构建前，Git 工作区必须干净。构建开始后再次核对 `HEAD` 和工作区，避免镜像混入未提交文件。
+3. **干净构建**：Actions 和人工应急构建都只能读取精确目标提交。生产发布前 Git 工作区必须干净，源码导入后再次核对 `HEAD` 和工作区。
 4. **一个发布进程**：服务器同一时间只运行一个拉取、构建、迁移或切换任务。
 5. **先备份再写入**：数据库迁移、规范模板同步和容器切换前，必须创建可读取的数据库备份并记录回滚镜像。
 6. **四项构建身份完整**：`BUILD_SHA`、`BUILD_TIME`、`BUILD_MIGRATION`、`BUILD_MIGRATION_HASH` 必须在构建和运行阶段保持一致，任何值都不能为 `unknown`。
@@ -78,6 +80,8 @@ TokEMS 使用根目录多阶段 `Dockerfile` 构建以下应用镜像：
 12. **逐层验证**：发布结论需要同时满足 GitHub、容器、数据库、本机 HTTP、公网 HTTP 和版本身份六层验证。
 13. **规范快照随推送**：`pnpm install` 会启用仓库内的 `pre-push` 门禁，每次 GitHub 推送自动运行 `pnpm canonical:check`。默认大会或后台设置有变化时先运行 `pnpm canonical:export`。检查失败时禁止推送。
 14. **快照严格脱敏**：规范快照只包含模板及可复用后台设置。管理员身份、凭据、API/第三方集成配置、个人数据、交易数据、销量和审计记录不得进入 Git。
+15. **原子源码与镜像集合**：`release-<SHA>` descriptor 在完整 Git Bundle、verifier、六个服务镜像与构建证明全部完成后发布。同一 SHA 的有效 descriptor 只允许复用，禁止覆盖。服务器导入 Bundle 前必须核对 provenance、payload SHA-256、固定 ref 和目标 SHA；仅允许 Fast-forward 更新 `origin/main`。
+16. **私有 registry 最小权限**：生产机只使用 `/etc/tokems/ghcr-read-token` 中的 `read:packages` PAT classic。登录配置只存在于 root-only `/run` 临时目录。
 
 ## 5. 发布类型判断
 
@@ -146,6 +150,10 @@ git rev-parse origin/main
 gh run list --repo yaojingang/TokEMS --branch main --limit 5
 ```
 
+首次启用镜像工作流前，先从生产机执行 `uname -m`。`x86_64` 对应仓库变量 `PRODUCTION_PLATFORM=linux/amd64`，`aarch64` 或 `arm64` 对应 `linux/arm64`。该变量缺失或超出允许值时，`tokems-image-publish` 会在构建前失败。GHCR 包保持 Private；仓库 Actions 只拥有当前工作流需要的 `contents: read`、`packages: write`、`id-token: write` 和 `attestations: write`。
+
+恢复 SSH 后连续执行三轮只读网络与鉴权探测，记录时间和结果：访问 `https://ghcr.io/v2/`、通过临时 Docker 配置执行 GHCR 登录、读取已发布 descriptor 或最小测试镜像的 manifest。三轮都失败时，在合并本方案前把相同 descriptor 接口切换到阿里云 ACR。一次生产发布固定使用一个 registry。
+
 ## 7. 服务器标准发布流程
 
 以下命令以生产目录和当前 `ecs-user` Git 所有权为准。执行过程中出现非预期输出时停止发布，先定位当前层级。
@@ -154,7 +162,7 @@ gh run list --repo yaojingang/TokEMS --branch main --limit 5
 
 部署脚本在 GitHub 仓库中的固定位置是 `tooling/production-deploy.sh`。成功发布后，对应服务器文件为 `/www/wwwroot/TokEMS/tooling/production-deploy.sh`。`/www/dk_project/wwwroot/hui.ailingdaoli.com` 只保存站点和反向代理配置，不放置部署脚本、源码或构建产物。
 
-首次安装时不要把脚本直接复制到 `/www/wwwroot/TokEMS/tooling/`。服务器 `production` 仍停留在旧提交时，这样会产生未跟踪文件，Git 清洁门禁会拒绝继续。优先使用本节后面的“首次固定引导流程”，它直接从已经合并且 CI 成功的 `origin/main` 读取精确目标脚本。
+首次安装时不要把脚本直接复制到 `/www/wwwroot/TokEMS/tooling/`。服务器 `production` 仍停留在旧提交时，这样会产生未跟踪文件，Git 清洁门禁会拒绝继续。使用下面的 SCP 固定引导流程，从本地已经合并且 CI 成功的 `origin/main` 导出精确目标脚本。
 
 需要通过 SCP 上传时，先在本地从已合并的 `origin/main` 导出脚本，再上传到服务器 `/tmp`。将 `<生产服务器>` 替换为实际 SSH 主机：
 
@@ -176,20 +184,23 @@ sudo install -o root -g root -m 0755 \
 sudo /usr/local/sbin/tokems-deploy --help
 ```
 
-`/usr/local/sbin/tokems-deploy` 每次启动都会读取 `origin/main` 的目标脚本，并复核合并 PR、官方 main push CI 和 `quality-and-flows`。日常发布也使用这个 root 所有的入口，避免 root 直接执行由 `ecs-user` 管理的工作区文件。首次基线依次执行以下命令，每一步成功后再继续：
+`/usr/local/sbin/tokems-deploy` 每次启动都会从 GitHub API 解析最新 `main`，复核合并 PR、官方 main push CI、`quality-and-flows` 与镜像发布工作流，再从经过证明的 GHCR descriptor 导入目标 Git Bundle 并读取目标脚本。日常发布也使用这个 root 所有的入口，避免 root 直接执行由 `ecs-user` 管理的工作区文件。首次基线依次执行以下命令，每一步成功后再继续：
 
 ```bash
 sudo install -d -o root -g root -m 0700 /etc/tokems
 sudo install -o root -g root -m 0600 \
   /www/wwwroot/TokEMS/.env /etc/tokems/production.env
+# 在本机安全准备只含 read:packages 的 PAT 文件后安装；不要把 Token 写入命令行或日志。
+sudo install -o root -g root -m 0600 \
+  /tmp/tokems-ghcr-read-token /etc/tokems/ghcr-read-token
 sudo /usr/local/sbin/tokems-deploy repair-identity --target-sha <origin-main-full-sha>
 sudo /usr/local/sbin/tokems-deploy check --target-sha <origin-main-full-sha>
 sudo /usr/local/sbin/tokems-deploy deploy --target-sha <origin-main-full-sha>
 ```
 
-`/etc/tokems` 必须保持 `root:root 0700`，`/etc/tokems/production.env` 必须保持 `root:root 0600`。脚本取得发布锁后立即创建 root-only 会话快照，后续 Compose 只读取受保护快照；发布成功或身份修复成功后再原子写回 `/etc/tokems/production.env`。不要把任何生产环境文件上传到 GitHub，也不要在终端输出其内容。确认新入口连续完成 `repair-identity`、`check` 和一次正式 `deploy` 后，可按既有凭据销毁流程处理工作区旧 `.env`。
+`/etc/tokems` 必须保持 `root:root 0700`，`production.env` 与 `ghcr-read-token` 必须保持 `root:root 0600`。脚本取得发布锁后立即创建 root-only 会话快照，后续 Compose 只读取受保护快照；发布成功或身份修复成功后再原子写回 `/etc/tokems/production.env`。GHCR 登录通过 `password-stdin` 完成，临时 Docker 配置在退出路径清除。不要把生产环境文件或 Token 上传到 GitHub，也不要在终端输出其内容。确认新入口连续完成 `repair-identity`、`check` 和一次正式 `deploy` 后，可按既有凭据销毁流程处理工作区旧 `.env`。
 
-当前生产主机的历史内存与交换空间总可用量低于脚本要求的 10 GiB 构建门槛时，需要构建镜像的 `check` 和 `deploy` 会在备份、迁移和容器切换前停止。目标规范快照与当前运行提交完全一致，且目标差异仅包含部署控制与文档时，可显式执行 `check --sync-canonical` 和 `deploy --sync-canonical`；脚本复用当前已验证镜像，并继续执行备份、写冻结、规范同步、生产数据保护和完整验收。
+4 核 8G 生产主机的标准 `check` 和 `deploy` 使用预构建镜像，不执行 Docker 构建，也不应用 10 GiB 构建内存门禁。Docker 磁盘、备份容量、数据库和数据保护门禁保持启用。人工应急构建使用 `--build-on-host`，资源不足时会在备份、迁移和容器切换前停止。目标规范快照与当前运行提交完全一致，且目标差异仅包含部署控制与文档时，可显式执行 `check --sync-canonical` 和 `deploy --sync-canonical`；脚本复用当前已验证镜像，并继续执行备份、写冻结、规范同步、生产数据保护和完整验收。
 
 服务器已经首次安装 root 所有的稳定入口后，日常发布使用以下两个命令：
 
@@ -226,106 +237,21 @@ sudo /usr/local/sbin/tokems-deploy resolve-recovery
 
 2026-08-24 的失败发布记录明确指出：线上容器已经回到 `01c7b490bb690e4e12695dba2996f7d2864566f4` / `0053_mute_vulcan.sql`，服务器 `.env` 仍留有失败目标的构建身份。首次使用本脚本时先执行 `repair-identity`，再执行 `check` 和 `deploy`。修复证据保存到 `/www/backup/TokEMS/identity-repair-<时间戳>`。
 
-`check` 只读检查当前运行版本、Git 工作区、官方远端、`production → origin/main`、GitHub 合并 PR、`quality-and-flows`、Compose、Nginx、容器、镜像标签、生产环境固定项、磁盘和构建内存。`deploy` 在相同门禁通过后自动完成以下流程：
+`check` 检查当前运行版本、Git 工作区、官方远端、`production → origin/main`、GitHub 合并 PR、`quality-and-flows`、`tokems-image-publish`、descriptor、源码 Bundle 与服务镜像 provenance、Compose、Nginx、容器、镜像标签、生产环境固定项、平台和磁盘。它可能把经过证明的 Bundle 对象导入 `.git` 并 Fast-forward 远端跟踪 ref，不更新工作树、环境文件、运行容器或数据库。`--build-on-host` 额外检查构建内存。`deploy` 在相同门禁通过后自动完成以下流程：
 
-1. 创建构建开始时的 PostgreSQL custom dump、生产数据证据、旧 `.env`、旧 Compose 配置和运行状态证据。
-2. 给六个当前应用镜像添加 `rollback-<时间戳>` 标签。
-3. 以 Fast-forward 方式把服务器 `production` 更新到已经合并且 CI 成功的 `origin/main`。
-4. 从目标提交生成 root-only 源码快照和 Compose 构建上下文，生成并持久化四项构建身份，按服务串行构建镜像，固定 `COMPOSE_PARALLEL_LIMIT=1`。构建和容器切换全程使用 root-only `.env` 快照及清洁进程环境。
-5. 所有发布在数据库写入前先把 API/Worker 的 Docker 重启策略持久改为 `no`，启动持续重试的写阻断 guard，再落盘 `RECOVERY_REQUIRED` 并停止写服务。随后重新生成最终 PostgreSQL dump、生产主键、计数与销量基线，再以 `SEED_DEMO_DATA=false` 执行迁移；规范快照变化时继续执行受保护的 `geo-conference` / `tokems26` 同步。稳定业务表按主键索引流式取证，带自动保留期的数据在 Worker 暂停的阶段单独比对。
-6. 使用 `--no-build --no-deps --force-recreate --wait` 切换应用容器，不协调 PostgreSQL、Redis、MinIO 等基础设施。验收阶段以数据库只读模式启动 API，并暂停 Worker 任务。
-7. 在写冻结窗口验证容器、迁移、五类构建身份、本机与公网 HTTP、公开首页投影，以及从生产数据库重新导出的脱敏完整规范大会与后台设置；冻结期生产主键集合、计数和票种/配额销量必须精确一致。验证通过后以 `restart: no` 和正常数据库权限重建 API/Worker。Worker 的两类 BullMQ 消费者都完成 Redis ready 后才写入包含 SHA、构建时间和迁移身份的 `/tmp/tokems-worker-ready.json`；脚本核对并观察稳定后恢复 `unless-stopped`，再检查健康、数据库实例和允许正常新增的生产数据。
-8. 失败时先停止 API/Worker，再读取数据库迁移证据并恢复发布前镜像标签与 `.env`。迁移证据不可读取时，旧镜像和环境已经恢复，API/Worker 保持停止，`RECOVERY_REQUIRED` 继续阻止下一次普通发布。数据库 dump 始终保留，脚本不会自动覆盖恢复数据库。
+1. 验证 descriptor provenance、Git Bundle 与 verifier SHA-256，确认 Bundle 只公开固定 ref 的精确目标 SHA，且服务器当前 `origin/main`、`production` 都是其祖先；随后 Fast-forward 远端跟踪 ref，工作树保持不变。
+2. 创建构建开始时的 PostgreSQL custom dump、生产数据证据、旧 `.env`、旧 Compose 配置、运行状态证据和目标提交的 root-only 源码快照，并给六个当前应用镜像添加 `rollback-<时间戳>` 标签。
+3. Fast-forward 服务器 `production` 到已验证目标，按 descriptor digest 拉取六个镜像，逐个校验平台、服务标签、四项构建身份和源码迁移哈希。全部候选验证成功后写入 descriptor 的四项 `BUILD_*`，再成组更新本机发布标签；中途失败由既有 rollback handler 恢复整组旧标签。`--build-on-host` 应急路径继续使用 root-only 构建上下文和 `COMPOSE_PARALLEL_LIMIT=1` 串行构建。
+4. 所有发布在数据库写入前先把 API/Worker 的 Docker 重启策略持久改为 `no`，启动持续重试的写阻断 guard，再落盘 `RECOVERY_REQUIRED` 并停止写服务。随后重新生成最终 PostgreSQL dump、生产主键、计数与销量基线，再以 `SEED_DEMO_DATA=false` 执行迁移；规范快照变化时继续执行受保护的 `geo-conference` / `tokems26` 同步。稳定业务表按主键索引流式取证，带自动保留期的数据在 Worker 暂停的阶段单独比对。
+5. 使用 `--no-build --no-deps --force-recreate --wait` 切换应用容器，不协调 PostgreSQL、Redis、MinIO 等基础设施。验收阶段以数据库只读模式启动 API，并暂停 Worker 任务。
+6. 在写冻结窗口验证容器、迁移、五类构建身份、本机与公网 HTTP、公开首页投影，以及从生产数据库重新导出的脱敏完整规范大会与后台设置；冻结期生产主键集合、计数和票种/配额销量必须精确一致。验证通过后以 `restart: no` 和正常数据库权限重建 API/Worker。Worker 的两类 BullMQ 消费者都完成 Redis ready 后才写入包含 SHA、构建时间和迁移身份的 `/tmp/tokems-worker-ready.json`；脚本核对并观察稳定后恢复 `unless-stopped`，再检查健康、数据库实例和允许正常新增的生产数据。
+7. 失败时先停止 API/Worker，再读取数据库迁移证据并恢复发布前镜像标签与 `.env`。迁移证据不可读取时，旧镜像和环境已经恢复，API/Worker 保持停止，`RECOVERY_REQUIRED` 继续阻止下一次普通发布。数据库 dump 始终保留，脚本不会自动覆盖恢复数据库。
 
-脚本会先验证 `origin/main` 对应的合并 PR 和 CI，再读取该提交中的最新脚本继续执行，因此后续仓库内的部署逻辑更新会随目标提交生效。服务器首次尚未取得该文件时，先用以下固定引导流程完成同样的外部校验，再授予目标脚本 root 权限。当前已知基线第一次把 `deploy_action` 设为 `repair-identity`；随后分别设为 `check` 和 `deploy` 重跑：
-
-```bash
-set -Eeuo pipefail
-
-app_dir=/www/wwwroot/TokEMS
-deploy_action=repair-identity
-sudo -u ecs-user git -C /www/wwwroot/TokEMS fetch --prune origin main
-target_sha="$(sudo -u ecs-user git -C "$app_dir" rev-parse origin/main)"
-bootstrap_dir="$(mktemp -d /tmp/tokems-deploy-bootstrap.XXXXXX)"
-trap 'rm -f -- "$bootstrap_dir/prs.json" "$bootstrap_dir/runs.json" "$bootstrap_dir/checks.json" "$bootstrap_dir/deploy.sh"; rmdir -- "$bootstrap_dir"' EXIT
-
-curl --fail --silent --show-error --location \
-  --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 --retry-connrefused \
-  -H 'Accept: application/vnd.github+json' \
-  -H 'X-GitHub-Api-Version: 2022-11-28' \
-  -H 'User-Agent: TokEMS-production-bootstrap' \
-  "https://api.github.com/repos/yaojingang/TokEMS/commits/${target_sha}/pulls?per_page=100" \
-  >"$bootstrap_dir/prs.json"
-curl --fail --silent --show-error --location \
-  --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 --retry-connrefused \
-  -H 'Accept: application/vnd.github+json' \
-  -H 'X-GitHub-Api-Version: 2022-11-28' \
-  -H 'User-Agent: TokEMS-production-bootstrap' \
-  "https://api.github.com/repos/yaojingang/TokEMS/actions/workflows/ci.yml/runs?branch=main&event=push&per_page=100" \
-  >"$bootstrap_dir/runs.json"
-curl --fail --silent --show-error --location \
-  --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 --retry-connrefused \
-  -H 'Accept: application/vnd.github+json' \
-  -H 'X-GitHub-Api-Version: 2022-11-28' \
-  -H 'User-Agent: TokEMS-production-bootstrap' \
-  "https://api.github.com/repos/yaojingang/TokEMS/commits/${target_sha}/check-runs?per_page=100" \
-  >"$bootstrap_dir/checks.json"
-
-python3 - "$target_sha" "$bootstrap_dir/prs.json" "$bootstrap_dir/runs.json" "$bootstrap_dir/checks.json" <<'PY'
-import json
-import sys
-
-target, pulls_file, runs_file, checks_file = sys.argv[1:]
-with open(pulls_file, encoding="utf-8") as handle:
-    pulls = json.load(handle)
-with open(runs_file, encoding="utf-8") as handle:
-    runs = json.load(handle).get("workflow_runs", [])
-with open(checks_file, encoding="utf-8") as handle:
-    checks = json.load(handle).get("check_runs", [])
-if not any(
-    item.get("merged_at")
-    and item.get("merge_commit_sha") == target
-    and (item.get("base") or {}).get("ref") == "main"
-    for item in pulls
-):
-    raise SystemExit("target commit has no merged main PR")
-if not any(
-    item.get("name") == "tokems-ci"
-    and item.get("path") == ".github/workflows/ci.yml"
-    and item.get("event") == "push"
-    and item.get("head_branch") == "main"
-    and item.get("head_sha") == target
-    and item.get("status") == "completed"
-    and item.get("conclusion") == "success"
-    and (item.get("repository") or {}).get("full_name") == "yaojingang/TokEMS"
-    and (item.get("head_repository") or {}).get("full_name") == "yaojingang/TokEMS"
-    for item in runs
-):
-    raise SystemExit("target commit has no successful official main push workflow")
-if not any(
-    item.get("name") == "quality-and-flows"
-    and item.get("head_sha") == target
-    and item.get("status") == "completed"
-    and item.get("conclusion") == "success"
-    and (item.get("app") or {}).get("slug") == "github-actions"
-    and "/yaojingang/TokEMS/actions/runs/" in (item.get("details_url") or "")
-    for item in checks
-):
-    raise SystemExit("target commit has no successful official quality-and-flows job")
-PY
-
-sudo -u ecs-user git -C "$app_dir" \
-  show "${target_sha}:tooling/production-deploy.sh" >"$bootstrap_dir/deploy.sh"
-chmod 700 "$bootstrap_dir/deploy.sh"
-bash -n "$bootstrap_dir/deploy.sh"
-sudo install -o root -g root -m 0755 \
-  "$bootstrap_dir/deploy.sh" /usr/local/sbin/tokems-deploy
-sudo bash /usr/local/sbin/tokems-deploy "$deploy_action" --target-sha "$target_sha"
-```
+脚本会先通过 GitHub API 验证最新 `main` 对应的合并 PR、CI 和镜像发布工作流，再从 descriptor digest 读取目标源码与最新版部署脚本。服务器首次启用使用本节前面的 SCP 固定引导流程：本地只从已合并的 `origin/main` 导出脚本，核对 SHA-256 后安装到 `/usr/local/sbin/tokems-deploy`。这一步不要求生产机连接 `github.com` Git Smart HTTP；安装后的稳定入口负责完成其余外部证明和 Bundle 导入。
 
 默认模板策略为自动判断。两个规范快照相对当前线上提交发生变化时，脚本强制同步规范模板；快照未变化时，预检仍会使用只读数据库连接导出线上完整规范状态，并与目标快照逐项比较，发现存量漂移后自动触发同步。`--sync-canonical` 可主动重跑幂等同步；`--skip-canonical` 仅在 Git 快照未变化且线上完整规范状态已经匹配时通过。常规发布的 `SEED_DEMO_DATA` 始终为 `false`；规范同步阶段才会向一次性 `db-init` 进程临时传入 `SEED_DEMO_DATA=true`。
 
-当线上运行镜像已经包含目标规范快照，且运行提交到目标提交之间的差异仅限 `AGENTS.md`、`docs/`、生产部署脚本及其测试时，自动检测到的规范漂移或显式 `--sync-canonical` 会进入规范修复流程。该流程先复核合并 PR、CI、运行身份、数据库实例和规范目标，再创建两轮数据库备份与镜像回滚标签、Fast-forward 服务器源码、冻结 API/Worker 写入、运行幂等规范同步，并在恢复写入前后核对公开首页、完整后台规范快照、业务主键、计数和销量。当前镜像和数据库迁移身份保持不变，因此无需镜像构建资源。任一运行相关文件或规范快照发生变化时，脚本回到标准构建流程。
+当线上运行镜像已经包含目标规范快照，且运行提交到目标提交之间的差异仅限 `AGENTS.md`、`docs/`、生产部署脚本及其测试时，自动检测到的规范漂移或显式 `--sync-canonical` 会进入规范修复流程。该流程先复核合并 PR、CI、运行身份、数据库实例和规范目标，再创建两轮数据库备份与镜像回滚标签、Fast-forward 服务器源码、冻结 API/Worker 写入、运行幂等规范同步，并在恢复写入前后核对公开首页、完整后台规范快照、业务主键、计数和销量。当前镜像和数据库迁移身份保持不变，因此无需镜像构建资源。任一运行相关文件或规范快照发生变化时，脚本回到标准预构建镜像流程。
 
 指定目标提交时使用完整 SHA。低内存服务器先运行只读预检，再执行同步：
 
@@ -338,11 +264,11 @@ sudo /usr/local/sbin/tokems-deploy deploy \
   --sync-canonical
 ```
 
-生产主机曾在 Docker BuildKit 构建期间发生 OOM 并导致同机服务中断。标准镜像构建要求 `MemAvailable + SwapFree` 至少 10 GiB，并要求源码文件系统和 Docker 实际 `DockerRootDir` 各有至少 12 GiB 可用空间。受保护的规范修复流程跳过这组三项构建资源门禁，备份与验收容量门禁保持启用。备份文件系统的初始门禁按四倍当前数据库体积加至少 4 GiB 计算；构建开始的稳定主键与保留期主键证据生成后，后续门禁使用这些文件的实测大小预算最终 dump、只读验收和 post-thaw 证据。预检从 `/www/backup/TokEMS` 的最深现存父目录读取设备号，创建发布目录后再次核对同一设备，每个大文件阶段前直接检查该发布目录。任一适用资源不足时会在备份、迁移和容器变更前停止。需要构建镜像的发布仍需先扩容，或采用外部构建并拉取固定镜像摘要。
+生产主机曾在 Docker BuildKit 构建期间发生 OOM 并导致同机服务中断。标准发布从 GHCR 拉取固定镜像摘要。`--build-on-host` 应急构建要求 `MemAvailable + SwapFree` 至少 10 GiB，并要求源码文件系统和 Docker 实际 `DockerRootDir` 各有至少 12 GiB 可用空间。受保护的规范修复流程跳过构建资源门禁，备份与验收容量门禁保持启用。备份文件系统的初始门禁按四倍当前数据库体积加至少 4 GiB 计算；构建开始的稳定主键与保留期主键证据生成后，后续门禁使用这些文件的实测大小预算最终 dump、只读验收和 post-thaw 证据。预检从 `/www/backup/TokEMS` 的最深现存父目录读取设备号，创建发布目录后再次核对同一设备，每个大文件阶段前直接检查该发布目录。任一适用资源不足时会在备份、迁移和容器变更前停止。
 
 标准单命令发布拒绝 `docker-compose.yml` 变化。数据库、缓存、对象存储、卷、端口和服务拓扑变更进入单独评审的基础设施维护窗口。
 
-每次标准发布都有短暂写冻结窗口：六个镜像构建完成后停止 API 和 Worker，持久化恢复标记，在静止写入状态重新生成最终数据库备份与业务基线，再执行迁移和可选的规范同步。语义验收期间 API 仅允许数据库读取，Worker 暂停消费。只读验收阶段公开浏览恢复；报名、支付回调、后台保存及异步任务会在窗口内失败或重试。脚本在恢复正常 API/Worker、核对持久 ready 身份和数据复验后归档恢复标记并记录成功。选择业务低峰执行，并确认支付渠道具备回调重试。
+每次标准发布都有短暂写冻结窗口：六个候选镜像拉取并验证完成后停止 API 和 Worker，持久化恢复标记，在静止写入状态重新生成最终数据库备份与业务基线，再执行迁移和可选的规范同步。语义验收期间 API 仅允许数据库读取，Worker 暂停消费。只读验收阶段公开浏览恢复；报名、支付回调、后台保存及异步任务会在窗口内失败或重试。脚本在恢复正常 API/Worker、核对持久 ready 身份和数据复验后归档恢复标记并记录成功。选择业务低峰执行，并确认支付渠道具备回调重试。
 
 数据库实例证明、查询、dump 和迁移都设置了进程级超时；连接串指向不可达地址或数据库停止响应时，脚本会失败退出并进入受控恢复。脚本保留全部备份和回滚镜像，不会自动清理历史文件。运维侧应按已验证的恢复演练和容量预算另行制定保留周期，删除前确认目标发布已过观察期且仍有可用备份。
 
@@ -360,12 +286,17 @@ sudo -u ecs-user git remote -v
 
 docker --version
 docker compose version
+docker buildx version
+gh --version
+gh attestation verify --help >/dev/null
 docker compose config --quiet
 docker compose ps
 nginx -t
 docker info --format '{{.DockerRootDir}}'
 df -h / /www/backup "$(docker info --format '{{.DockerRootDir}}')"
 free -h
+uname -m
+sudo stat -c '%U:%G %a %n' /etc/tokems/ghcr-read-token
 ```
 
 允许继续发布的条件：
@@ -374,7 +305,10 @@ free -h
 - 当前分支为 `production`。
 - `origin` 指向官方仓库。
 - Compose 配置和 Nginx 配置通过。
-- 磁盘、内存和 Docker 状态满足构建需要。
+- 生产平台与仓库变量 `PRODUCTION_PLATFORM` 一致，值为 `linux/amd64` 或 `linux/arm64`。
+- 预构建模式的磁盘、备份容量、Docker、Buildx、GitHub CLI 和 GHCR 只读凭据满足要求。
+- `api.github.com` 与 `ghcr.io` 可访问；`github.com` Git Smart HTTP 不属于标准发布依赖。
+- `--build-on-host` 应急模式额外满足 10 GiB 内存与构建磁盘门禁。
 - 没有其他构建或发布进程。
 
 ### 7.2 创建备份和镜像回滚点
@@ -442,24 +376,30 @@ docker image inspect \
 
 如果发布涉及 MinIO 配置、模板图片或发票文件存储，增加 MinIO 卷快照或对象存储备份，并把备份标识写入本次发布记录。Redis 卷不随发布删除。
 
-### 7.3 同步官方主分支
+### 7.3 Fast-forward 到已验证源码
+
+标准入口已经通过 descriptor provenance 和源码 Bundle 更新 `origin/main`。手工等价操作只允许把 `production` Fast-forward 到同一个已批准 SHA；这一阶段不再访问远端 Git Smart HTTP。
 
 ```bash
 cd /www/wwwroot/TokEMS || exit 1
 
 test -z "$(sudo -u ecs-user git status --porcelain --untracked-files=all)"
 sudo -u ecs-user git switch production
-sudo -u ecs-user git fetch --prune origin main
-sudo -u ecs-user git pull --ff-only origin main
-
-target_sha=$(sudo -u ecs-user git rev-parse HEAD)
-origin_sha=$(sudo -u ecs-user git rev-parse origin/main)
-test "$target_sha" = "$origin_sha"
+approved_sha=<origin-main-full-sha>
+origin_sha="$(sudo -u ecs-user git rev-parse origin/main)"
+test "$approved_sha" = "$origin_sha"
+sudo -u ecs-user git merge-base --is-ancestor HEAD "$approved_sha"
+sudo -u ecs-user git merge --ff-only "$approved_sha"
+test "$(sudo -u ecs-user git rev-parse HEAD)" = "$approved_sha"
 ```
 
 禁止使用 `git reset --hard` 或删除服务器工作区来解决分支分歧。出现分歧时停止发布，查明服务器提交来源。
 
-### 7.4 生成并持久化构建身份
+### 7.4 验证并持久化构建身份
+
+标准发布从 `release-<SHA>` descriptor 读取 `BUILD_SHA`、`BUILD_TIME`、`BUILD_MIGRATION`、`BUILD_MIGRATION_HASH`。脚本验证 descriptor 与六个服务镜像的 source、revision、service、platform 和 GitHub provenance，并把迁移名称与目标提交中的迁移文件 SHA-256 对照。四项值随后写入 root-only 发布环境快照；生产机不会重新生成构建时间。
+
+以下手工生成方式只用于显式 `--build-on-host` 应急路径。
 
 生产服务器当前没有 Node.js 和 pnpm，不能直接运行 `pnpm docker:deploy`。手工 Compose 发布需要显式生成与持久化四项构建身份：
 
@@ -512,7 +452,11 @@ docker compose config --quiet
 
 构建变量要在镜像构建前写入 `.env`。同一文件也供后续 `docker compose up` 使用，避免新终端丢失 Shell 临时变量。
 
-### 7.5 构建镜像
+### 7.5 拉取预构建镜像
+
+标准发布按 descriptor 中的 digest 拉取 API、Worker、Web、Admin、Gateway 与 notification-sink。六个候选镜像全部完成本地标签与架构复核前，脚本不会改变任何 `tokems-*:local` 标签。候选集合完整后，脚本为当前镜像保留 `rollback-<时间戳>`，再更新 `:local` 和本次 `release-<时间戳>` 标签。拉取或验证失败会留下下载缓存与审计文件，运行容器和发布标签保持原状。
+
+`--build-on-host` 应急路径使用以下串行构建等价步骤：
 
 ```bash
 cd /www/wwwroot/TokEMS || exit 1
@@ -778,6 +722,7 @@ docker compose \
 - 发布日期、操作者、目标环境和目标域名
 - GitHub PR、CI、目标提交和最高迁移
 - 构建时间、迁移文件 SHA-256 和镜像摘要
+- Release descriptor digest、源码 Bundle SHA-256、verifier SHA-256、目标平台和六个服务 digest
 - 备份目录、数据库 dump SHA-256 和回滚标签
 - 是否执行规范模板同步
 - 发布前后的组织、大会、票种、报名、订单数据摘要
@@ -789,8 +734,8 @@ docker compose \
 
 ## 13. 当前环境待改进项
 
-- 服务器没有 Node.js 和 pnpm，仓库内 Bash 脚本已覆盖单命令 Docker Compose 发布。后续优先建设基于 GitHub Actions、受保护生产环境和固定镜像摘要的外部构建流程，消除生产主机 BuildKit OOM 风险。
+- GitHub Actions 已负责固定镜像摘要的外部构建。完成三个不同 SHA 的真实预构建生产发布后，再通过独立 PR 增加 `production` Environment 审批、专用受限 SSH Key、root-owned 强制命令入口和 `deploy-production.yml`。规范修复复用旧镜像的发布不计入三次验证。
 - 当前 `.env` 由服务器权限保护。后续应把生产密钥迁移到 Secret Manager 或等价的受控密钥系统。
 - 服务器操作系统安全更新需要独立维护窗口处理，不能与应用发布混在同一次变更中。
 - MinIO 资产恢复演练和定期备份仍需形成独立记录。
-- GitHub Actions 自动发布完成前，每次 GitHub 合并后都要人工执行服务器部署脚本，并按模板补充日期化发布记录。
+- 带批准的 GitHub Actions 自动部署完成前，每次镜像发布成功后都要人工执行服务器部署脚本，并按模板补充日期化发布记录。

--- a/docs/release-records/TEMPLATE.md
+++ b/docs/release-records/TEMPLATE.md
@@ -16,15 +16,20 @@
 
 ## 2. GitHub 和构建身份
 
-| 项目         | 本次值        |
-| ------------ | ------------- |
-| PR           |               |
-| CI           |               |
-| 目标提交     |               |
-| 构建时间     |               |
-| 最高迁移     |               |
-| 迁移 SHA-256 |               |
-| 发布分支     | `origin/main` |
+| 项目                        | 本次值        |
+| --------------------------- | ------------- |
+| PR                          |               |
+| CI                          |               |
+| 镜像发布工作流              |               |
+| 目标提交                    |               |
+| 构建时间                    |               |
+| 最高迁移                    |               |
+| 迁移 SHA-256                |               |
+| 发布分支                    | `origin/main` |
+| Release descriptor digest   |               |
+| Source Bundle SHA-256       |               |
+| Descriptor verifier SHA-256 |               |
+| 目标平台                    |               |
 
 ## 3. 发布前检查
 
@@ -32,7 +37,7 @@
 - [ ] `production` 跟踪 `origin/main`
 - [ ] Compose 配置通过
 - [ ] Nginx 配置通过
-- [ ] 磁盘和内存满足构建需要
+- [ ] 预构建模式的磁盘与备份容量满足要求；主机构建时额外通过 10 GiB 内存门禁
 - [ ] 没有并行发布任务
 - [ ] GitHub 必需检查成功
 
@@ -74,6 +79,8 @@
 | Admin             |          |          |
 | Gateway           |          |          |
 | notification-sink |          |          |
+
+六个服务均填写 descriptor 固定的 GHCR digest；容器验收同时记录实际 image ID。
 
 ## 7. 验证结果
 

--- a/tooling/lib/production-deploy.test.mjs
+++ b/tooling/lib/production-deploy.test.mjs
@@ -9,6 +9,10 @@ import test from 'node:test';
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const scriptPath = resolve(repositoryRoot, 'tooling/production-deploy.sh');
 const source = readFileSync(scriptPath, 'utf8');
+const descriptorVerifierSource = readFileSync(
+  resolve(repositoryRoot, 'tooling/release-descriptor.py'),
+  'utf8',
+);
 const workerSource = readFileSync(resolve(repositoryRoot, 'apps/worker/src/main.ts'), 'utf8');
 const dockerfileSource = readFileSync(resolve(repositoryRoot, 'Dockerfile'), 'utf8');
 
@@ -24,6 +28,7 @@ test('production deploy script has valid Bash syntax and a read-only help path',
   assert.match(help.stdout, /production-deploy\.sh recover-interrupted/);
   assert.match(help.stdout, /production-deploy\.sh resolve-recovery/);
   assert.match(help.stdout, /--resume-recovery/);
+  assert.match(help.stdout, /--build-on-host/);
   assert.match(help.stdout, /default canonical mode is automatic/);
 
   const modeHelp = spawnSync('bash', [scriptPath, 'check', '--help'], { encoding: 'utf8' });
@@ -46,6 +51,65 @@ test('production deploy script has valid Bash syntax and a read-only help path',
   }
 });
 
+test('prebuilt images are the default release path and host builds remain resource-gated', () => {
+  assert.match(source, /GHCR_TOKEN_FILE='\/etc\/tokems\/ghcr-read-token'/);
+  assert.match(source, /GHCR_PACKAGE='ghcr\.io\/yaojingang\/tokems'/);
+  assert.match(source, /verify_image_publish_gate/);
+  assert.match(source, /verify_release_descriptor/);
+  assert.match(source, /pull_prebuilt_images/);
+  assert.match(source, /activate_prebuilt_images/);
+  assert.match(source, /gh attestation verify/);
+  assert.match(source, /docker buildx imagetools inspect/);
+  assert.match(source, /GHCR network probe failed/);
+  assert.match(source, /GHCR read token file is missing/);
+  assert.match(source, /GHCR authentication failed; the read token may be expired or invalid/);
+  assert.match(source, /prepare_release_source_bundle/);
+  assert.match(source, /verify-source-bundle/);
+  assert.match(source, /import-source-bundle/);
+  assert.match(source, /refs\/heads\/tokems-release-source/);
+  assert.match(descriptorVerifierSource, /refs\/tokems-deploy\/source-candidate/);
+  assert.match(descriptorVerifierSource, /EXPECTED_UPSTREAM_REF/);
+  assert.match(descriptorVerifierSource, /"update-ref",\s+EXPECTED_UPSTREAM_REF/);
+  assert.doesNotMatch(source, /git -C "\$APP_DIR" fetch --prune origin main/);
+  assert.match(source, /source_bundle_sha256=%s/);
+  assert.match(source, /descriptor_verifier_sha256=%s/);
+  const prepareDescriptor = source.slice(
+    source.indexOf('prepare_release_source_bundle() {'),
+    source.indexOf('\ndescriptor_image_ref() {'),
+  );
+  assert.ok(
+    prepareDescriptor.indexOf('--format \'{{.Manifest.Digest}}\' "$release_ref"') <
+      prepareDescriptor.indexOf("--format '{{json .Image.Config.Labels}}'"),
+    'the release tag must resolve to a digest before descriptor labels are read',
+  );
+  assert.match(prepareDescriptor, /"\$descriptor_ref" >"\$labels_file"/);
+  assert.doesNotMatch(
+    prepareDescriptor,
+    /--format '\{\{json \.Image\.Config\.Labels\}\}'[\s\\]*\n\s+"\$release_ref"/,
+  );
+
+  const main = source.slice(source.indexOf('\nmain() {'));
+  assert.match(
+    main,
+    /if \[\[ "\$build_on_host" == 'true' \]\]; then[\s\S]*?write_build_identity[\s\S]*?build_images[\s\S]*?else[\s\S]*?pull_prebuilt_images[\s\S]*?write_prebuilt_build_identity[\s\S]*?activate_prebuilt_images/,
+  );
+  assert.match(source, /if \[\[ "\$build_on_host" == 'true' \]\]; then\n\s+assert_build_capacity/);
+
+  const pull = source.slice(
+    source.indexOf('pull_prebuilt_images() {'),
+    source.indexOf('\nactivate_prebuilt_images() {'),
+  );
+  assert.doesNotMatch(pull, /:local/);
+  assert.doesNotMatch(pull, /docker (compose )?build/);
+  assert.match(pull, /registry_docker pull --platform "\$descriptor_platform" "\$image_ref"/);
+  const activate = source.slice(
+    source.indexOf('activate_prebuilt_images() {'),
+    source.indexOf('\nread_only_database_url() {'),
+  );
+  assert.match(activate, /images_changed='true'/);
+  assert.match(activate, /:local/);
+});
+
 test('forced canonical sync reuses a compatible runtime without building images', () => {
   const help = spawnSync('bash', [scriptPath, 'deploy', '--help'], { encoding: 'utf8' });
   assert.equal(help.status, 0, help.stderr);
@@ -55,10 +119,14 @@ test('forced canonical sync reuses a compatible runtime without building images'
     source.indexOf('run_full_preflight() {'),
     source.indexOf('\ncapture_business_snapshot() {'),
   );
+  assert.doesNotMatch(
+    preflight,
+    /verify_github_release_gate|verify_image_publish_gate|verify_release_descriptor/,
+  );
   assert.match(preflight, /canonical_repair_scope_is_compatible/);
   assert.match(
     preflight,
-    /if \[\[ "\$canonical_sync_required" == 'true' \]\] && canonical_repair_scope_is_compatible; then[\s\S]*?canonical_repair_mode='true'[\s\S]*?else[\s\S]*?assert_build_capacity/,
+    /if \[\[ "\$canonical_sync_required" == 'true' \]\] && canonical_repair_scope_is_compatible; then[\s\S]*?canonical_repair_mode='true'[\s\S]*?elif \[\[ "\$build_on_host" == 'true' \]\]; then[\s\S]*?assert_build_capacity/,
   );
 
   const repair = source.slice(
@@ -100,6 +168,7 @@ test('production deploy script pins the documented topology and release gates', 
     "readonly EXPECTED_ORIGIN='https://github.com/yaojingang/TokEMS.git'",
     "readonly EXPECTED_BRANCH='production'",
     "readonly EXPECTED_UPSTREAM='origin/main'",
+    "readonly EXPECTED_UPSTREAM_REF='refs/remotes/origin/main'",
     "readonly CANONICAL_ORGANIZATION_SLUG='geo-conference'",
     "readonly CANONICAL_EVENT_SLUG='tokems26'",
     'MIN_BUILD_CAPACITY_KIB=10485760',
@@ -109,7 +178,7 @@ test('production deploy script pins the documented topology and release gates', 
     'GIT_CONFIG_GLOBAL=/dev/null',
     "PRODUCTION_ENV_FILE='/etc/tokems/production.env'",
     'GIT_TERMINAL_PROMPT=0',
-    'GIT_FETCH_TIMEOUT_SECONDS=180',
+    'GIT_BUNDLE_IMPORT_TIMEOUT_SECONDS=180',
     'BUILD_TIMEOUT_SECONDS=3600',
     "LOCAL_DOCKER_HOST='unix:///var/run/docker.sock'",
     '--project-name "$COMPOSE_PROJECT"',
@@ -215,6 +284,8 @@ test('production deploy workflow creates recovery evidence before mutation and v
   assert.match(source, /canonical-homepage\.public\.before\.json/);
   assert.match(source, /business-counts-post-thaw\.csv/);
   assert.match(source, /compare_production_data post-thaw/);
+  assert.match(source, /assert_runtime_image_tags\n\s+assert_api_uses_compose_database/);
+  assert.match(source, /containers-after\.json/);
   assert.match(source, /write_pending_recovery_marker 'release-pre-write-armed'/);
   assert.doesNotMatch(source, /return \{tuple\(row\) for row/);
   assert.match(
@@ -449,7 +520,10 @@ test('worker publishes a persistent release identity only after startup maintena
   const finalStartupMaintenance = workerSource.indexOf('await maintainFeishuDigests()');
   assert.ok(finalStartupMaintenance >= 0 && finalStartupMaintenance < firstConsumerStart);
   assert.equal(workerSource.match(/autorun: false/g)?.length, 2);
-  assert.match(workerSource, /Promise\.all\(\[worker\.waitUntilReady\(\), htmlImportWorker\.waitUntilReady\(\)\]\)/);
+  assert.match(
+    workerSource,
+    /Promise\.all\(\[worker\.waitUntilReady\(\), htmlImportWorker\.waitUntilReady\(\)\]\)/,
+  );
   assert.match(workerSource, /rename\(workerReadyTempFile, workerReadyFile\)/);
   assert.match(workerSource, /unlink\(workerReadyFile\)/);
   assert.match(source, /fs\.readFileSync\('\/tmp\/tokems-worker-ready\.json'/);
@@ -476,17 +550,25 @@ test('rollback keeps the immutable pre-release identity after target verificatio
 
 test('target pinning is shared by every mode and recovery verifies the public API', () => {
   assert.ok(
-    source.match(/assert_target_selection "\$target_sha"/g)?.length >= 3,
-    'target selection must be rechecked by deploy, repair, and recovery modes',
+    source.match(/assert_github_main_unchanged/g)?.length >= 4,
+    'GitHub main must be rechecked by deploy, source sync, repair, and recovery modes',
   );
+  assert.match(source, /latest_sha="\$\(github_main_sha\)"/);
+  assert.match(source, /assert_target_selection "\$latest_sha"/);
   assert.match(source, /public-health-recovery-resolve\.json/);
-  assert.match(source, /assert_health_json <"\$pending_recovery_backup_dir\/public-health-recovery-resolve\.json"/);
+  assert.match(
+    source,
+    /assert_health_json <"\$pending_recovery_backup_dir\/public-health-recovery-resolve\.json"/,
+  );
 });
 
 test('root deployment pins Docker Compose and trusts only protected recovery paths', () => {
   assert.match(source, /umask 077/);
   assert.match(source, /export DOCKER_HOST="\$LOCAL_DOCKER_HOST"/);
-  assert.match(source, /unset COMPOSE_FILE COMPOSE_PROJECT_NAME COMPOSE_PROFILES COMPOSE_ENV_FILES/);
+  assert.match(
+    source,
+    /unset COMPOSE_FILE COMPOSE_PROJECT_NAME COMPOSE_PROFILES COMPOSE_ENV_FILES/,
+  );
   assert.match(source, /--project-name "\$COMPOSE_PROJECT"/);
   assert.match(source, /--project-directory "\$APP_DIR"/);
   assert.match(source, /--env-file "\$active_env_file"/);
@@ -499,7 +581,10 @@ test('root deployment pins Docker Compose and trusts only protected recovery pat
   assert.match(source, /Recovery evidence must be owned by root with mode 600/);
   assert.match(source, /Git replacement references are forbidden/);
   assert.match(source, /readlink -f \/proc\/\$\$\/fd\/9/);
-  assert.doesNotMatch(source, /TOKEMS_DEPLOY_LOCK_HELD|TOKEMS_DEPLOY_BOOTSTRAPPED|TOKEMS_RECOVERY_BOOTSTRAPPED/);
+  assert.doesNotMatch(
+    source,
+    /TOKEMS_DEPLOY_LOCK_HELD|TOKEMS_DEPLOY_BOOTSTRAPPED|TOKEMS_RECOVERY_BOOTSTRAPPED/,
+  );
   assert.doesNotMatch(source, /"\$APP_DIR\/\.env"|"\$\{APP_DIR\}\/\.env"/);
   for (const key of [
     'PUBLIC_ORIGIN',
@@ -512,35 +597,33 @@ test('root deployment pins Docker Compose and trusts only protected recovery pat
     'VITE_SIMPLE_AUTH',
     'ENABLE_LOCAL_PAYMENT_SIMULATION',
   ]) {
-    assert.match(source, new RegExp(`env_value ${key}`), `missing fixed production gate for ${key}`);
+    assert.match(
+      source,
+      new RegExp(`env_value ${key}`),
+      `missing fixed production gate for ${key}`,
+    );
   }
 });
 
 test('public release verification proves the deployed web bundle and document', () => {
   assert.match(source, /public-web-version-after\.json/);
-  assert.match(source, /build_fingerprint_from_stdin web <"\$backup_dir\/public-web-version-after\.json"/);
+  assert.match(
+    source,
+    /build_fingerprint_from_stdin web <"\$backup_dir\/public-web-version-after\.json"/,
+  );
   assert.match(source, /public-homepage-document-after\.html/);
   assert.match(source, /Public web bundle does not match/);
 });
 
 test('target-schema protected tables may be absent only from the pre-migration baseline', () => {
   assert.match(source, /:'capture_role' <> 'baseline' and namespace\.oid is null/);
-  assert.match(
-    source,
-    /retention-managed-ids-after\.csv" retention comparison/,
-  );
+  assert.match(source, /retention-managed-ids-after\.csv" retention comparison/);
 });
 
 test('agent terminal states expand only for post-thaw growth evidence', () => {
   assert.match(source, /:'capture_role' = 'growth_comparison'/);
-  assert.match(
-    source,
-    /protected-business-ids-post-thaw\.csv" stable growth_comparison/,
-  );
-  assert.match(
-    source,
-    /protected-business-ids-after\.csv" stable comparison/,
-  );
+  assert.match(source, /protected-business-ids-post-thaw\.csv" stable growth_comparison/);
+  assert.match(source, /protected-business-ids-after\.csv" stable comparison/);
 });
 
 test('a resumed write-freeze release never downgrades its persistent recovery phase', () => {
@@ -548,7 +631,7 @@ test('a resumed write-freeze release never downgrades its persistent recovery ph
     source.indexOf('create_backup_and_rollback_point() {'),
     source.indexOf('\nrefresh_pre_mutation_database_backup() {'),
   );
-  const inherited = backup.indexOf("if [[ \"$recovery_in_progress\" == 'true' ]]");
+  const inherited = backup.indexOf('if [[ "$recovery_in_progress" == \'true\' ]]');
   const writeFreeze = backup.indexOf("release_phase='write-freeze'", inherited);
   const preWrite = backup.indexOf("release_phase='pre-write'", inherited);
   assert.ok(inherited >= 0 && writeFreeze > inherited && preWrite > writeFreeze);
@@ -557,7 +640,10 @@ test('a resumed write-freeze release never downgrades its persistent recovery ph
 });
 
 test('the thaw watchdog remains active until protected exit recovery finishes', () => {
-  const exitHandler = source.slice(source.indexOf('on_exit() {'), source.indexOf('\non_signal() {'));
+  const exitHandler = source.slice(
+    source.indexOf('on_exit() {'),
+    source.indexOf('\non_signal() {'),
+  );
   const rollback = exitHandler.indexOf('restore_application_rollback');
   const stopWatchdog = exitHandler.lastIndexOf('stop_thaw_watchdog');
   assert.ok(rollback >= 0 && stopWatchdog > rollback);
@@ -627,8 +713,8 @@ test('recovery is versioned, offline-capable, and waits for detached database wo
   );
   assert.doesNotMatch(recover, /git_fetch_origin_main|verify_github_release_gate/);
   const resume = source.slice(
-    source.indexOf("if [[ \"$mode\" == 'deploy' && \"$resume_recovery\" == 'true' ]]") ,
-    source.indexOf("if [[ \"$mode\" == 'resolve-recovery' ]]") ,
+    source.indexOf('if [[ "$mode" == \'deploy\' && "$resume_recovery" == \'true\' ]]'),
+    source.indexOf('if [[ "$mode" == \'resolve-recovery\' ]]'),
   );
   assert.match(resume, /wait_for_db_init_quiescence/);
   assert.match(resume, /pending_recovery_target_image_tag/);
@@ -642,7 +728,10 @@ test('release verifies public recovery projection and the full canonical backend
   assert.match(source, /canonical-homepage\.snapshot\.\$\{evidence_suffix\}\.json/);
   assert.match(source, /export-canonical-homepage\.js --stdout/);
   assert.match(source, /CANONICAL_EXPORT_TRUSTED_COMPOSE_INTERNAL=true/);
-  assert.match(source, /verify_canonical_full_snapshot \\\n\s+"\$resolved_full_snapshot" \\\n\s+recovery-resolve/);
+  assert.match(
+    source,
+    /verify_canonical_full_snapshot \\\n\s+"\$resolved_full_snapshot" \\\n\s+recovery-resolve/,
+  );
   assert.match(source, /homepage_projection=shared-by-previous-and-runtime/);
   assert.match(source, /alternate_full_snapshot/);
   assert.match(source, /backend settings differ from the verified target snapshot/);

--- a/tooling/lib/publish-images-workflow.test.mjs
+++ b/tooling/lib/publish-images-workflow.test.mjs
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const workflowPath = resolve(repositoryRoot, '.github/workflows/publish-images.yml');
+const source = readFileSync(workflowPath, 'utf8');
+const descriptorDockerfile = readFileSync(
+  resolve(repositoryRoot, 'tooling/release-descriptor.Dockerfile'),
+  'utf8',
+);
+
+test('image publication starts only after the official main CI workflow succeeds', () => {
+  assert.match(source, /^name: tokems-image-publish$/m);
+  assert.match(source, /workflow_run:/);
+  assert.match(source, /workflows: \[tokems-ci\]/);
+  assert.match(source, /types: \[completed\]/);
+  for (const gate of [
+    "workflow_run.event != 'push'",
+    "workflow_run.head_branch != 'main'",
+    "workflow_run.status != 'completed'",
+    "workflow_run.conclusion != 'success'",
+    'workflow_run.repository.full_name != expected_repository',
+    'workflow_run.head_repository.full_name != expected_repository',
+    "os.environ.get('WORKFLOW_SHA') != workflow_run.head_sha",
+  ]) {
+    assert.ok(source.includes(gate), `missing workflow trust gate: ${gate}`);
+  }
+  assert.match(source, /ref: \$\{\{ github\.event\.workflow_run\.head_sha \}\}/);
+  assert.match(source, /cancel-in-progress: false/);
+});
+
+test('workflow source guard rejects untrusted workflow_run payloads', () => {
+  const match = source.match(/python3 - <<'PY'\n([\s\S]*?)\n {10}PY/);
+  assert.ok(match, 'workflow_run source guard was not found');
+  const targetSha = 'a'.repeat(40);
+  const valid = {
+    event: 'push',
+    head_branch: 'main',
+    head_sha: targetSha,
+    status: 'completed',
+    conclusion: 'success',
+    repository: { full_name: 'yaojingang/TokEMS' },
+    head_repository: { full_name: 'yaojingang/TokEMS' },
+  };
+  const run = (payload, platform = 'linux/amd64') =>
+    spawnSync('python3', ['-'], {
+      encoding: 'utf8',
+      input: match[1].replace(/^ {10}/gm, ''),
+      env: {
+        ...process.env,
+        EXPECTED_REPOSITORY: 'yaojingang/TokEMS',
+        TARGET_SHA: targetSha,
+        WORKFLOW_SHA: targetSha,
+        PRODUCTION_PLATFORM: platform,
+        WORKFLOW_RUN_JSON: JSON.stringify(payload),
+      },
+    });
+
+  assert.equal(run(valid).status, 0);
+  for (const [field, value] of [
+    ['event', 'pull_request'],
+    ['head_branch', 'feature'],
+    ['status', 'in_progress'],
+    ['conclusion', 'failure'],
+  ]) {
+    assert.notEqual(run({ ...valid, [field]: value }).status, 0, `${field} drift passed`);
+  }
+  assert.notEqual(run({ ...valid, head_repository: { full_name: 'attacker/TokEMS' } }).status, 0);
+  assert.notEqual(run(valid, 'linux/riscv64').status, 0);
+  const staleWorkflow = spawnSync('python3', ['-'], {
+    encoding: 'utf8',
+    input: match[1].replace(/^ {10}/gm, ''),
+    env: {
+      ...process.env,
+      EXPECTED_REPOSITORY: 'yaojingang/TokEMS',
+      TARGET_SHA: targetSha,
+      WORKFLOW_SHA: 'b'.repeat(40),
+      PRODUCTION_PLATFORM: 'linux/amd64',
+      WORKFLOW_RUN_JSON: JSON.stringify(valid),
+    },
+  });
+  assert.notEqual(staleWorkflow.status, 0);
+});
+
+test('image publication uses an explicit production platform and immutable release identity', () => {
+  assert.match(source, /PRODUCTION_PLATFORM: \$\{\{ vars\.PRODUCTION_PLATFORM \}\}/);
+  assert.match(source, /linux\/(amd64|arm64)/);
+  assert.doesNotMatch(source, /PRODUCTION_PLATFORM:-linux\/amd64/);
+  for (const service of ['api', 'worker', 'web', 'admin', 'gateway', 'notification-sink']) {
+    assert.match(source, new RegExp(`- ${service.replace('-', '\\-')}`));
+  }
+  assert.match(
+    source,
+    /\$\{\{ matrix\.service \}\}-\$\{\{ needs\.guard\.outputs\.target_sha \}\}-\$\{\{ github\.run_id \}\}/,
+  );
+  assert.match(source, /release-\$\{TARGET_SHA\}/);
+  assert.match(source, /Refusing to overwrite the immutable release descriptor/);
+  assert.match(source, /TokEMS GHCR package must remain private/);
+  assert.match(source, /Unable to establish TokEMS GHCR package visibility before publication/);
+  assert.doesNotMatch(source, /package_visibility=.*gh api[^\n]+\|\| true/);
+  assert.match(source, /docker buildx imagetools create/);
+  assert.match(source, /--prefer-index=false/);
+  assert.match(source, /final_digest.*steps\.descriptor\.outputs\.digest/s);
+  assert.match(source, /descriptor_ref="\$\{GHCR_PACKAGE\}@\$\{descriptor_digest\}"/);
+  assert.match(
+    source,
+    /imagetools inspect --format '\{\{json \.Image\.Config\.Labels\}\}' "\$descriptor_ref"/,
+  );
+  assert.ok(
+    source.indexOf('Attest release descriptor provenance') <
+      source.indexOf('Publish the immutable release descriptor last'),
+    'the final release tag must appear only after descriptor attestation',
+  );
+  assert.match(descriptorDockerfile, /com\.tokems\.release\.image\.notification-sink/);
+  assert.match(
+    descriptorDockerfile,
+    /COPY --from=release source\.bundle \/release\/source\.bundle/,
+  );
+  assert.match(
+    descriptorDockerfile,
+    /COPY tooling\/release-descriptor\.py \/release\/release-descriptor\.py/,
+  );
+  assert.match(descriptorDockerfile, /com\.tokems\.release\.source-bundle\.sha256/);
+  assert.match(descriptorDockerfile, /com\.tokems\.release\.verifier\.sha256/);
+  assert.match(source, /source_ref='refs\/heads\/tokems-release-source'/);
+  assert.match(source, /git bundle create "\$bundle_file" "\$source_ref"/);
+  assert.match(source, /git bundle verify/);
+  assert.match(source, /fetch-depth: 0/);
+  assert.match(
+    source,
+    /build-contexts:[\s\S]*release=\$\{\{ runner\.temp \}\}\/tokems-release-context/,
+  );
+  assert.match(source, /SOURCE_BUNDLE_SHA256=\$\{\{ steps\.source\.outputs\.bundle_sha256 \}\}/);
+  assert.match(source, /VERIFIER_SHA256=\$\{\{ steps\.source\.outputs\.verifier_sha256 \}\}/);
+  assert.match(source, /sha256sum tooling\/release-descriptor\.py/);
+  assert.doesNotMatch(source, /python3 "\$payload_dir\/release-descriptor\.py"/);
+});
+
+test('every service and the descriptor receive GitHub provenance', () => {
+  assert.match(source, /permissions:[\s\S]*packages: write/);
+  assert.match(source, /permissions:[\s\S]*id-token: write/);
+  assert.match(source, /permissions:[\s\S]*attestations: write/);
+  assert.ok(
+    source.match(/actions\/attest-build-provenance@[0-9a-f]{40}/g)?.length >= 2,
+    'service images and the release descriptor must both be attested',
+  );
+  assert.match(source, /gh attestation verify/);
+  assert.match(source, /--source-digest "\$TARGET_SHA"/);
+  assert.match(source, /--source-ref refs\/heads\/main/);
+  assert.match(source, /--deny-self-hosted-runners/);
+  assert.doesNotMatch(source, /uses: [^\n]+@(v|main|master)(?:\d|\b)/);
+});

--- a/tooling/lib/release-descriptor.test.mjs
+++ b/tooling/lib/release-descriptor.test.mjs
@@ -1,0 +1,419 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const verifierPath = resolve(repositoryRoot, 'tooling/release-descriptor.py');
+const sha = 'a'.repeat(40);
+const migrationHash = 'b'.repeat(64);
+const sourceBundleHash = 'c'.repeat(64);
+const verifierHash = 'd'.repeat(64);
+const buildTime = '2026-09-02T04:05:06Z';
+const platform = 'linux/amd64';
+const services = ['api', 'worker', 'web', 'admin', 'gateway', 'notification-sink'];
+
+function descriptorLabels(overrides = {}) {
+  const labels = {
+    'org.opencontainers.image.source': 'https://github.com/yaojingang/TokEMS',
+    'org.opencontainers.image.revision': sha,
+    'org.opencontainers.image.created': buildTime,
+    'com.tokems.release.schema': '2',
+    'com.tokems.release.platform': platform,
+    'com.tokems.release.source-bundle.ref': 'refs/heads/tokems-release-source',
+    'com.tokems.release.source-bundle.sha256': sourceBundleHash,
+    'com.tokems.release.verifier.sha256': verifierHash,
+    'com.tokems.build.sha': sha,
+    'com.tokems.build.time': buildTime,
+    'com.tokems.build.migration': '0054_example.sql',
+    'com.tokems.build.migration-hash': migrationHash,
+  };
+  services.forEach((service, index) => {
+    labels[`com.tokems.release.image.${service}`] =
+      `ghcr.io/yaojingang/tokems@sha256:${String(index + 1).repeat(64)}`;
+  });
+  return { ...labels, ...overrides };
+}
+
+function runVerifier(args) {
+  return spawnSync('python3', [verifierPath, ...args], { encoding: 'utf8' });
+}
+
+test('release descriptor verifier emits a complete immutable image set', () => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-release-descriptor-'));
+  const labelsFile = resolve(directory, 'labels.json');
+  const recordsFile = resolve(directory, 'records.tsv');
+  try {
+    writeFileSync(labelsFile, JSON.stringify(descriptorLabels()));
+    const result = runVerifier([
+      'verify-descriptor',
+      '--labels-file',
+      labelsFile,
+      '--target-sha',
+      sha,
+      '--platform',
+      platform,
+      '--records-output',
+      recordsFile,
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    const records = readFileSync(recordsFile, 'utf8');
+    assert.match(records, new RegExp(`^build\\tsha\\t${sha}$`, 'm'));
+    assert.match(records, /^build\tmigration\t0054_example\.sql$/m);
+    assert.match(
+      records,
+      new RegExp(`^release\\tsource-bundle-sha256\\t${sourceBundleHash}$`, 'm'),
+    );
+    assert.match(records, new RegExp(`^release\\tverifier-sha256\\t${verifierHash}$`, 'm'));
+    for (const service of services) {
+      assert.match(
+        records,
+        new RegExp(
+          `^image\\t${service.replace('-', '\\-')}\\tghcr\\.io/yaojingang/tokems@sha256:[0-9]+$`,
+          'm',
+        ),
+      );
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('release descriptor verifier rejects partial, drifting, and non-atomic descriptors', () => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-release-descriptor-invalid-'));
+  const labelsFile = resolve(directory, 'labels.json');
+  try {
+    const cases = [
+      [
+        'missing service',
+        (() => {
+          const labels = descriptorLabels();
+          delete labels['com.tokems.release.image.worker'];
+          return labels;
+        })(),
+        /exactly the six supported service images/i,
+      ],
+      [
+        'wrong source sha',
+        descriptorLabels({ 'org.opencontainers.image.revision': 'c'.repeat(40) }),
+        /revision/i,
+      ],
+      [
+        'wrong platform',
+        descriptorLabels({ 'com.tokems.release.platform': 'linux/arm64' }),
+        /platform/i,
+      ],
+      [
+        'duplicate digest',
+        descriptorLabels({
+          'com.tokems.release.image.worker': 'ghcr.io/yaojingang/tokems@sha256:' + '1'.repeat(64),
+        }),
+        /unique digest/i,
+      ],
+      [
+        'extra service',
+        descriptorLabels({
+          'com.tokems.release.image.debug': 'ghcr.io/yaojingang/tokems@sha256:' + '9'.repeat(64),
+        }),
+        /exactly the six supported service images/i,
+      ],
+      [
+        'invalid calendar time',
+        descriptorLabels({
+          'org.opencontainers.image.created': '2026-99-02T04:05:06Z',
+          'com.tokems.build.time': '2026-99-02T04:05:06Z',
+        }),
+        /valid calendar time/i,
+      ],
+      [
+        'missing source bundle hash',
+        (() => {
+          const labels = descriptorLabels();
+          delete labels['com.tokems.release.source-bundle.sha256'];
+          return labels;
+        })(),
+        /source bundle/i,
+      ],
+      [
+        'wrong source bundle ref',
+        descriptorLabels({
+          'com.tokems.release.source-bundle.ref': 'refs/heads/attacker',
+        }),
+        /source bundle ref/i,
+      ],
+    ];
+
+    for (const [name, labels, expected] of cases) {
+      writeFileSync(labelsFile, JSON.stringify(labels));
+      const result = runVerifier([
+        'verify-descriptor',
+        '--labels-file',
+        labelsFile,
+        '--target-sha',
+        sha,
+        '--platform',
+        platform,
+      ]);
+      assert.notEqual(result.status, 0, `${name} unexpectedly passed`);
+      assert.match(result.stderr, expected, name);
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('source bundle verifier accepts the exact release ref and rejects wrong or corrupt bundles', () => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-source-bundle-'));
+  const repository = resolve(directory, 'repository');
+  const bundle = resolve(directory, 'source.bundle');
+  const corruptedBundle = resolve(directory, 'source-corrupt.bundle');
+  const runGit = (args) => spawnSync('git', ['-C', repository, ...args], { encoding: 'utf8' });
+  try {
+    assert.equal(spawnSync('git', ['init', repository], { encoding: 'utf8' }).status, 0);
+    assert.equal(runGit(['config', 'user.name', 'TokEMS Test']).status, 0);
+    assert.equal(runGit(['config', 'user.email', 'tokems-test@example.invalid']).status, 0);
+    writeFileSync(resolve(repository, 'release.txt'), 'verified source\n');
+    assert.equal(runGit(['add', 'release.txt']).status, 0);
+    assert.equal(runGit(['commit', '-m', 'release source']).status, 0);
+    const targetSha = runGit(['rev-parse', 'HEAD']).stdout.trim();
+    assert.match(targetSha, /^[0-9a-f]{40}$/);
+    assert.equal(runGit(['update-ref', 'refs/heads/tokems-release-source', targetSha]).status, 0);
+    const created = runGit(['bundle', 'create', bundle, 'refs/heads/tokems-release-source']);
+    assert.equal(created.status, 0, created.stderr);
+
+    const accepted = runVerifier([
+      'verify-source-bundle',
+      '--bundle-file',
+      bundle,
+      '--target-sha',
+      targetSha,
+    ]);
+    assert.equal(accepted.status, 0, accepted.stderr);
+
+    const wrongSha = runVerifier([
+      'verify-source-bundle',
+      '--bundle-file',
+      bundle,
+      '--target-sha',
+      'f'.repeat(40),
+    ]);
+    assert.notEqual(wrongSha.status, 0);
+    assert.match(wrongSha.stderr, /target/i);
+
+    const bundleBytes = readFileSync(bundle);
+    writeFileSync(corruptedBundle, bundleBytes.subarray(0, Math.max(1, bundleBytes.length - 32)));
+    const corrupted = runVerifier([
+      'verify-source-bundle',
+      '--bundle-file',
+      corruptedBundle,
+      '--target-sha',
+      targetSha,
+    ]);
+    assert.notEqual(corrupted.status, 0);
+    assert.match(corrupted.stderr, /bundle/i);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('source bundle importer fast-forwards only origin/main and leaves production HEAD untouched', () => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-source-import-'));
+  const sourceRepository = resolve(directory, 'source');
+  const productionRepository = resolve(directory, 'production');
+  const unrelatedRepository = resolve(directory, 'unrelated');
+  const bundle = resolve(directory, 'source.bundle');
+  const unrelatedBundle = resolve(directory, 'unrelated.bundle');
+  const runGit = (repository, args) =>
+    spawnSync('git', ['-C', repository, ...args], { encoding: 'utf8' });
+  try {
+    assert.equal(
+      spawnSync('git', ['init', '--initial-branch=main', sourceRepository], {
+        encoding: 'utf8',
+      }).status,
+      0,
+    );
+    assert.equal(runGit(sourceRepository, ['config', 'user.name', 'TokEMS Test']).status, 0);
+    assert.equal(
+      runGit(sourceRepository, ['config', 'user.email', 'tokems-test@example.invalid']).status,
+      0,
+    );
+    writeFileSync(resolve(sourceRepository, 'release.txt'), 'base\n');
+    assert.equal(runGit(sourceRepository, ['add', 'release.txt']).status, 0);
+    assert.equal(runGit(sourceRepository, ['commit', '-m', 'base']).status, 0);
+    const baseSha = runGit(sourceRepository, ['rev-parse', 'HEAD']).stdout.trim();
+
+    const cloned = spawnSync('git', ['clone', sourceRepository, productionRepository], {
+      encoding: 'utf8',
+    });
+    assert.equal(cloned.status, 0, cloned.stderr);
+    assert.equal(runGit(productionRepository, ['branch', '-m', 'production']).status, 0);
+
+    writeFileSync(resolve(sourceRepository, 'release.txt'), 'target\n');
+    assert.equal(runGit(sourceRepository, ['add', 'release.txt']).status, 0);
+    assert.equal(runGit(sourceRepository, ['commit', '-m', 'target']).status, 0);
+    const targetSha = runGit(sourceRepository, ['rev-parse', 'HEAD']).stdout.trim();
+    assert.equal(
+      runGit(sourceRepository, ['update-ref', 'refs/heads/tokems-release-source', targetSha])
+        .status,
+      0,
+    );
+    const created = runGit(sourceRepository, [
+      'bundle',
+      'create',
+      bundle,
+      'refs/heads/tokems-release-source',
+    ]);
+    assert.equal(created.status, 0, created.stderr);
+
+    const imported = runVerifier([
+      'import-source-bundle',
+      '--bundle-file',
+      bundle,
+      '--repository',
+      productionRepository,
+      '--target-sha',
+      targetSha,
+      '--timeout-seconds',
+      '30',
+    ]);
+    assert.equal(imported.status, 0, imported.stderr);
+    assert.equal(
+      runGit(productionRepository, ['rev-parse', 'refs/remotes/origin/main']).stdout.trim(),
+      targetSha,
+    );
+    assert.equal(runGit(productionRepository, ['rev-parse', 'HEAD']).stdout.trim(), baseSha);
+    assert.equal(runGit(productionRepository, ['status', '--porcelain']).stdout, '');
+
+    assert.equal(
+      runGit(productionRepository, ['update-ref', 'refs/tokems-deploy/source-candidate', targetSha])
+        .status,
+      0,
+    );
+    const concurrentImport = runVerifier([
+      'import-source-bundle',
+      '--bundle-file',
+      bundle,
+      '--repository',
+      productionRepository,
+      '--target-sha',
+      targetSha,
+      '--timeout-seconds',
+      '30',
+    ]);
+    assert.notEqual(concurrentImport.status, 0);
+    assert.match(concurrentImport.stderr, /reserved source candidate ref already exists/i);
+    assert.equal(
+      runGit(productionRepository, ['update-ref', '-d', 'refs/tokems-deploy/source-candidate'])
+        .status,
+      0,
+    );
+
+    assert.equal(
+      spawnSync('git', ['init', '--initial-branch=main', unrelatedRepository], {
+        encoding: 'utf8',
+      }).status,
+      0,
+    );
+    assert.equal(runGit(unrelatedRepository, ['config', 'user.name', 'TokEMS Test']).status, 0);
+    assert.equal(
+      runGit(unrelatedRepository, ['config', 'user.email', 'tokems-test@example.invalid']).status,
+      0,
+    );
+    writeFileSync(resolve(unrelatedRepository, 'unrelated.txt'), 'unrelated\n');
+    assert.equal(runGit(unrelatedRepository, ['add', 'unrelated.txt']).status, 0);
+    assert.equal(runGit(unrelatedRepository, ['commit', '-m', 'unrelated']).status, 0);
+    const unrelatedSha = runGit(unrelatedRepository, ['rev-parse', 'HEAD']).stdout.trim();
+    assert.equal(
+      runGit(unrelatedRepository, ['update-ref', 'refs/heads/tokems-release-source', unrelatedSha])
+        .status,
+      0,
+    );
+    assert.equal(
+      runGit(unrelatedRepository, [
+        'bundle',
+        'create',
+        unrelatedBundle,
+        'refs/heads/tokems-release-source',
+      ]).status,
+      0,
+    );
+    const rejected = runVerifier([
+      'import-source-bundle',
+      '--bundle-file',
+      unrelatedBundle,
+      '--repository',
+      productionRepository,
+      '--target-sha',
+      unrelatedSha,
+      '--timeout-seconds',
+      '30',
+    ]);
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stderr, /cannot fast-forward/i);
+    assert.equal(
+      runGit(productionRepository, [
+        'show-ref',
+        '--verify',
+        '--quiet',
+        'refs/tokems-deploy/source-candidate',
+      ]).status,
+      1,
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('service image verifier checks platform, service, source, and all build identity fields', () => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-release-image-'));
+  const metadataFile = resolve(directory, 'image.json');
+  const labels = {
+    'org.opencontainers.image.source': 'https://github.com/yaojingang/TokEMS',
+    'org.opencontainers.image.revision': sha,
+    'org.opencontainers.image.created': buildTime,
+    'com.tokems.service': 'api',
+    'com.tokems.build.sha': sha,
+    'com.tokems.build.time': buildTime,
+    'com.tokems.build.migration': '0054_example.sql',
+    'com.tokems.build.migration-hash': migrationHash,
+  };
+  try {
+    writeFileSync(
+      metadataFile,
+      JSON.stringify({ architecture: 'amd64', os: 'linux', config: { Labels: labels } }),
+    );
+    const baseArgs = [
+      'verify-service',
+      '--metadata-file',
+      metadataFile,
+      '--service',
+      'api',
+      '--target-sha',
+      sha,
+      '--build-time',
+      buildTime,
+      '--migration',
+      '0054_example.sql',
+      '--migration-hash',
+      migrationHash,
+      '--platform',
+      platform,
+    ];
+    const accepted = runVerifier(baseArgs);
+    assert.equal(accepted.status, 0, accepted.stderr);
+
+    labels['com.tokems.service'] = 'worker';
+    writeFileSync(
+      metadataFile,
+      JSON.stringify({ architecture: 'amd64', os: 'linux', config: { Labels: labels } }),
+    );
+    const rejected = runVerifier(baseArgs);
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stderr, /service/i);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/tooling/production-deploy.sh
+++ b/tooling/production-deploy.sh
@@ -12,7 +12,14 @@ readonly GIT_USER='ecs-user'
 readonly EXPECTED_ORIGIN='https://github.com/yaojingang/TokEMS.git'
 readonly EXPECTED_BRANCH='production'
 readonly EXPECTED_UPSTREAM='origin/main'
+readonly EXPECTED_UPSTREAM_REF='refs/remotes/origin/main'
+readonly SOURCE_BUNDLE_REF='refs/heads/tokems-release-source'
 readonly GITHUB_REPOSITORY='yaojingang/TokEMS'
+readonly IMAGE_PUBLISH_WORKFLOW='.github/workflows/publish-images.yml'
+readonly GHCR_REGISTRY='ghcr.io'
+readonly GHCR_USERNAME='yaojingang'
+readonly GHCR_PACKAGE='ghcr.io/yaojingang/tokems'
+readonly GHCR_TOKEN_FILE='/etc/tokems/ghcr-read-token'
 readonly PUBLIC_ORIGIN='https://hui.ailingdaoli.com'
 readonly ADMIN_ORIGIN='https://admin.hui.ailingdaoli.com'
 readonly PAYMENT_URL='https://www.ailingdaoli.com/pay/hui/'
@@ -34,7 +41,7 @@ readonly DB_QUERY_TIMEOUT_SECONDS=120
 readonly DB_DUMP_TIMEOUT_SECONDS=1800
 readonly DB_MIGRATION_TIMEOUT_SECONDS=1800
 readonly SERVICE_TRANSITION_TIMEOUT_SECONDS=360
-readonly GIT_FETCH_TIMEOUT_SECONDS=180
+readonly GIT_BUNDLE_IMPORT_TIMEOUT_SECONDS=180
 readonly BUILD_TIMEOUT_SECONDS=3600
 readonly DATA_COMPARE_TIMEOUT_SECONDS=300
 readonly DATA_COMPARE_MAX_VIRTUAL_KIB=262144
@@ -69,6 +76,7 @@ readonly -a CANONICAL_SNAPSHOT_PATHS=(
 
 mode=''
 canonical_mode='auto'
+build_on_host='false'
 requested_target_sha=''
 target_sha=''
 source_head_before=''
@@ -131,6 +139,24 @@ active_compose_file="$DEFAULT_COMPOSE_FILE_PATH"
 session_env_file=''
 release_source_dir=''
 build_compose_file=''
+registry_auth_dir=''
+descriptor_evidence_dir=''
+source_bundle_dir=''
+descriptor_container_id=''
+descriptor_digest=''
+descriptor_platform=''
+descriptor_build_sha=''
+descriptor_build_time=''
+descriptor_migration=''
+descriptor_migration_hash=''
+descriptor_source_bundle_sha256=''
+descriptor_verifier_sha256=''
+descriptor_api_ref=''
+descriptor_worker_ref=''
+descriptor_web_ref=''
+descriptor_admin_ref=''
+descriptor_gateway_ref=''
+descriptor_notification_sink_ref=''
 
 usage() {
   cat <<'USAGE'
@@ -156,11 +182,12 @@ Options:
                                 reuse the current images when the target changes only deployment controls.
   --skip-canonical              Allowed only when Git snapshots and production already match.
   --resume-recovery             Allow deploy to continue a verified read-only recovery state.
+  --build-on-host               Emergency path: build all images on this host after the 10 GiB gate.
   -h, --help                    Show this help.
 
 The default canonical mode is automatic. A Git snapshot change or production database
 drift enables the protected geo-conference/tokems26 synchronization while preserving
-production business data.
+production business data. Standard check and deploy modes use verified prebuilt images.
 USAGE
 }
 
@@ -182,18 +209,6 @@ git_as_owner() {
     GIT_CONFIG_NOSYSTEM=1 \
     GIT_CONFIG_GLOBAL=/dev/null \
     git -C "$APP_DIR" "$@"
-}
-
-git_fetch_origin_main() {
-  timeout --foreground --kill-after=10s "${GIT_FETCH_TIMEOUT_SECONDS}s" \
-    sudo -u "$GIT_USER" env -i \
-    "PATH=$SAFE_PATH" \
-    'HOME=/nonexistent' \
-    GIT_TERMINAL_PROMPT=0 \
-    GIT_NO_REPLACE_OBJECTS=1 \
-    GIT_CONFIG_NOSYSTEM=1 \
-    GIT_CONFIG_GLOBAL=/dev/null \
-    git -C "$APP_DIR" fetch --prune origin main
 }
 
 compose() {
@@ -291,8 +306,40 @@ cleanup_canonical_probe() {
   canonical_probe_actual_snapshot=''
 }
 
+cleanup_registry_state() {
+  if [[ -n "$descriptor_container_id" ]]; then
+    docker rm -f "$descriptor_container_id" >/dev/null 2>&1 || true
+    descriptor_container_id=''
+  fi
+  if [[ -n "$source_bundle_dir" && -d "$source_bundle_dir" ]]; then
+    case "$source_bundle_dir" in
+      /run/tokems-release-source.*)
+        find "$source_bundle_dir" -depth -delete 2>/dev/null || true
+        ;;
+    esac
+  fi
+  source_bundle_dir=''
+  if [[ -n "$registry_auth_dir" && -d "$registry_auth_dir" ]]; then
+    case "$registry_auth_dir" in
+      /run/lock/tokems-production-deploy/registry-auth.*)
+        find "$registry_auth_dir" -depth -delete 2>/dev/null || true
+        ;;
+    esac
+  fi
+  registry_auth_dir=''
+  if [[ -n "$descriptor_evidence_dir" && -d "$descriptor_evidence_dir" ]]; then
+    case "$descriptor_evidence_dir" in
+      /run/lock/tokems-production-deploy/release-descriptor.*)
+        find "$descriptor_evidence_dir" -depth -delete 2>/dev/null || true
+        ;;
+    esac
+  fi
+  descriptor_evidence_dir=''
+}
+
 cleanup_temp_script() {
   cleanup_canonical_probe
+  cleanup_registry_state
   if [[ -f "${BASH_SOURCE[0]}" ]]; then
     case "${BASH_SOURCE[0]}" in
       /run/lock/tokems-production-deploy/bootstrap.*) rm -f -- "${BASH_SOURCE[0]}" ;;
@@ -720,6 +767,10 @@ parse_arguments() {
         resume_recovery='true'
         shift
         ;;
+      --build-on-host)
+        build_on_host='true'
+        shift
+        ;;
       -h | --help)
         usage
         exit 0
@@ -736,6 +787,9 @@ parse_arguments() {
   fi
   if [[ "$resume_recovery" == 'true' && "$mode" != 'deploy' ]]; then
     die '--resume-recovery applies only to deploy mode.'
+  fi
+  if [[ "$build_on_host" == 'true' && "$mode" != 'check' && "$mode" != 'deploy' ]]; then
+    die '--build-on-host applies only to check and deploy modes.'
   fi
 }
 
@@ -755,13 +809,14 @@ pin_local_runtime_controls() {
   unset COMPOSE_FILE COMPOSE_PROJECT_NAME COMPOSE_PROFILES COMPOSE_ENV_FILES
   unset COMPOSE_PATH_SEPARATOR COMPOSE_CONVERT_WINDOWS_PATHS COMPOSE_IGNORE_ORPHANS
   unset BUILD_SHA BUILD_TIME BUILD_MIGRATION BUILD_MIGRATION_HASH
+  unset GH_TOKEN GITHUB_TOKEN
   unset TOKEMS_READ_ONLY_DATABASE_URL SEED_DEMO_DATA COMPOSE_PARALLEL_LIMIT
 }
 
 require_root_and_base_commands() {
   [[ "$(id -u)" -eq 0 ]] || die 'Run this command with sudo or as root.'
   local command_name
-  for command_name in bash sudo env git flock curl python3 docker nginx awk grep sed sha256sum find sort tail tar install ps mkdir stat dirname df mktemp cp mv chmod chown rm basename date timeout sleep cat readlink systemd-run systemctl; do
+  for command_name in bash sudo env git flock curl python3 docker nginx awk grep sed sha256sum find sort tail tar install ps mkdir stat dirname df mktemp cp mv chmod chown rm basename date timeout sleep cat readlink systemd-run systemctl uname; do
     require_command "$command_name"
   done
   [[ "$(cd "$APP_DIR" && pwd -P)" == "$APP_DIR" ]] || die 'Production app path resolved unexpectedly.'
@@ -1095,16 +1150,21 @@ assert_minimal_git_state() {
 }
 
 bootstrap_latest_script() {
-  log 'Loading the deployment script from the latest origin/main commit'
-  git_fetch_origin_main
+  log 'Loading the deployment script from the latest verified main release'
   local latest_sha latest_script_sha current_script_sha temp_script
-  latest_sha="$(git_as_owner rev-parse origin/main)"
+  latest_sha="$(github_main_sha)"
   assert_target_selection "$latest_sha"
+  target_sha="$latest_sha"
+  verify_github_release_gate
+  verify_image_publish_gate
+  prepare_release_source_bundle
+  verify_release_descriptor
+  [[ "$(git_as_owner rev-parse "$EXPECTED_UPSTREAM_REF")" == "$target_sha" ]] || {
+    die 'Verified release source did not update origin/main to the target commit.'
+  }
   git_as_owner merge-base --is-ancestor "$(git_as_owner rev-parse HEAD)" "$latest_sha" || {
     die 'Server production branch cannot fast-forward to origin/main.'
   }
-  target_sha="$latest_sha"
-  verify_github_release_gate
   latest_script_sha="$(git_as_owner show "${latest_sha}:tooling/production-deploy.sh" | sha256sum | awk '{ print $1 }')"
   current_script_sha="$(sha256sum "${BASH_SOURCE[0]}" | awk '{ print $1 }')"
   [[ "$current_script_sha" != "$latest_script_sha" ]] || return 0
@@ -1118,6 +1178,8 @@ bootstrap_latest_script() {
     rm -f -- "$temp_script"
     die 'The deployment script on origin/main failed shell syntax validation.'
   }
+
+  cleanup_registry_state
 
   exec env -i \
     "PATH=$SAFE_PATH" \
@@ -1233,6 +1295,27 @@ github_get() {
   curl "${CURL_ARGS[@]}" --location "${headers[@]}" "$url"
 }
 
+github_main_sha() {
+  github_get "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/main" \
+    | python3 -c '
+import json, re, sys
+payload = json.load(sys.stdin)
+sha = payload.get("sha", "")
+if not re.fullmatch(r"[0-9a-f]{40}", sha):
+    raise SystemExit("GitHub main did not resolve to a full lowercase commit SHA")
+print(sha)
+'
+}
+
+assert_github_main_unchanged() {
+  local latest_sha
+  latest_sha="$(github_main_sha)"
+  [[ "$latest_sha" == "$target_sha" ]] || {
+    die "GitHub main advanced to ${latest_sha}; approved target was ${target_sha}."
+  }
+  assert_target_selection "$latest_sha"
+}
+
 verify_github_release_gate() {
   log "Verifying merged PR and successful main CI for ${target_sha}"
   github_get "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${target_sha}/pulls?per_page=100" \
@@ -1291,6 +1374,346 @@ if not valid:
     raise SystemExit("official GitHub Actions quality-and-flows job has not completed successfully for origin/main")
 print("Official GitHub Actions quality-and-flows job verified")
 ' "$target_sha"
+}
+
+verify_image_publish_gate() {
+  log "Verifying successful immutable image publication for ${target_sha}"
+  github_get "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/publish-images.yml/runs?branch=main&event=workflow_run&per_page=100" \
+    | python3 -c '
+import json, sys
+target = sys.argv[1]
+payload = json.load(sys.stdin)
+valid = [
+    item for item in payload.get("workflow_runs", [])
+    if item.get("name") == "tokems-image-publish"
+    and item.get("path") == ".github/workflows/publish-images.yml"
+    and item.get("event") == "workflow_run"
+    and item.get("head_branch") == "main"
+    and item.get("head_sha") == target
+    and item.get("status") == "completed"
+    and item.get("conclusion") == "success"
+    and (item.get("repository") or {}).get("full_name") == "yaojingang/TokEMS"
+    and (item.get("head_repository") or {}).get("full_name") == "yaojingang/TokEMS"
+]
+if not valid:
+    raise SystemExit("official image publication workflow has not completed successfully for origin/main")
+print("Official image publication workflow verified: run {}".format(valid[0]["id"]))
+' "$target_sha"
+}
+
+expected_release_platform() {
+  case "$(uname -m)" in
+    x86_64) printf 'linux/amd64\n' ;;
+    aarch64 | arm64) printf 'linux/arm64\n' ;;
+    *) die "Unsupported production CPU architecture: $(uname -m)" ;;
+  esac
+}
+
+registry_docker() {
+  [[ -n "$registry_auth_dir" && -d "$registry_auth_dir" ]] || die 'Temporary GHCR authentication is unavailable.'
+  env -i \
+    "PATH=$SAFE_PATH" \
+    'HOME=/root' \
+    "DOCKER_HOST=$LOCAL_DOCKER_HOST" \
+    "DOCKER_CONFIG=$registry_auth_dir" \
+    docker "$@"
+}
+
+registry_gh() {
+  [[ -n "$registry_auth_dir" && -d "$registry_auth_dir" ]] || die 'Temporary GHCR authentication is unavailable.'
+  local token
+  IFS= read -r token <"$GHCR_TOKEN_FILE"
+  [[ -n "$token" && "$token" != *[[:space:]]* ]] || die 'GHCR read token file contains an invalid value.'
+  env -i \
+    "PATH=$SAFE_PATH" \
+    'HOME=/root' \
+    "XDG_CACHE_HOME=$registry_auth_dir/cache" \
+    "DOCKER_CONFIG=$registry_auth_dir" \
+    "GH_TOKEN=$token" \
+    gh "$@"
+}
+
+login_ghcr() {
+  require_command gh
+  docker buildx version >/dev/null || die 'Docker Buildx is required to inspect immutable release images.'
+  gh attestation verify --help >/dev/null || die 'GitHub CLI does not support attestation verification.'
+
+  local network_status
+  network_status="$({
+    env -i "PATH=$SAFE_PATH" 'HOME=/root' curl \
+      --silent \
+      --show-error \
+      --connect-timeout 10 \
+      --max-time 30 \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      "https://${GHCR_REGISTRY}/v2/"
+  } 2>/dev/null)" || die 'GHCR network probe failed before authentication.'
+  [[ "$network_status" == '200' || "$network_status" == '401' ]] || {
+    die "GHCR network probe returned unexpected HTTP status ${network_status}."
+  }
+  [[ -e "$GHCR_TOKEN_FILE" || -L "$GHCR_TOKEN_FILE" ]] || {
+    die "GHCR read token file is missing: ${GHCR_TOKEN_FILE}"
+  }
+  assert_trusted_recovery_file "$GHCR_TOKEN_FILE"
+
+  registry_auth_dir="$(mktemp -d "${LOCK_DIR}/registry-auth.XXXXXX")"
+  chmod 700 "$registry_auth_dir"
+  local token login_error
+  IFS= read -r token <"$GHCR_TOKEN_FILE"
+  [[ -n "$token" && "$token" != *[[:space:]]* ]] || die 'GHCR read token file contains an invalid value.'
+  login_error="$registry_auth_dir/login.err"
+  if ! printf '%s' "$token" \
+    | env -i \
+      "PATH=$SAFE_PATH" \
+      'HOME=/root' \
+      "DOCKER_HOST=$LOCAL_DOCKER_HOST" \
+      "DOCKER_CONFIG=$registry_auth_dir" \
+      docker login "$GHCR_REGISTRY" --username "$GHCR_USERNAME" --password-stdin \
+      >/dev/null 2>"$login_error"; then
+    die 'GHCR authentication failed; the read token may be expired or invalid.'
+  fi
+  : >"$login_error"
+  local package_visibility
+  package_visibility="$(registry_gh api /users/yaojingang/packages/container/tokems --jq .visibility)" || {
+    die 'Unable to verify the TokEMS GHCR package visibility.'
+  }
+  [[ "$package_visibility" == 'private' ]] || die 'The TokEMS GHCR package must remain private.'
+}
+
+prepare_release_source_bundle() {
+  [[ -z "$descriptor_evidence_dir" ]] || die 'Release descriptor preparation ran more than once.'
+  login_ghcr
+  descriptor_platform="$(expected_release_platform)"
+  descriptor_evidence_dir="$(mktemp -d "${LOCK_DIR}/release-descriptor.XXXXXX")"
+  chmod 700 "$descriptor_evidence_dir"
+
+  local release_ref descriptor_ref labels_file bootstrap_records_file
+  local source_bundle_file verifier git_group target_verifier_hash
+  release_ref="${GHCR_PACKAGE}:release-${target_sha}"
+  labels_file="$descriptor_evidence_dir/labels.json"
+  bootstrap_records_file="$descriptor_evidence_dir/bootstrap-records.tsv"
+  source_bundle_file="$descriptor_evidence_dir/source.bundle"
+  verifier="$descriptor_evidence_dir/release-descriptor.py"
+
+  descriptor_digest="$(registry_docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$release_ref")"
+  [[ "$descriptor_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || die 'Release descriptor has an invalid registry digest.'
+  descriptor_ref="${GHCR_PACKAGE}@${descriptor_digest}"
+  registry_docker buildx imagetools inspect \
+    --format '{{json .Image.Config.Labels}}' \
+    "$descriptor_ref" >"$labels_file" || {
+    die "Immutable release descriptor is missing or unreadable: release-${target_sha}"
+  }
+  printf '%s\n' "$descriptor_digest" >"$descriptor_evidence_dir/descriptor-digest.txt"
+  registry_gh attestation verify "oci://${GHCR_PACKAGE}@${descriptor_digest}" \
+    --repo "$GITHUB_REPOSITORY" \
+    --signer-workflow "${GITHUB_REPOSITORY}/${IMAGE_PUBLISH_WORKFLOW}" \
+    --source-digest "$target_sha" \
+    --source-ref refs/heads/main \
+    --deny-self-hosted-runners \
+    --format json >"$descriptor_evidence_dir/descriptor-attestation.json"
+
+  python3 - "$labels_file" "$target_sha" "$descriptor_platform" >"$bootstrap_records_file" <<'PY'
+import json
+import re
+import sys
+
+labels_file, target_sha, platform = sys.argv[1:]
+with open(labels_file, encoding="utf-8") as handle:
+    labels = json.load(handle)
+if not isinstance(labels, dict):
+    raise SystemExit("release descriptor labels must be a JSON object")
+
+expected = {
+    "org.opencontainers.image.source": "https://github.com/yaojingang/TokEMS",
+    "org.opencontainers.image.revision": target_sha,
+    "com.tokems.release.schema": "2",
+    "com.tokems.release.platform": platform,
+    "com.tokems.release.source-bundle.ref": "refs/heads/tokems-release-source",
+    "com.tokems.build.sha": target_sha,
+}
+for key, value in expected.items():
+    if labels.get(key) != value:
+        raise SystemExit(f"release descriptor bootstrap label mismatch: {key}")
+
+for record_name, key in (
+    ("source-bundle-sha256", "com.tokems.release.source-bundle.sha256"),
+    ("verifier-sha256", "com.tokems.release.verifier.sha256"),
+):
+    value = labels.get(key, "")
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value):
+        raise SystemExit(f"release descriptor bootstrap hash is invalid: {key}")
+    print("release", record_name, value, sep="\t")
+PY
+
+  while IFS=$'\t' read -r record_type record_name record_value; do
+    case "${record_type}:${record_name}" in
+      release:source-bundle-sha256) descriptor_source_bundle_sha256="$record_value" ;;
+      release:verifier-sha256) descriptor_verifier_sha256="$record_value" ;;
+      *) die "Unexpected bootstrap descriptor record: ${record_type}:${record_name}" ;;
+    esac
+  done <"$bootstrap_records_file"
+
+  registry_docker pull --platform "$descriptor_platform" "$descriptor_ref" \
+    >"$descriptor_evidence_dir/descriptor-pull.log" 2>&1 || {
+    die 'Unable to pull the verified release descriptor payload.'
+  }
+  descriptor_container_id="$(registry_docker create "$descriptor_ref" /release/source.bundle)"
+  [[ -n "$descriptor_container_id" ]] || die 'Unable to create a temporary descriptor payload container.'
+  registry_docker cp "${descriptor_container_id}:/release/source.bundle" "$source_bundle_file"
+  registry_docker cp "${descriptor_container_id}:/release/release-descriptor.py" "$verifier"
+  registry_docker rm "$descriptor_container_id" >/dev/null
+  descriptor_container_id=''
+
+  [[ -f "$source_bundle_file" && ! -L "$source_bundle_file" ]] || die 'Descriptor source bundle is not a regular file.'
+  [[ -f "$verifier" && ! -L "$verifier" ]] || die 'Descriptor verifier is not a regular file.'
+  [[ "$(sha256sum "$source_bundle_file" | awk '{ print $1 }')" == "$descriptor_source_bundle_sha256" ]] || {
+    die 'Descriptor source bundle payload hash does not match its verified label.'
+  }
+  [[ "$(sha256sum "$verifier" | awk '{ print $1 }')" == "$descriptor_verifier_sha256" ]] || {
+    die 'Descriptor verifier payload hash does not match its verified label.'
+  }
+  chmod 600 "$source_bundle_file" "$verifier"
+
+  source_bundle_dir="$(mktemp -d /run/tokems-release-source.XXXXXX)"
+  [[ -d "$source_bundle_dir" && ! -L "$source_bundle_dir" ]] || die 'Unable to create a trusted source bundle transport directory.'
+  chmod 711 "$source_bundle_dir"
+  git_group="$(id -gn "$GIT_USER")"
+  install -o root -g "$git_group" -m 440 "$source_bundle_file" "$source_bundle_dir/source.bundle"
+  install -o root -g "$git_group" -m 440 "$verifier" "$source_bundle_dir/release-descriptor.py"
+  sudo -u "$GIT_USER" env -i \
+    "PATH=$SAFE_PATH" \
+    'HOME=/nonexistent' \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_NO_REPLACE_OBJECTS=1 \
+    GIT_TERMINAL_PROMPT=0 \
+    python3 "$source_bundle_dir/release-descriptor.py" import-source-bundle \
+      --bundle-file "$source_bundle_dir/source.bundle" \
+      --repository "$APP_DIR" \
+      --target-sha "$target_sha" \
+      --timeout-seconds "$GIT_BUNDLE_IMPORT_TIMEOUT_SECONDS" \
+      >"$descriptor_evidence_dir/source-import.log" || {
+    die 'Verified source bundle could not be imported into the production checkout.'
+  }
+  git_as_owner cat-file -e "${target_sha}^{commit}"
+
+  target_verifier_hash="$({
+    git_as_owner show "${target_sha}:tooling/release-descriptor.py" | sha256sum | awk '{ print $1 }'
+  })" || die 'Unable to read the release descriptor verifier from the imported target source.'
+  [[ "$target_verifier_hash" == "$descriptor_verifier_sha256" ]] || {
+    die 'Descriptor verifier payload differs from the verified target source.'
+  }
+
+  find "$source_bundle_dir" -depth -delete
+  source_bundle_dir=''
+  printf 'target_sha=%s\nsource_bundle_sha256=%s\nverifier_sha256=%s\n' \
+    "$target_sha" "$descriptor_source_bundle_sha256" "$descriptor_verifier_sha256" \
+    >"$descriptor_evidence_dir/source-import.txt"
+  chmod 600 "$descriptor_evidence_dir/source-import.txt"
+  log "Imported verified main source bundle for ${target_sha}."
+}
+
+descriptor_image_ref() {
+  case "$1" in
+    api) printf '%s\n' "$descriptor_api_ref" ;;
+    worker) printf '%s\n' "$descriptor_worker_ref" ;;
+    web) printf '%s\n' "$descriptor_web_ref" ;;
+    admin) printf '%s\n' "$descriptor_admin_ref" ;;
+    gateway) printf '%s\n' "$descriptor_gateway_ref" ;;
+    notification-sink) printf '%s\n' "$descriptor_notification_sink_ref" ;;
+    *) die "Unknown release service: $1" ;;
+  esac
+}
+
+local_image_for_service() {
+  case "$1" in
+    api) printf 'tokems-api\n' ;;
+    worker) printf 'tokems-worker\n' ;;
+    web) printf 'tokems-web\n' ;;
+    admin) printf 'tokems-admin\n' ;;
+    gateway) printf 'tokems-gateway\n' ;;
+    notification-sink) printf 'tokems-notification-sink\n' ;;
+    *) die "Unknown release service: $1" ;;
+  esac
+}
+
+verify_release_descriptor() {
+  [[ -n "$descriptor_evidence_dir" && -d "$descriptor_evidence_dir" ]] || {
+    die 'Release descriptor source evidence is unavailable.'
+  }
+  [[ "$descriptor_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || die 'Verified descriptor digest is unavailable.'
+  local verifier labels_file records_file source_migration source_migration_hash
+  verifier="$descriptor_evidence_dir/release-descriptor.py"
+  labels_file="$descriptor_evidence_dir/labels.json"
+  records_file="$descriptor_evidence_dir/records.tsv"
+  [[ -f "$verifier" && ! -L "$verifier" ]] || die 'Verified descriptor verifier is unavailable.'
+  [[ -f "$labels_file" && ! -L "$labels_file" ]] || die 'Verified descriptor labels are unavailable.'
+  python3 "$verifier" verify-descriptor \
+    --labels-file "$labels_file" \
+    --target-sha "$target_sha" \
+    --platform "$descriptor_platform" \
+    --records-output "$records_file"
+
+  while IFS=$'\t' read -r record_type record_name record_value; do
+    case "${record_type}:${record_name}" in
+      build:sha) descriptor_build_sha="$record_value" ;;
+      build:time) descriptor_build_time="$record_value" ;;
+      build:migration) descriptor_migration="$record_value" ;;
+      build:migration-hash) descriptor_migration_hash="$record_value" ;;
+      release:platform) [[ "$record_value" == "$descriptor_platform" ]] || die 'Descriptor platform record changed during verification.' ;;
+      release:source-bundle-ref) [[ "$record_value" == "$SOURCE_BUNDLE_REF" ]] || die 'Descriptor source bundle ref changed during verification.' ;;
+      release:source-bundle-sha256) [[ "$record_value" == "$descriptor_source_bundle_sha256" ]] || die 'Descriptor source bundle hash changed during verification.' ;;
+      release:verifier-sha256) [[ "$record_value" == "$descriptor_verifier_sha256" ]] || die 'Descriptor verifier hash changed during verification.' ;;
+      image:api) descriptor_api_ref="$record_value" ;;
+      image:worker) descriptor_worker_ref="$record_value" ;;
+      image:web) descriptor_web_ref="$record_value" ;;
+      image:admin) descriptor_admin_ref="$record_value" ;;
+      image:gateway) descriptor_gateway_ref="$record_value" ;;
+      image:notification-sink) descriptor_notification_sink_ref="$record_value" ;;
+      *) die "Unexpected release descriptor record: ${record_type}:${record_name}" ;;
+    esac
+  done <"$records_file"
+
+  [[ "$descriptor_build_sha" == "$target_sha" ]] || die 'Descriptor build SHA differs from the target commit.'
+  python3 "$verifier" verify-source-bundle \
+    --bundle-file "$descriptor_evidence_dir/source.bundle" \
+    --target-sha "$target_sha"
+  source_migration="$({
+    git_as_owner ls-tree -r --name-only "$target_sha" -- packages/database/drizzle \
+      | awk -F/ '$NF ~ /^[0-9][0-9][0-9][0-9]_.*[.]sql$/ { print $NF }' \
+      | sort \
+      | tail -n 1
+  })"
+  [[ "$source_migration" == "$descriptor_migration" ]] || die 'Descriptor migration differs from target source.'
+  source_migration_hash="$(git_as_owner show "${target_sha}:packages/database/drizzle/${source_migration}" | sha256sum | awk '{ print $1 }')"
+  [[ "$source_migration_hash" == "$descriptor_migration_hash" ]] || die 'Descriptor migration hash differs from target source.'
+
+  local service image_ref metadata_file attestation_file
+  for service in "${BUILD_SERVICES[@]}"; do
+    image_ref="$(descriptor_image_ref "$service")"
+    metadata_file="$descriptor_evidence_dir/image-${service}.json"
+    attestation_file="$descriptor_evidence_dir/attestation-${service}.json"
+    registry_docker buildx imagetools inspect --format '{{json .Image}}' "$image_ref" >"$metadata_file" || {
+      die "Release descriptor image is missing or unreadable: ${service}"
+    }
+    python3 "$verifier" verify-service \
+      --metadata-file "$metadata_file" \
+      --service "$service" \
+      --target-sha "$target_sha" \
+      --build-time "$descriptor_build_time" \
+      --migration "$descriptor_migration" \
+      --migration-hash "$descriptor_migration_hash" \
+      --platform "$descriptor_platform"
+    registry_gh attestation verify "oci://${image_ref}" \
+      --repo "$GITHUB_REPOSITORY" \
+      --signer-workflow "${GITHUB_REPOSITORY}/${IMAGE_PUBLISH_WORKFLOW}" \
+      --source-digest "$target_sha" \
+      --source-ref refs/heads/main \
+      --deny-self-hosted-runners \
+      --format json >"$attestation_file"
+  done
+  log "Verified release descriptor ${descriptor_digest} for ${descriptor_platform}."
 }
 
 combined_build_capacity_kib() {
@@ -1471,7 +1894,7 @@ assert_final_backup_capacity() {
   required_bytes=$(( database_bytes + 6 * stable_bytes + 4 * retention_bytes ))
   required_kib=$(( (required_bytes + 1023) / 1024 + MIN_BACKUP_RESERVE_KIB ))
   (( available_kib >= required_kib )) || {
-    die "Final backup and measured production-ID evidence need $((required_kib / 1048576)) GiB free after the image build."
+    die "Final backup and measured production-ID evidence need $((required_kib / 1048576)) GiB free after image preparation."
   }
 }
 
@@ -1830,12 +2253,12 @@ assert_standard_release_scope() {
 canonical_repair_scope_is_compatible() {
   local changed_path changed_paths
   if ! git_as_owner diff --quiet "$release_baseline_sha" "$target_sha" -- "${CANONICAL_SNAPSHOT_PATHS[@]}"; then
-    log 'Canonical snapshots changed since the running release; target images must be built.'
+    log 'Canonical snapshots changed since the running release; verified target images are required.'
     return 1
   fi
 
   changed_paths="$(git_as_owner diff --name-only "$release_baseline_sha" "$target_sha" --)" || {
-    log 'Unable to inspect the target change scope; target images must be built.'
+    log 'Unable to inspect the target change scope; verified target images are required.'
     return 1
   }
   while IFS= read -r changed_path; do
@@ -1843,7 +2266,7 @@ canonical_repair_scope_is_compatible() {
     case "$changed_path" in
       AGENTS.md | docs/* | tooling/production-deploy.sh | tooling/lib/production-deploy.test.mjs) ;;
       *)
-        log "Runtime-affecting target change requires an image build: ${changed_path}"
+        log "Runtime-affecting target change requires the verified target images: ${changed_path}"
         return 1
         ;;
     esac
@@ -1858,9 +2281,10 @@ run_full_preflight() {
   assert_no_parallel_release
   assert_pending_recovery_policy
 
-  git_fetch_origin_main
-  target_sha="$(git_as_owner rev-parse origin/main)"
-  assert_target_selection "$target_sha"
+  assert_github_main_unchanged
+  [[ "$(git_as_owner rev-parse "$EXPECTED_UPSTREAM_REF")" == "$target_sha" ]] || {
+    die 'origin/main differs from the verified release source bundle.'
+  }
   if [[ "$recovery_in_progress" == 'true' ]]; then
     git_as_owner cat-file -e "${pending_recovery_target_sha}^{commit}"
     git_as_owner merge-base --is-ancestor "$pending_recovery_target_sha" "$target_sha" || {
@@ -1901,14 +2325,19 @@ run_full_preflight() {
   }
   curl "${CURL_ARGS[@]}" "${PUBLIC_ORIGIN}/api/v1/health" | assert_health_json
 
-  verify_github_release_gate
   assert_standard_release_scope
   determine_canonical_sync
   if [[ "$canonical_sync_required" == 'true' ]] && canonical_repair_scope_is_compatible; then
     canonical_repair_mode='true'
-    log 'Canonical repair can reuse the verified running images; image-build capacity is not required.'
-  else
+    log 'Canonical repair can reuse the verified running images; host-build capacity is not required.'
+  elif [[ "$build_on_host" == 'true' ]]; then
     assert_build_capacity
+    log 'Emergency host-build preflight passed.'
+  else
+    [[ "$descriptor_build_sha" == "$target_sha" ]] || {
+      die 'Prebuilt release descriptor evidence changed after bootstrap verification.'
+    }
+    log "Prebuilt descriptor remains verified: ${descriptor_digest}"
   fi
   assert_backup_capacity
 
@@ -2152,6 +2581,12 @@ create_backup_and_rollback_point() {
   [[ "$(stat -c '%d' "$backup_dir")" == "$backup_device_id" ]] || {
     die 'The created release backup directory is on a different filesystem from the preflight capacity check.'
   }
+  if [[ -n "$descriptor_evidence_dir" && -d "$descriptor_evidence_dir" ]]; then
+    cp -a -- "$descriptor_evidence_dir" "$backup_dir/release-descriptor"
+    chown -R root:root "$backup_dir/release-descriptor"
+    chmod 700 "$backup_dir/release-descriptor"
+    find "$backup_dir/release-descriptor" -type f -exec chmod 600 {} +
+  fi
   cp -- "${BASH_SOURCE[0]}" "$backup_dir/production-deploy.recovery.sh"
   chown root:root "$backup_dir/production-deploy.recovery.sh"
   chmod 600 "$backup_dir/production-deploy.recovery.sh"
@@ -2300,9 +2735,9 @@ refresh_pre_mutation_database_backup() {
 
 sync_source() {
   log 'Fast-forwarding production to the verified origin/main commit'
-  git_fetch_origin_main
-  [[ "$(git_as_owner rev-parse origin/main)" == "$target_sha" ]] || {
-    die 'origin/main changed after preflight; run the deployment again with the new target.'
+  assert_github_main_unchanged
+  [[ "$(git_as_owner rev-parse "$EXPECTED_UPSTREAM_REF")" == "$target_sha" ]] || {
+    die 'origin/main changed after verified bundle import; run the deployment again.'
   }
   git_as_owner merge --ff-only "$target_sha"
   [[ "$(git_as_owner rev-parse HEAD)" == "$target_sha" ]] || die 'Server HEAD does not equal target commit.'
@@ -2422,6 +2857,88 @@ build_images() {
     "tokems-gateway:${target_image_tag}" \
     "tokems-notification-sink:${target_image_tag}" \
     >"$backup_dir/images-target.json"
+}
+
+pull_prebuilt_images() {
+  [[ -n "$descriptor_evidence_dir" && -d "$descriptor_evidence_dir" ]] || {
+    die 'Verified release descriptor evidence is unavailable.'
+  }
+  local verifier service image_ref image_name metadata_file pull_log
+  verifier="$descriptor_evidence_dir/release-descriptor.py"
+  log "Pulling six digest-pinned images for ${target_sha}"
+  for service in "${BUILD_SERVICES[@]}"; do
+    image_ref="$(descriptor_image_ref "$service")"
+    image_name="$(local_image_for_service "$service")"
+    pull_log="$backup_dir/pull-${service}.log"
+    if ! registry_docker pull --platform "$descriptor_platform" "$image_ref" >"$pull_log" 2>&1; then
+      tail -n 80 "$pull_log" >&2 || true
+      die "Prebuilt image pull failed for ${service}; running containers and release tags are unchanged."
+    fi
+    metadata_file="$backup_dir/pulled-image-${service}.json"
+    docker image inspect --format '{{json .}}' "$image_ref" >"$metadata_file"
+    python3 "$verifier" verify-service \
+      --metadata-file "$metadata_file" \
+      --service "$service" \
+      --target-sha "$target_sha" \
+      --build-time "$descriptor_build_time" \
+      --migration "$descriptor_migration" \
+      --migration-hash "$descriptor_migration_hash" \
+      --platform "$descriptor_platform"
+    printf 'service=%s\nimage=%s\nsource=%s\n' "$service" "$image_name" "$image_ref" \
+      >"$backup_dir/pulled-image-${service}.txt"
+  done
+
+  for service in "${BUILD_SERVICES[@]}"; do
+    image_ref="$(descriptor_image_ref "$service")"
+    image_name="$(local_image_for_service "$service")"
+    docker tag "$image_ref" "${image_name}:candidate-${release_stamp}"
+  done
+  log 'All candidate images were pulled and verified without changing release tags.'
+}
+
+write_prebuilt_build_identity() {
+  [[ "$descriptor_build_sha" == "$target_sha" ]] || die 'Verified descriptor SHA is unavailable.'
+  [[ -n "$descriptor_build_time" && -n "$descriptor_migration" && -n "$descriptor_migration_hash" ]] || {
+    die 'Verified descriptor build identity is incomplete.'
+  }
+  environment_changed='true'
+  clear_compatibility_release_metadata
+  set_env_value BUILD_SHA "$descriptor_build_sha"
+  set_env_value BUILD_TIME "$descriptor_build_time"
+  set_env_value BUILD_MIGRATION "$descriptor_migration"
+  set_env_value BUILD_MIGRATION_HASH "$descriptor_migration_hash"
+  chown root:root "$active_env_file"
+  chmod 600 "$active_env_file"
+
+  BUILD_SHA="$descriptor_build_sha"
+  BUILD_TIME="$descriptor_build_time"
+  BUILD_MIGRATION="$descriptor_migration"
+  BUILD_MIGRATION_HASH="$descriptor_migration_hash"
+  export BUILD_SHA BUILD_TIME BUILD_MIGRATION BUILD_MIGRATION_HASH
+  compose config --quiet
+  printf 'BUILD_SHA=%s\nBUILD_TIME=%s\nBUILD_MIGRATION=%s\nBUILD_MIGRATION_HASH=%s\n' \
+    "$BUILD_SHA" "$BUILD_TIME" "$BUILD_MIGRATION" "$BUILD_MIGRATION_HASH" \
+    >"$backup_dir/build-identity.txt"
+}
+
+activate_prebuilt_images() {
+  local service image_name
+  images_changed='true'
+  for service in "${BUILD_SERVICES[@]}"; do
+    image_name="$(local_image_for_service "$service")"
+    docker image inspect "${image_name}:candidate-${release_stamp}" >/dev/null
+    docker tag "${image_name}:candidate-${release_stamp}" "${image_name}:local"
+    docker tag "${image_name}:local" "${image_name}:${target_image_tag}"
+  done
+  docker image inspect \
+    "tokems-api:${target_image_tag}" \
+    "tokems-admin:${target_image_tag}" \
+    "tokems-web:${target_image_tag}" \
+    "tokems-worker:${target_image_tag}" \
+    "tokems-gateway:${target_image_tag}" \
+    "tokems-notification-sink:${target_image_tag}" \
+    >"$backup_dir/images-target.json"
+  log 'Activated the complete verified image set for the Compose release.'
 }
 
 read_only_database_url() {
@@ -2972,11 +3489,20 @@ verify_release() {
   local expected_migration="${2:-${BUILD_MIGRATION:-}}"
   local expected_migration_hash="${3:-${BUILD_MIGRATION_HASH:-}}"
   log 'Verifying containers, build identity, HTTP, canonical homepage, and production data'
-  local service worker_container
+  local service worker_container container_id
+  local -a release_container_ids=()
   for service in "${LONG_RUNNING_SERVICES[@]}"; do
     assert_service_healthy "$service"
   done
+  assert_runtime_image_tags
   assert_api_uses_compose_database
+
+  for service in notification-sink api worker web payment-web admin gateway; do
+    container_id="$(compose ps -q "$service")"
+    [[ -n "$container_id" ]] || die "Release container is missing during image evidence capture: ${service}"
+    release_container_ids+=("$container_id")
+  done
+  docker inspect "${release_container_ids[@]}" >"$backup_dir/containers-after.json"
 
   compose ps >"$backup_dir/compose-ps-after.txt"
   compose logs --no-color --tail=200 api worker db-init gateway >"$backup_dir/runtime-logs-after.txt" 2>&1
@@ -3057,9 +3583,10 @@ repair_runtime_identity() {
   wait_for_worker_ready
 
   source_sha="$(git_as_owner rev-parse HEAD)"
-  git_fetch_origin_main
-  target_sha="$(git_as_owner rev-parse origin/main)"
-  assert_target_selection "$target_sha"
+  assert_github_main_unchanged
+  [[ "$(git_as_owner rev-parse "$EXPECTED_UPSTREAM_REF")" == "$target_sha" ]] || {
+    die 'origin/main differs from the verified release source bundle.'
+  }
   git_as_owner cat-file -e "${runtime_sha}^{commit}"
   git_as_owner merge-base --is-ancestor "$runtime_sha" "$target_sha" || {
     die 'The running release is not an ancestor of origin/main.'
@@ -3210,9 +3737,10 @@ resolve_pending_recovery() {
   wait_for_worker_ready
   curl "${CURL_ARGS[@]}" 'http://127.0.0.1:8088/api/v1/health' | assert_health_json
 
-  git_fetch_origin_main
-  target_sha="$(git_as_owner rev-parse origin/main)"
-  assert_target_selection "$target_sha"
+  assert_github_main_unchanged
+  [[ "$(git_as_owner rev-parse "$EXPECTED_UPSTREAM_REF")" == "$target_sha" ]] || {
+    die 'origin/main differs from the verified release source bundle.'
+  }
   git_as_owner cat-file -e "${runtime_sha}^{commit}"
   git_as_owner merge-base --is-ancestor "$runtime_sha" "$target_sha" || {
     die 'Resolved runtime is not an ancestor of origin/main.'
@@ -3319,20 +3847,27 @@ run_canonical_repair_release() {
 
 write_success_summary() {
   install_active_production_environment
-  local result_status='deployed'
+  local result_status='deployed' release_strategy='prebuilt-images'
   local runtime_after_sha="$target_sha"
   if [[ "$canonical_repair_mode" == 'true' ]]; then
     result_status='canonical-synchronized'
+    release_strategy='verified-runtime-reuse'
     runtime_after_sha="$release_baseline_sha"
+  elif [[ "$build_on_host" == 'true' ]]; then
+    release_strategy='emergency-host-build'
   fi
-  printf 'status=%s\nruntime_before=%s\nruntime_after=%s\ntarget_sha=%s\ncanonical_sync=%s\nbackup_dir=%s\nrollback_tag=%s\n' \
+  printf 'status=%s\nrelease_strategy=%s\nruntime_before=%s\nruntime_after=%s\ntarget_sha=%s\ncanonical_sync=%s\nbackup_dir=%s\nrollback_tag=%s\nrelease_descriptor_digest=%s\nsource_bundle_sha256=%s\ndescriptor_verifier_sha256=%s\n' \
     "$result_status" \
+    "$release_strategy" \
     "$release_baseline_sha" \
     "$runtime_after_sha" \
     "$target_sha" \
     "$canonical_sync_performed" \
     "$backup_dir" \
     "$rollback_tag" \
+    "$descriptor_digest" \
+    "$descriptor_source_bundle_sha256" \
+    "$descriptor_verifier_sha256" \
     >"$backup_dir/deployment-result.txt"
   chmod 600 "$backup_dir/deployment-result.txt"
   clear_pending_recovery_marker
@@ -3379,8 +3914,10 @@ main() {
   if [[ "$mode" == 'check' ]]; then
     if [[ "$canonical_repair_mode" == 'true' ]]; then
       log 'Canonical repair preflight passed; the current images are compatible and the build-memory gate is not required.'
+    elif [[ "$build_on_host" == 'true' ]]; then
+      log 'Emergency host-build preflight passed; no production state was changed.'
     else
-      log 'Production preflight passed; source checkout, environment, database, images, and containers were unchanged.'
+      log "Prebuilt image preflight passed for descriptor ${descriptor_digest}; production state was unchanged."
     fi
     return 0
   fi
@@ -3392,8 +3929,14 @@ main() {
 
   create_backup_and_rollback_point
   sync_source
-  write_build_identity
-  build_images
+  if [[ "$build_on_host" == 'true' ]]; then
+    write_build_identity
+    build_images
+  else
+    pull_prebuilt_images
+    write_prebuilt_build_identity
+    activate_prebuilt_images
+  fi
   enter_release_write_freeze
   refresh_pre_mutation_database_backup
   run_database_updates

--- a/tooling/release-descriptor.Dockerfile
+++ b/tooling/release-descriptor.Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7
+
+FROM scratch
+
+COPY --from=release source.bundle /release/source.bundle
+COPY tooling/release-descriptor.py /release/release-descriptor.py
+
+ARG BUILD_SHA
+ARG BUILD_TIME
+ARG BUILD_MIGRATION
+ARG BUILD_MIGRATION_HASH
+ARG RELEASE_PLATFORM
+ARG SOURCE_BUNDLE_SHA256
+ARG VERIFIER_SHA256
+ARG API_IMAGE
+ARG WORKER_IMAGE
+ARG WEB_IMAGE
+ARG ADMIN_IMAGE
+ARG GATEWAY_IMAGE
+ARG NOTIFICATION_SINK_IMAGE
+
+LABEL org.opencontainers.image.source="https://github.com/yaojingang/TokEMS" \
+      org.opencontainers.image.revision="${BUILD_SHA}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      com.tokems.release.schema="2" \
+      com.tokems.release.platform="${RELEASE_PLATFORM}" \
+      com.tokems.release.source-bundle.ref="refs/heads/tokems-release-source" \
+      com.tokems.release.source-bundle.sha256="${SOURCE_BUNDLE_SHA256}" \
+      com.tokems.release.verifier.sha256="${VERIFIER_SHA256}" \
+      com.tokems.build.sha="${BUILD_SHA}" \
+      com.tokems.build.time="${BUILD_TIME}" \
+      com.tokems.build.migration="${BUILD_MIGRATION}" \
+      com.tokems.build.migration-hash="${BUILD_MIGRATION_HASH}" \
+      com.tokems.release.image.api="${API_IMAGE}" \
+      com.tokems.release.image.worker="${WORKER_IMAGE}" \
+      com.tokems.release.image.web="${WEB_IMAGE}" \
+      com.tokems.release.image.admin="${ADMIN_IMAGE}" \
+      com.tokems.release.image.gateway="${GATEWAY_IMAGE}" \
+      com.tokems.release.image.notification-sink="${NOTIFICATION_SINK_IMAGE}"

--- a/tooling/release-descriptor.py
+++ b/tooling/release-descriptor.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Validate TokEMS immutable release descriptors and service image metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_SOURCE = "https://github.com/yaojingang/TokEMS"
+EXPECTED_PACKAGE = "ghcr.io/yaojingang/tokems"
+SERVICES = ("api", "worker", "web", "admin", "gateway", "notification-sink")
+SOURCE_BUNDLE_REF = "refs/heads/tokems-release-source"
+SOURCE_CANDIDATE_REF = "refs/tokems-deploy/source-candidate"
+EXPECTED_UPSTREAM_REF = "refs/remotes/origin/main"
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_REF_PATTERN = re.compile(
+    rf"^{re.escape(EXPECTED_PACKAGE)}@sha256:([0-9a-f]{{64}})$"
+)
+MIGRATION_PATTERN = re.compile(r"^[0-9]{4}_[A-Za-z0-9_.-]+\.sql$")
+MIGRATION_HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+TIME_PATTERN = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+PLATFORMS = {"linux/amd64", "linux/arm64"}
+
+
+class DescriptorError(ValueError):
+    pass
+
+
+def validate_time(value: str, description: str) -> None:
+    if not TIME_PATTERN.fullmatch(value):
+        raise DescriptorError(f"{description} must be a UTC second-resolution RFC3339 value")
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as error:
+        raise DescriptorError(f"{description} is not a valid calendar time") from error
+
+
+def validate_build_values(
+    target_sha: str, build_time: str, migration: str, migration_hash: str
+) -> None:
+    if not SHA_PATTERN.fullmatch(target_sha):
+        raise DescriptorError("target SHA must be a lowercase 40-character Git SHA")
+    validate_time(build_time, "build time")
+    if not MIGRATION_PATTERN.fullmatch(migration):
+        raise DescriptorError("build migration has an invalid file name")
+    if not MIGRATION_HASH_PATTERN.fullmatch(migration_hash):
+        raise DescriptorError("build migration hash must be a lowercase SHA-256")
+
+
+def load_object(path: str, description: str) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise DescriptorError(f"unable to read {description}: {error}") from error
+    if not isinstance(value, dict):
+        raise DescriptorError(f"{description} must be a JSON object")
+    return value
+
+
+def require_text(mapping: dict[str, Any], key: str, description: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise DescriptorError(f"missing required {description}: {key}")
+    if "\n" in value or "\r" in value or "\t" in value:
+        raise DescriptorError(f"invalid control character in {description}: {key}")
+    return value
+
+
+def expect_equal(actual: str, expected: str, description: str) -> None:
+    if actual != expected:
+        raise DescriptorError(f"{description} mismatch: expected {expected}, received {actual}")
+
+
+def validate_build_identity(
+    labels: dict[str, Any], target_sha: str
+) -> tuple[str, str, str, str]:
+    build_sha = require_text(labels, "com.tokems.build.sha", "build label")
+    build_time = require_text(labels, "com.tokems.build.time", "build label")
+    migration = require_text(labels, "com.tokems.build.migration", "build label")
+    migration_hash = require_text(
+        labels, "com.tokems.build.migration-hash", "build label"
+    )
+    expect_equal(build_sha, target_sha, "build SHA")
+    validate_build_values(target_sha, build_time, migration, migration_hash)
+    return build_sha, build_time, migration, migration_hash
+
+
+def validate_common_labels(labels: dict[str, Any], target_sha: str) -> str:
+    expect_equal(
+        require_text(labels, "org.opencontainers.image.source", "OCI label"),
+        EXPECTED_SOURCE,
+        "OCI source",
+    )
+    expect_equal(
+        require_text(labels, "org.opencontainers.image.revision", "OCI label"),
+        target_sha,
+        "OCI revision",
+    )
+    created = require_text(labels, "org.opencontainers.image.created", "OCI label")
+    validate_time(created, "OCI created label")
+    return created
+
+
+def verify_descriptor(args: argparse.Namespace) -> None:
+    if not SHA_PATTERN.fullmatch(args.target_sha):
+        raise DescriptorError("target SHA must be a lowercase 40-character Git SHA")
+    if args.platform not in PLATFORMS:
+        raise DescriptorError("platform must be linux/amd64 or linux/arm64")
+
+    labels = load_object(args.labels_file, "descriptor labels")
+    created = validate_common_labels(labels, args.target_sha)
+    expect_equal(
+        require_text(labels, "com.tokems.release.schema", "descriptor label"),
+        "2",
+        "descriptor schema",
+    )
+    expect_equal(
+        require_text(labels, "com.tokems.release.platform", "descriptor label"),
+        args.platform,
+        "descriptor platform",
+    )
+    build_sha, build_time, migration, migration_hash = validate_build_identity(
+        labels, args.target_sha
+    )
+    expect_equal(created, build_time, "OCI created/build time")
+
+    source_bundle_ref = require_text(
+        labels, "com.tokems.release.source-bundle.ref", "source bundle label"
+    )
+    expect_equal(source_bundle_ref, SOURCE_BUNDLE_REF, "source bundle ref")
+    source_bundle_hash = require_text(
+        labels, "com.tokems.release.source-bundle.sha256", "source bundle label"
+    )
+    if not SHA256_PATTERN.fullmatch(source_bundle_hash):
+        raise DescriptorError("source bundle hash must be a lowercase SHA-256")
+    verifier_hash = require_text(
+        labels, "com.tokems.release.verifier.sha256", "release verifier label"
+    )
+    if not SHA256_PATTERN.fullmatch(verifier_hash):
+        raise DescriptorError("release verifier hash must be a lowercase SHA-256")
+
+    release_image_keys = {
+        key for key in labels if key.startswith("com.tokems.release.image.")
+    }
+    expected_image_keys = {
+        f"com.tokems.release.image.{service}" for service in SERVICES
+    }
+    if release_image_keys != expected_image_keys:
+        raise DescriptorError("descriptor must contain exactly the six supported service images")
+
+    image_refs: dict[str, str] = {}
+    digests: set[str] = set()
+    for service in SERVICES:
+        key = f"com.tokems.release.image.{service}"
+        image_ref = require_text(labels, key, "descriptor label")
+        match = DIGEST_REF_PATTERN.fullmatch(image_ref)
+        if not match:
+            raise DescriptorError(
+                f"descriptor image {service} must use the private TokEMS package and a SHA-256 digest"
+            )
+        digest = match.group(1)
+        if digest in digests:
+            raise DescriptorError("every service image must have a unique digest")
+        digests.add(digest)
+        image_refs[service] = image_ref
+
+    records = [
+        ("build", "sha", build_sha),
+        ("build", "time", build_time),
+        ("build", "migration", migration),
+        ("build", "migration-hash", migration_hash),
+        ("release", "platform", args.platform),
+        ("release", "source-bundle-ref", source_bundle_ref),
+        ("release", "source-bundle-sha256", source_bundle_hash),
+        ("release", "verifier-sha256", verifier_hash),
+    ]
+    records.extend(("image", service, image_refs[service]) for service in SERVICES)
+    payload = "".join("\t".join(record) + "\n" for record in records)
+    if args.records_output:
+        Path(args.records_output).write_text(payload, encoding="utf-8")
+    else:
+        sys.stdout.write(payload)
+
+
+def verify_source_bundle(args: argparse.Namespace) -> None:
+    if not SHA_PATTERN.fullmatch(args.target_sha):
+        raise DescriptorError("target SHA must be a lowercase 40-character Git SHA")
+    bundle = Path(args.bundle_file)
+    if not bundle.is_file() or bundle.is_symlink():
+        raise DescriptorError("source bundle must be a regular non-symbolic file")
+
+    with tempfile.TemporaryDirectory(prefix="tokems-bundle-verify-") as directory:
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": directory,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+
+        def run_git(*command: str) -> subprocess.CompletedProcess[str]:
+            try:
+                return subprocess.run(
+                    ["git", *command],
+                    cwd=directory,
+                    env=environment,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+            except (OSError, subprocess.SubprocessError) as error:
+                detail = getattr(error, "stderr", "") or ""
+                detail = detail.strip()
+                suffix = f": {detail}" if detail else ""
+                raise DescriptorError(f"source bundle Git validation failed{suffix}") from error
+
+        run_git("init", "--bare", "--quiet", ".")
+        run_git("bundle", "verify", str(bundle))
+        heads = run_git("bundle", "list-heads", str(bundle), SOURCE_BUNDLE_REF).stdout
+        records = [line.split() for line in heads.splitlines() if line.strip()]
+        if records != [[args.target_sha, SOURCE_BUNDLE_REF]]:
+            raise DescriptorError("source bundle target ref does not equal the requested SHA")
+        candidate_ref = "refs/tokems-verify/source"
+        run_git(
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            "--no-write-fetch-head",
+            str(bundle),
+            f"{SOURCE_BUNDLE_REF}:{candidate_ref}",
+        )
+        imported_sha = run_git("rev-parse", candidate_ref).stdout.strip()
+        if imported_sha != args.target_sha:
+            raise DescriptorError("source bundle imported a different target SHA")
+        object_type = run_git("cat-file", "-t", args.target_sha).stdout.strip()
+        if object_type != "commit":
+            raise DescriptorError("source bundle target is not a Git commit")
+
+
+def import_source_bundle(args: argparse.Namespace) -> None:
+    if not 1 <= args.timeout_seconds <= 600:
+        raise DescriptorError("bundle import timeout must be between 1 and 600 seconds")
+    verify_source_bundle(args)
+    repository = Path(args.repository).resolve()
+    if not repository.is_dir() or not (repository / ".git").is_dir():
+        raise DescriptorError("production source repository is not a Git checkout")
+    bundle = Path(args.bundle_file).resolve()
+    environment = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "HOME": str(repository),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_NO_REPLACE_OBJECTS": "1",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+
+    def run_git(*command: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(
+                ["git", *command],
+                cwd=repository,
+                env=environment,
+                check=check,
+                capture_output=True,
+                text=True,
+                timeout=args.timeout_seconds,
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            detail = getattr(error, "stderr", "") or ""
+            detail = detail.strip()
+            suffix = f": {detail}" if detail else ""
+            raise DescriptorError(f"source bundle import failed{suffix}") from error
+
+    if run_git("status", "--porcelain", "--untracked-files=all").stdout:
+        raise DescriptorError("production source worktree changed before bundle import")
+    if run_git("for-each-ref", "--format=%(refname)", "refs/replace").stdout:
+        raise DescriptorError("Git replacement references are forbidden during bundle import")
+
+    current_origin_sha = run_git("rev-parse", EXPECTED_UPSTREAM_REF).stdout.strip()
+    current_head_sha = run_git("rev-parse", "HEAD").stdout.strip()
+    existing_candidate = run_git(
+        "show-ref", "--verify", "--quiet", SOURCE_CANDIDATE_REF, check=False
+    )
+    if existing_candidate.returncode == 0:
+        raise DescriptorError("reserved source candidate ref already exists")
+    if existing_candidate.returncode != 1:
+        raise DescriptorError("unable to establish reserved source candidate ref state")
+    try:
+        run_git(
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            "--no-write-fetch-head",
+            str(bundle),
+            f"{SOURCE_BUNDLE_REF}:{SOURCE_CANDIDATE_REF}",
+        )
+        candidate_sha = run_git("rev-parse", SOURCE_CANDIDATE_REF).stdout.strip()
+        if candidate_sha != args.target_sha:
+            raise DescriptorError("imported source candidate differs from the requested SHA")
+        for description, ancestor in (
+            ("current origin/main", current_origin_sha),
+            ("production HEAD", current_head_sha),
+        ):
+            ancestry = run_git(
+                "merge-base", "--is-ancestor", ancestor, args.target_sha, check=False
+            )
+            if ancestry.returncode == 1:
+                raise DescriptorError(
+                    f"{description} cannot fast-forward to the verified source bundle"
+                )
+            if ancestry.returncode != 0:
+                raise DescriptorError(f"unable to verify {description} ancestry")
+        run_git(
+            "update-ref",
+            EXPECTED_UPSTREAM_REF,
+            args.target_sha,
+            current_origin_sha,
+        )
+    finally:
+        run_git("update-ref", "-d", SOURCE_CANDIDATE_REF, check=False)
+    print(f"Imported verified source bundle: {current_origin_sha} -> {args.target_sha}")
+
+
+def image_labels(metadata: dict[str, Any]) -> dict[str, Any]:
+    config = metadata.get("config")
+    if not isinstance(config, dict):
+        config = metadata.get("Config")
+    if not isinstance(config, dict):
+        raise DescriptorError("service image metadata is missing its config object")
+    labels = config.get("Labels")
+    if labels is None:
+        labels = config.get("labels")
+    if not isinstance(labels, dict):
+        raise DescriptorError("service image metadata is missing labels")
+    return labels
+
+
+def verify_service(args: argparse.Namespace) -> None:
+    validate_build_values(
+        args.target_sha, args.build_time, args.migration, args.migration_hash
+    )
+    if args.service not in SERVICES:
+        raise DescriptorError("service is not part of the TokEMS release set")
+    if args.platform not in PLATFORMS:
+        raise DescriptorError("platform must be linux/amd64 or linux/arm64")
+    expected_os, expected_architecture = args.platform.split("/", 1)
+    metadata = load_object(args.metadata_file, "service image metadata")
+    expect_equal(str(metadata.get("os", metadata.get("Os", ""))), expected_os, "image OS")
+    expect_equal(
+        str(metadata.get("architecture", metadata.get("Architecture", ""))),
+        expected_architecture,
+        "image architecture",
+    )
+    labels = image_labels(metadata)
+    created = validate_common_labels(labels, args.target_sha)
+    expect_equal(created, args.build_time, "OCI created/build time")
+    expect_equal(
+        require_text(labels, "com.tokems.service", "service image label"),
+        args.service,
+        "service image service",
+    )
+    expected = {
+        "com.tokems.build.sha": args.target_sha,
+        "com.tokems.build.time": args.build_time,
+        "com.tokems.build.migration": args.migration,
+        "com.tokems.build.migration-hash": args.migration_hash,
+    }
+    for key, value in expected.items():
+        expect_equal(require_text(labels, key, "service image label"), value, key)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    descriptor = subparsers.add_parser("verify-descriptor")
+    descriptor.add_argument("--labels-file", required=True)
+    descriptor.add_argument("--target-sha", required=True)
+    descriptor.add_argument("--platform", required=True)
+    descriptor.add_argument("--records-output")
+    descriptor.set_defaults(handler=verify_descriptor)
+
+    service = subparsers.add_parser("verify-service")
+    service.add_argument("--metadata-file", required=True)
+    service.add_argument("--service", required=True)
+    service.add_argument("--target-sha", required=True)
+    service.add_argument("--build-time", required=True)
+    service.add_argument("--migration", required=True)
+    service.add_argument("--migration-hash", required=True)
+    service.add_argument("--platform", required=True)
+    service.set_defaults(handler=verify_service)
+
+    bundle = subparsers.add_parser("verify-source-bundle")
+    bundle.add_argument("--bundle-file", required=True)
+    bundle.add_argument("--target-sha", required=True)
+    bundle.set_defaults(handler=verify_source_bundle)
+
+    importer = subparsers.add_parser("import-source-bundle")
+    importer.add_argument("--bundle-file", required=True)
+    importer.add_argument("--repository", required=True)
+    importer.add_argument("--target-sha", required=True)
+    importer.add_argument("--timeout-seconds", type=int, default=180)
+    importer.set_defaults(handler=import_source_bundle)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        args.handler(args)
+    except DescriptorError as error:
+        print(f"release descriptor validation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- publish six production service images only after the official main CI succeeds
- publish an immutable, attested schema 2 release descriptor containing digest-pinned images, build identity, target platform, a full Git Bundle, and the exact verifier
- make `/usr/local/sbin/tokems-deploy` use verified prebuilt images by default while preserving the 10 GiB-gated `--build-on-host` emergency path
- import `origin/main` from the descriptor Bundle with exact-SHA and fast-forward checks so production does not depend on Git Smart HTTP
- extend rollback evidence, release records, tests, and the production runbook

## Validation

- `pnpm canonical:verify`
- `pnpm test:tooling` (48 passed)
- `pnpm check`
- `pnpm audit:security`
- isolated worktree: `pnpm test:tooling && pnpm check`
- `actionlint` for CI and image publication workflows
- release descriptor Docker build, payload extraction, hash verification, and Bundle verification smoke test

## Rollout

- repository variable `PRODUCTION_PLATFORM=linux/amd64` is configured
- after merge, wait for `tokems-ci` and `tokems-image-publish` to complete
- install GitHub CLI plus a root-only `read:packages` GHCR token, install the merged deploy controller, then run `check` and `deploy` during a low-traffic window
- add the approved SSH automation workflow in PR 2 after three different prebuilt production SHAs complete successfully