### PR TITLE
fix(deploy): publish production images to a private GHCR package

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GHCR_PACKAGE: ghcr.io/yaojingang/tokems
+  GHCR_PACKAGE: ghcr.io/yaojingang/tokems-production
 
 jobs:
   guard:
@@ -110,15 +110,20 @@ jobs:
         run: |
           set -Eeuo pipefail
           package_error="$RUNNER_TEMP/package-visibility.err"
+          package_name="${GHCR_PACKAGE##*/}"
           package_visibility=''
-          if ! package_visibility="$(gh api /users/yaojingang/packages/container/tokems --jq .visibility 2>"$package_error")"; then
+          if ! package_visibility="$(gh api "/users/yaojingang/packages/container/${package_name}" --jq .visibility 2>"$package_error")"; then
             if ! grep -Eq 'HTTP 404|Not Found' "$package_error"; then
               cat "$package_error" >&2
               echo 'Unable to establish TokEMS GHCR package visibility before publication.' >&2
               exit 1
             fi
           fi
-          if [[ -n "$package_visibility" && "$package_visibility" != private ]]; then
+          if [[ -z "$package_visibility" ]]; then
+            echo 'reuse=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$package_visibility" != private ]]; then
             echo 'The TokEMS GHCR package must remain private.' >&2
             exit 1
           fi
@@ -326,7 +331,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -Eeuo pipefail
-          visibility="$(gh api /users/yaojingang/packages/container/tokems --jq .visibility)"
+          package_name="${GHCR_PACKAGE##*/}"
+          visibility="$(gh api "/users/yaojingang/packages/container/${package_name}" --jq .visibility)"
           [[ "$visibility" == private ]] || {
             echo 'The TokEMS GHCR package must remain private.' >&2
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - 服务器分支 `production` 跟踪 `origin/main`。发布前确认工作区干净，并确认服务器 `HEAD` 与 `origin/main` 完全一致。
 - 每次生产变更都要先创建数据库备份、记录当前提交和容器状态，并为当前应用镜像添加 `rollback-<时间戳>` 标签。
 - Docker 构建和运行必须使用同一组 `BUILD_SHA`、`BUILD_TIME`、`BUILD_MIGRATION`、`BUILD_MIGRATION_HASH`。任何值为 `unknown` 时禁止切换生产流量。
-- 标准生产发布使用 `.github/workflows/publish-images.yml` 产出的私有 GHCR 预构建镜像。`release-<SHA>` descriptor 必须最后发布，并固定目标平台、四项 `BUILD_*` 和六个服务 digest；生产机验证 GitHub provenance 后才能更新 `tokems-*:local`。
+- 标准生产发布只使用 `.github/workflows/publish-images.yml` 写入私有包 `ghcr.io/yaojingang/tokems-production` 的预构建镜像。历史公开包 `ghcr.io/yaojingang/tokems` 禁止进入生产发布。`release-<SHA>` descriptor 必须最后发布，并固定目标平台、四项 `BUILD_*` 和六个服务 digest；生产机验证 GitHub provenance 后才能更新 `tokems-*:local`。
 - Release descriptor schema 2 同时携带目标提交的完整 Git Bundle 和 descriptor verifier，并固定两者 SHA-256。生产机只允许在 descriptor provenance、Bundle 目标 ref、目标 SHA 和 Fast-forward 历史全部通过后更新 `refs/remotes/origin/main`；标准发布不得依赖生产机直连 `github.com` Git Smart HTTP。
 - `/etc/tokems/ghcr-read-token` 仅保存 `read:packages` PAT classic，权限固定为 `root:root 0600`。临时 Docker 登录目录只允许位于 `/run/lock/tokems-production-deploy`，发布日志和证据不得包含 Token。
 - `--build-on-host` 只作为人工应急入口，继续执行 10 GiB 构建内存门禁。自动化受限入口不得传入该参数。

--- a/docs/production-deployment-runbook.md
+++ b/docs/production-deployment-runbook.md
@@ -42,7 +42,7 @@ TokEMS 使用根目录多阶段 `Dockerfile` 构建以下应用镜像：
 
 长期基础服务包括 PostgreSQL、Redis、MinIO 和 Mailpit。一次性任务 `db-init`、`minio-init` 正常结束状态为 `Exited (0)`。
 
-标准生产镜像由 `.github/workflows/publish-images.yml` 在官方 `main push` 的 `tokems-ci` 成功完成后构建，统一写入私有包 `ghcr.io/yaojingang/tokems`。六个服务镜像全部完成并生成 GitHub provenance 后，工作流最后发布 `release-<SHA>` descriptor。schema 2 descriptor 固定四项构建身份、生产平台、六个 digest，以及目标提交的完整 Git Bundle 和 verifier SHA-256，是完整可部署版本的唯一标志。生产机通过 GitHub API 核对 `main`、PR 和 CI，通过 GHCR 获取并证明源码与镜像；标准路径不要求生产机直连 `github.com` Git Smart HTTP。
+标准生产镜像由 `.github/workflows/publish-images.yml` 在官方 `main push` 的 `tokems-ci` 成功完成后构建，统一写入私有包 `ghcr.io/yaojingang/tokems-production`。历史公开包 `ghcr.io/yaojingang/tokems` 不得用于生产发布。六个服务镜像全部完成并生成 GitHub provenance 后，工作流最后发布 `release-<SHA>` descriptor。schema 2 descriptor 固定四项构建身份、生产平台、六个 digest，以及目标提交的完整 Git Bundle 和 verifier SHA-256，是完整可部署版本的唯一标志。生产机通过 GitHub API 核对 `main`、PR 和 CI，通过 GHCR 获取并证明源码与镜像；标准路径不要求生产机直连 `github.com` Git Smart HTTP。
 
 持久数据卷为：
 

--- a/tooling/lib/production-deploy.test.mjs
+++ b/tooling/lib/production-deploy.test.mjs
@@ -53,7 +53,14 @@ test('production deploy script has valid Bash syntax and a read-only help path',
 
 test('prebuilt images are the default release path and host builds remain resource-gated', () => {
   assert.match(source, /GHCR_TOKEN_FILE='\/etc\/tokems\/ghcr-read-token'/);
-  assert.match(source, /GHCR_PACKAGE='ghcr\.io\/yaojingang\/tokems'/);
+  assert.match(source, /GHCR_PACKAGE='ghcr\.io\/yaojingang\/tokems-production'/);
+  assert.doesNotMatch(source, /GHCR_PACKAGE='ghcr\.io\/yaojingang\/tokems'/);
+  assert.match(source, /package_name="\$\{GHCR_PACKAGE##\*\/\}"/);
+  assert.match(source, /packages\/container\/\$\{package_name\}/);
+  assert.match(
+    descriptorVerifierSource,
+    /EXPECTED_PACKAGE = "ghcr\.io\/yaojingang\/tokems-production"/,
+  );
   assert.match(source, /verify_image_publish_gate/);
   assert.match(source, /verify_release_descriptor/);
   assert.match(source, /pull_prebuilt_images/);

--- a/tooling/lib/publish-images-workflow.test.mjs
+++ b/tooling/lib/publish-images-workflow.test.mjs
@@ -87,6 +87,14 @@ test('workflow source guard rejects untrusted workflow_run payloads', () => {
 });
 
 test('image publication uses an explicit production platform and immutable release identity', () => {
+  assert.match(source, /GHCR_PACKAGE: ghcr\.io\/yaojingang\/tokems-production/);
+  assert.doesNotMatch(source, /ghcr\.io\/yaojingang\/tokems(?=$|\s|["'@:])/m);
+  assert.match(source, /package_name="\$\{GHCR_PACKAGE##\*\/\}"/);
+  assert.match(source, /packages\/container\/\$\{package_name\}/);
+  assert.match(
+    source,
+    /if \[\[ -z "\$package_visibility" \]\]; then\s+echo 'reuse=false' >> "\$GITHUB_OUTPUT"\s+exit 0\s+fi/,
+  );
   assert.match(source, /PRODUCTION_PLATFORM: \$\{\{ vars\.PRODUCTION_PLATFORM \}\}/);
   assert.match(source, /linux\/(amd64|arm64)/);
   assert.doesNotMatch(source, /PRODUCTION_PLATFORM:-linux\/amd64/);

--- a/tooling/lib/release-descriptor.test.mjs
+++ b/tooling/lib/release-descriptor.test.mjs
@@ -33,7 +33,7 @@ function descriptorLabels(overrides = {}) {
   };
   services.forEach((service, index) => {
     labels[`com.tokems.release.image.${service}`] =
-      `ghcr.io/yaojingang/tokems@sha256:${String(index + 1).repeat(64)}`;
+      `ghcr.io/yaojingang/tokems-production@sha256:${String(index + 1).repeat(64)}`;
   });
   return { ...labels, ...overrides };
 }
@@ -72,7 +72,7 @@ test('release descriptor verifier emits a complete immutable image set', () => {
       assert.match(
         records,
         new RegExp(
-          `^image\\t${service.replace('-', '\\-')}\\tghcr\\.io/yaojingang/tokems@sha256:[0-9]+$`,
+          `^image\\t${service.replace('-', '\\-')}\\tghcr\\.io/yaojingang/tokems-production@sha256:[0-9]+$`,
           'm',
         ),
       );
@@ -109,14 +109,23 @@ test('release descriptor verifier rejects partial, drifting, and non-atomic desc
       [
         'duplicate digest',
         descriptorLabels({
-          'com.tokems.release.image.worker': 'ghcr.io/yaojingang/tokems@sha256:' + '1'.repeat(64),
+          'com.tokems.release.image.worker':
+            'ghcr.io/yaojingang/tokems-production@sha256:' + '1'.repeat(64),
         }),
         /unique digest/i,
       ],
       [
+        'legacy public package',
+        descriptorLabels({
+          'com.tokems.release.image.worker': 'ghcr.io/yaojingang/tokems@sha256:' + '8'.repeat(64),
+        }),
+        /private TokEMS package/i,
+      ],
+      [
         'extra service',
         descriptorLabels({
-          'com.tokems.release.image.debug': 'ghcr.io/yaojingang/tokems@sha256:' + '9'.repeat(64),
+          'com.tokems.release.image.debug':
+            'ghcr.io/yaojingang/tokems-production@sha256:' + '9'.repeat(64),
         }),
         /exactly the six supported service images/i,
       ],

--- a/tooling/production-deploy.sh
+++ b/tooling/production-deploy.sh
@@ -18,7 +18,7 @@ readonly GITHUB_REPOSITORY='yaojingang/TokEMS'
 readonly IMAGE_PUBLISH_WORKFLOW='.github/workflows/publish-images.yml'
 readonly GHCR_REGISTRY='ghcr.io'
 readonly GHCR_USERNAME='yaojingang'
-readonly GHCR_PACKAGE='ghcr.io/yaojingang/tokems'
+readonly GHCR_PACKAGE='ghcr.io/yaojingang/tokems-production'
 readonly GHCR_TOKEN_FILE='/etc/tokems/ghcr-read-token'
 readonly PUBLIC_ORIGIN='https://hui.ailingdaoli.com'
 readonly ADMIN_ORIGIN='https://admin.hui.ailingdaoli.com'
@@ -1474,8 +1474,9 @@ login_ghcr() {
     die 'GHCR authentication failed; the read token may be expired or invalid.'
   fi
   : >"$login_error"
-  local package_visibility
-  package_visibility="$(registry_gh api /users/yaojingang/packages/container/tokems --jq .visibility)" || {
+  local package_name package_visibility
+  package_name="${GHCR_PACKAGE##*/}"
+  package_visibility="$(registry_gh api "/users/yaojingang/packages/container/${package_name}" --jq .visibility)" || {
     die 'Unable to verify the TokEMS GHCR package visibility.'
   }
   [[ "$package_visibility" == 'private' ]] || die 'The TokEMS GHCR package must remain private.'

--- a/tooling/release-descriptor.py
+++ b/tooling/release-descriptor.py
@@ -16,7 +16,7 @@ from typing import Any
 
 
 EXPECTED_SOURCE = "https://github.com/yaojingang/TokEMS"
-EXPECTED_PACKAGE = "ghcr.io/yaojingang/tokems"
+EXPECTED_PACKAGE = "ghcr.io/yaojingang/tokems-production"
 SERVICES = ("api", "worker", "web", "admin", "gateway", "notification-sink")
 SOURCE_BUNDLE_REF = "refs/heads/tokems-release-source"
 SOURCE_CANDIDATE_REF = "refs/tokems-deploy/source-candidate"


### PR DESCRIPTION
## Summary

- Route image publication, descriptor validation, and production deployment through `ghcr.io/yaojingang/tokems-production`.
- Treat a missing package as the first publication and start the six-image build without probing a nonexistent descriptor.
- Reject descriptor image references from the legacy public package.
- Record the private-package invariant in the production runbook and repository rules.

## Root cause

The merged image workflow reached its private-package guard successfully, then stopped because `ghcr.io/yaojingang/tokems` is already public. The failed run ended before any service image build. GitHub does not support restoring a public container package to private visibility, so production needs a dedicated package identity.

Failed run: https://github.com/yaojingang/TokEMS/actions/runs/33593544008

## Verification

- Regression tests failed against the old package and first-publication behavior, then passed after the fix.
- `node --test tooling/lib/publish-images-workflow.test.mjs tooling/lib/release-descriptor.test.mjs tooling/lib/production-deploy.test.mjs` — 37 passed.
- `pnpm test:tooling` — 48 passed.
- `TURBO_FORCE=true pnpm check` — passed, including canonical verification, lint, typecheck, tests, builds, contract snapshots, and documentation inventory.
- Workflow YAML parsing, Bash syntax, Python compilation, Prettier, and `git diff --check` passed.
- The pre-push canonical snapshot gate passed.

## Rollout

This PR does not change the production server. After merge, `tokems-ci` must pass first. The image workflow will then create the new package, verify that it is private, publish all six service images, and publish `release-<SHA>` last.