### PR TITLE
fix(deploy): support production Python 3.6 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           image='python:3.6.15-alpine3.15@sha256:579978dec4602646fe1262f02b96371779bfb0294e92c91392707fa999c0c989'
           runtime_args=(
             --rm
+            --user "$(id -u):$(id -g)"
             --network none
             --read-only
             --security-opt no-new-privileges:true
@@ -28,7 +29,7 @@ jobs:
             --pids-limit 64
             --memory 128m
             --cpus 1
-            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=16m
+            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=16m,mode=1777
             --volume "$GITHUB_WORKSPACE:/workspace:ro"
             --workdir /workspace
           )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,45 @@ permissions:
   pull-requests: read
 
 jobs:
+  release-descriptor-python36:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify the production Python 3.6 descriptor interface
+        run: |
+          image='python:3.6.15-alpine3.15@sha256:579978dec4602646fe1262f02b96371779bfb0294e92c91392707fa999c0c989'
+          runtime_args=(
+            --rm
+            --network none
+            --read-only
+            --security-opt no-new-privileges:true
+            --cap-drop ALL
+            --pids-limit 64
+            --memory 128m
+            --cpus 1
+            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=16m
+            --volume "$GITHUB_WORKSPACE:/workspace:ro"
+            --workdir /workspace
+          )
+          docker run "${runtime_args[@]}" "$image" \
+            python tooling/release-descriptor.py --help >/dev/null
+
+          evidence_dir="$(mktemp -d "$RUNNER_TEMP/python36-descriptor.XXXXXX")"
+          : >"$evidence_dir/invalid-source.bundle"
+          set +e
+          docker run "${runtime_args[@]}" \
+            --volume "$evidence_dir:/evidence" \
+            "$image" \
+            sh -c 'PATH=/missing /usr/local/bin/python tooling/release-descriptor.py verify-source-bundle \
+              --bundle-file /evidence/invalid-source.bundle \
+              --target-sha aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+              2>/evidence/python36-verifier.err'
+          verifier_status=$?
+          set -e
+          [[ "$verifier_status" -eq 1 ]]
+          grep -Fq 'source bundle Git validation failed' "$evidence_dir/python36-verifier.err"
+
   quality-and-flows:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/docs/production-deployment-runbook.md
+++ b/docs/production-deployment-runbook.md
@@ -184,7 +184,7 @@ sudo install -o root -g root -m 0755 \
 sudo /usr/local/sbin/tokems-deploy --help
 ```
 
-`/usr/local/sbin/tokems-deploy` 每次启动都会从 GitHub API 解析最新 `main`，复核合并 PR、官方 main push CI、`quality-and-flows` 与镜像发布工作流，再从经过证明的 GHCR descriptor 导入目标 Git Bundle 并读取目标脚本。日常发布也使用这个 root 所有的入口，避免 root 直接执行由 `ecs-user` 管理的工作区文件。首次基线依次执行以下命令，每一步成功后再继续：
+`/usr/local/sbin/tokems-deploy` 每次启动都会从 GitHub API 解析最新 `main`，复核合并 PR、官方 main push CI、`quality-and-flows` 与镜像发布工作流，再从经过证明的 GHCR descriptor 导入目标 Git Bundle 并读取目标脚本。生产机需要 Python 3.6 或更高版本及 Docker Buildx 0.36.1 或更高版本；`tokems-ci` 使用固定的 Python 3.6.15 容器验证 descriptor CLI，保证 verifier 可在当前生产系统上运行。日常发布也使用这个 root 所有的入口，避免 root 直接执行由 `ecs-user` 管理的工作区文件。首次基线依次执行以下命令，每一步成功后再继续：
 
 ```bash
 sudo install -d -o root -g root -m 0700 /etc/tokems
@@ -198,7 +198,7 @@ sudo /usr/local/sbin/tokems-deploy check --target-sha <origin-main-full-sha>
 sudo /usr/local/sbin/tokems-deploy deploy --target-sha <origin-main-full-sha>
 ```
 
-`/etc/tokems` 必须保持 `root:root 0700`，`production.env` 与 `ghcr-read-token` 必须保持 `root:root 0600`。脚本取得发布锁后立即创建 root-only 会话快照，后续 Compose 只读取受保护快照；发布成功或身份修复成功后再原子写回 `/etc/tokems/production.env`。GHCR 登录通过 `password-stdin` 完成，临时 Docker 配置在退出路径清除。不要把生产环境文件或 Token 上传到 GitHub，也不要在终端输出其内容。确认新入口连续完成 `repair-identity`、`check` 和一次正式 `deploy` 后，可按既有凭据销毁流程处理工作区旧 `.env`。
+`/etc/tokems` 必须保持 `root:root 0700`，`production.env` 与 `ghcr-read-token` 必须保持 `root:root 0600`。脚本取得发布锁后立即创建 root-only 会话快照，后续 Compose 只读取受保护快照；发布成功或身份修复成功后再原子写回 `/etc/tokems/production.env`。GHCR 登录通过 `password-stdin` 完成，每次最多等待 45 秒并执行三次有限重试；超时、Token 无效和传输失败返回不同错误。临时 Docker 配置在退出路径清除。不要把生产环境文件或 Token 上传到 GitHub，也不要在终端输出其内容。确认新入口连续完成 `repair-identity`、`check` 和一次正式 `deploy` 后，可按既有凭据销毁流程处理工作区旧 `.env`。
 
 4 核 8G 生产主机的标准 `check` 和 `deploy` 使用预构建镜像，不执行 Docker 构建，也不应用 10 GiB 构建内存门禁。Docker 磁盘、备份容量、数据库和数据保护门禁保持启用。人工应急构建使用 `--build-on-host`，资源不足时会在备份、迁移和容器切换前停止。目标规范快照与当前运行提交完全一致，且目标差异仅包含部署控制与文档时，可显式执行 `check --sync-canonical` 和 `deploy --sync-canonical`；脚本复用当前已验证镜像，并继续执行备份、写冻结、规范同步、生产数据保护和完整验收。
 
@@ -306,7 +306,7 @@ sudo stat -c '%U:%G %a %n' /etc/tokems/ghcr-read-token
 - `origin` 指向官方仓库。
 - Compose 配置和 Nginx 配置通过。
 - 生产平台与仓库变量 `PRODUCTION_PLATFORM` 一致，值为 `linux/amd64` 或 `linux/arm64`。
-- 预构建模式的磁盘、备份容量、Docker、Buildx、GitHub CLI 和 GHCR 只读凭据满足要求。
+- 预构建模式的磁盘、备份容量、Python 3.6 或更高版本、Docker、Buildx 0.36.1 或更高版本、GitHub CLI 和 GHCR 只读凭据满足要求。
 - `api.github.com` 与 `ghcr.io` 可访问；`github.com` Git Smart HTTP 不属于标准发布依赖。
 - `--build-on-host` 应急模式额外满足 10 GiB 内存与构建磁盘门禁。
 - 没有其他构建或发布进程。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ overrides:
   '@fastify/static': 10.1.3
   '@esbuild-kit/core-utils>esbuild': 0.25.4
   brace-expansion: 5.0.9
-  fast-uri@>=3.0.0 <4.0.0: 3.1.5
-  fast-uri@>=4.0.0 <5.0.0: 4.1.2
+  fast-uri@>=3.0.0 <4.0.0: 3.1.6
+  fast-uri@>=4.0.0 <5.0.0: 4.1.3
   fastify: 5.12.1
   find-my-way: 9.7.0
   js-yaml: 5.2.2
@@ -3578,11 +3578,11 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.3:
+    resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6710,7 +6710,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
 
   '@fastify/cookie@11.1.2':
     dependencies:
@@ -8472,7 +8472,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9266,7 +9266,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.2
+      fast-uri: 4.1.3
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -9288,9 +9288,9 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ overrides:
   '@fastify/static': 10.1.3
   '@esbuild-kit/core-utils>esbuild': 0.25.4
   brace-expansion: 5.0.9
-  'fast-uri@>=3.0.0 <4.0.0': 3.1.5
-  'fast-uri@>=4.0.0 <5.0.0': 4.1.2
+  'fast-uri@>=3.0.0 <4.0.0': 3.1.6
+  'fast-uri@>=4.0.0 <5.0.0': 4.1.3
   fastify: 5.12.1
   find-my-way: 9.7.0
   js-yaml: 5.2.2

--- a/tooling/lib/production-deploy.test.mjs
+++ b/tooling/lib/production-deploy.test.mjs
@@ -71,6 +71,21 @@ test('prebuilt images are the default release path and host builds remain resour
   assert.match(source, /GHCR network probe failed/);
   assert.match(source, /GHCR read token file is missing/);
   assert.match(source, /GHCR authentication failed; the read token may be expired or invalid/);
+  assert.match(source, /GHCR_LOGIN_TIMEOUT_SECONDS=45/);
+  assert.match(source, /GHCR_LOGIN_ATTEMPTS=3/);
+  assert.match(source, /GHCR authentication timed out after bounded retries/);
+  assert.match(source, /GHCR authentication transport failed after bounded retries/);
+  assert.match(
+    source,
+    /timeout --foreground --kill-after=10s "\$\{GHCR_LOGIN_TIMEOUT_SECONDS\}s"/,
+  );
+  assert.match(source, /sys\.version_info >= \(3, 6\)/);
+  assert.match(source, /Python 3\.6 or newer is required for release verification/);
+  assert.match(source, /MIN_BUILDX_VERSION='0\.36\.1'/);
+  assert.match(
+    source,
+    /Docker Buildx \$\{MIN_BUILDX_VERSION\} or newer is required for release verification/,
+  );
   assert.match(source, /prepare_release_source_bundle/);
   assert.match(source, /verify-source-bundle/);
   assert.match(source, /import-source-bundle/);
@@ -116,6 +131,20 @@ test('prebuilt images are the default release path and host builds remain resour
   );
   assert.match(activate, /images_changed='true'/);
   assert.match(activate, /:local/);
+});
+
+test('production runtime gate accepts supported Buildx versions and rejects older clients', () => {
+  const match = source.match(
+    /assert_buildx_runtime\(\) \{[\s\S]*?python3 -c '\n([\s\S]*?)\n' "\$buildx_version" "\$MIN_BUILDX_VERSION"/,
+  );
+  assert.ok(match, 'Buildx runtime version parser was not found');
+  const runGate = (versionOutput) =>
+    spawnSync('python3', ['-c', match[1], versionOutput, '0.36.1'], { encoding: 'utf8' });
+
+  assert.equal(runGate('github.com/docker/buildx v0.36.1 abc123').status, 0);
+  assert.equal(runGate('github.com/docker/buildx v0.40.0-rc1 abc123').status, 0);
+  assert.notEqual(runGate('github.com/docker/buildx v0.14.0 abc123').status, 0);
+  assert.notEqual(runGate('unexpected output').status, 0);
 });
 
 test('forced canonical sync reuses a compatible runtime without building images', () => {
@@ -715,6 +744,14 @@ test('recovery is versioned, offline-capable, and waits for detached database wo
   assert.match(source, /production-deploy\.recovery\.sh/);
   assert.match(source, /recovery_script_sha256/);
   assert.match(source, /bootstrap_recovery_script "\$@"/);
+  const baseRequirements = source.slice(
+    source.indexOf('require_root_and_base_commands() {'),
+    source.indexOf('\nassert_trusted_root_directory() {'),
+  );
+  assert.match(
+    baseRequirements,
+    /if \[\[ "\$mode" != 'recover-interrupted' \]\]; then\n\s+assert_buildx_runtime\n\s+fi/,
+  );
   const recover = source.slice(
     source.indexOf('recover_interrupted_release() {'),
     source.indexOf('\nresolve_pending_recovery() {'),

--- a/tooling/production-deploy.sh
+++ b/tooling/production-deploy.sh
@@ -33,6 +33,10 @@ readonly SAFE_PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 readonly LOCK_DIR='/run/lock/tokems-production-deploy'
 readonly LOCK_FILE="${LOCK_DIR}/deploy.lock"
 readonly RECOVERY_MARKER="${BACKUP_ROOT}/RECOVERY_REQUIRED"
+readonly MIN_BUILDX_VERSION='0.36.1'
+readonly GHCR_LOGIN_TIMEOUT_SECONDS=45
+readonly GHCR_LOGIN_ATTEMPTS=3
+readonly GHCR_LOGIN_RETRY_SECONDS=3
 readonly MIN_BUILD_CAPACITY_KIB=10485760
 readonly MIN_BUILD_DISK_KIB=12582912
 readonly MIN_BACKUP_RESERVE_KIB=4194304
@@ -813,12 +817,35 @@ pin_local_runtime_controls() {
   unset TOKEMS_READ_ONLY_DATABASE_URL SEED_DEMO_DATA COMPOSE_PARALLEL_LIMIT
 }
 
+assert_python_runtime() {
+  python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 6) else 1)' || {
+    die 'Python 3.6 or newer is required for release verification.'
+  }
+}
+
+assert_buildx_runtime() {
+  local buildx_version
+  buildx_version="$(docker buildx version)" || die 'Docker Buildx is unavailable.'
+  python3 -c '
+import re
+import sys
+
+match = re.search(r"(?:^|\s)v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:[-\s]|$)", sys.argv[1])
+current = tuple(int(part) for part in match.groups()) if match else ()
+minimum = tuple(int(part) for part in sys.argv[2].split("."))
+raise SystemExit(0 if current and current >= minimum else 1)
+' "$buildx_version" "$MIN_BUILDX_VERSION" || {
+    die "Docker Buildx ${MIN_BUILDX_VERSION} or newer is required for release verification."
+  }
+}
+
 require_root_and_base_commands() {
   [[ "$(id -u)" -eq 0 ]] || die 'Run this command with sudo or as root.'
   local command_name
   for command_name in bash sudo env git flock curl python3 docker nginx awk grep sed sha256sum find sort tail tar install ps mkdir stat dirname df mktemp cp mv chmod chown rm basename date timeout sleep cat readlink systemd-run systemctl uname; do
     require_command "$command_name"
   done
+  assert_python_runtime
   [[ "$(cd "$APP_DIR" && pwd -P)" == "$APP_DIR" ]] || die 'Production app path resolved unexpectedly.'
   if [[ ! -e "$ENV_DIR" && ! -L "$ENV_DIR" ]]; then
     install -d -o root -g root -m 700 "$ENV_DIR"
@@ -830,6 +857,9 @@ require_root_and_base_commands() {
     assert_trusted_recovery_file "$PRODUCTION_ENV_FILE"
   fi
   [[ -S /var/run/docker.sock ]] || die 'The local Docker Unix socket is unavailable.'
+  if [[ "$mode" != 'recover-interrupted' ]]; then
+    assert_buildx_runtime
+  fi
   ensure_trusted_backup_root
 }
 
@@ -1459,19 +1489,37 @@ login_ghcr() {
 
   registry_auth_dir="$(mktemp -d "${LOCK_DIR}/registry-auth.XXXXXX")"
   chmod 700 "$registry_auth_dir"
-  local token login_error
+  local token login_error login_status attempt
   IFS= read -r token <"$GHCR_TOKEN_FILE"
   [[ -n "$token" && "$token" != *[[:space:]]* ]] || die 'GHCR read token file contains an invalid value.'
   login_error="$registry_auth_dir/login.err"
-  if ! printf '%s' "$token" \
-    | env -i \
-      "PATH=$SAFE_PATH" \
-      'HOME=/root' \
-      "DOCKER_HOST=$LOCAL_DOCKER_HOST" \
-      "DOCKER_CONFIG=$registry_auth_dir" \
-      docker login "$GHCR_REGISTRY" --username "$GHCR_USERNAME" --password-stdin \
-      >/dev/null 2>"$login_error"; then
-    die 'GHCR authentication failed; the read token may be expired or invalid.'
+  login_status=1
+  for ((attempt = 1; attempt <= GHCR_LOGIN_ATTEMPTS; attempt += 1)); do
+    : >"$login_error"
+    if printf '%s' "$token" \
+      | timeout --foreground --kill-after=10s "${GHCR_LOGIN_TIMEOUT_SECONDS}s" \
+        env -i \
+          "PATH=$SAFE_PATH" \
+          'HOME=/root' \
+          "DOCKER_HOST=$LOCAL_DOCKER_HOST" \
+          "DOCKER_CONFIG=$registry_auth_dir" \
+          docker login "$GHCR_REGISTRY" --username "$GHCR_USERNAME" --password-stdin \
+          >/dev/null 2>"$login_error"; then
+      login_status=0
+      break
+    else
+      login_status=$?
+    fi
+    [[ "$attempt" -eq "$GHCR_LOGIN_ATTEMPTS" ]] || sleep "$GHCR_LOGIN_RETRY_SECONDS"
+  done
+  if [[ "$login_status" -ne 0 ]]; then
+    if [[ "$login_status" -eq 124 || "$login_status" -eq 137 ]]; then
+      die 'GHCR authentication timed out after bounded retries.'
+    fi
+    if grep -Eqi 'unauthorized|denied|forbidden|authentication required' "$login_error"; then
+      die 'GHCR authentication failed; the read token may be expired or invalid.'
+    fi
+    die 'GHCR authentication transport failed after bounded retries.'
   fi
   : >"$login_error"
   local package_name package_visibility

--- a/tooling/release-descriptor.py
+++ b/tooling/release-descriptor.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 """Validate TokEMS immutable release descriptors and service image metadata."""
 
-from __future__ import annotations
-
 import argparse
 import json
 import os
@@ -12,7 +10,7 @@ import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Set, Tuple
 
 
 EXPECTED_SOURCE = "https://github.com/yaojingang/TokEMS"
@@ -57,7 +55,7 @@ def validate_build_values(
         raise DescriptorError("build migration hash must be a lowercase SHA-256")
 
 
-def load_object(path: str, description: str) -> dict[str, Any]:
+def load_object(path: str, description: str) -> Dict[str, Any]:
     try:
         value = json.loads(Path(path).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
@@ -67,7 +65,7 @@ def load_object(path: str, description: str) -> dict[str, Any]:
     return value
 
 
-def require_text(mapping: dict[str, Any], key: str, description: str) -> str:
+def require_text(mapping: Dict[str, Any], key: str, description: str) -> str:
     value = mapping.get(key)
     if not isinstance(value, str) or not value:
         raise DescriptorError(f"missing required {description}: {key}")
@@ -82,8 +80,8 @@ def expect_equal(actual: str, expected: str, description: str) -> None:
 
 
 def validate_build_identity(
-    labels: dict[str, Any], target_sha: str
-) -> tuple[str, str, str, str]:
+    labels: Dict[str, Any], target_sha: str
+) -> Tuple[str, str, str, str]:
     build_sha = require_text(labels, "com.tokems.build.sha", "build label")
     build_time = require_text(labels, "com.tokems.build.time", "build label")
     migration = require_text(labels, "com.tokems.build.migration", "build label")
@@ -95,7 +93,7 @@ def validate_build_identity(
     return build_sha, build_time, migration, migration_hash
 
 
-def validate_common_labels(labels: dict[str, Any], target_sha: str) -> str:
+def validate_common_labels(labels: Dict[str, Any], target_sha: str) -> str:
     expect_equal(
         require_text(labels, "org.opencontainers.image.source", "OCI label"),
         EXPECTED_SOURCE,
@@ -158,8 +156,8 @@ def verify_descriptor(args: argparse.Namespace) -> None:
     if release_image_keys != expected_image_keys:
         raise DescriptorError("descriptor must contain exactly the six supported service images")
 
-    image_refs: dict[str, str] = {}
-    digests: set[str] = set()
+    image_refs: Dict[str, str] = {}
+    digests: Set[str] = set()
     for service in SERVICES:
         key = f"com.tokems.release.image.{service}"
         image_ref = require_text(labels, key, "descriptor label")
@@ -209,15 +207,16 @@ def verify_source_bundle(args: argparse.Namespace) -> None:
             "GIT_TERMINAL_PROMPT": "0",
         }
 
-        def run_git(*command: str) -> subprocess.CompletedProcess[str]:
+        def run_git(*command: str) -> subprocess.CompletedProcess:
             try:
                 return subprocess.run(
                     ["git", *command],
                     cwd=directory,
                     env=environment,
                     check=True,
-                    capture_output=True,
-                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    universal_newlines=True,
                     timeout=120,
                 )
             except (OSError, subprocess.SubprocessError) as error:
@@ -266,15 +265,16 @@ def import_source_bundle(args: argparse.Namespace) -> None:
         "GIT_TERMINAL_PROMPT": "0",
     }
 
-    def run_git(*command: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    def run_git(*command: str, check: bool = True) -> subprocess.CompletedProcess:
         try:
             return subprocess.run(
                 ["git", *command],
                 cwd=repository,
                 env=environment,
                 check=check,
-                capture_output=True,
-                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
                 timeout=args.timeout_seconds,
             )
         except (OSError, subprocess.SubprocessError) as error:
@@ -333,7 +333,7 @@ def import_source_bundle(args: argparse.Namespace) -> None:
     print(f"Imported verified source bundle: {current_origin_sha} -> {args.target_sha}")
 
 
-def image_labels(metadata: dict[str, Any]) -> dict[str, Any]:
+def image_labels(metadata: Dict[str, Any]) -> Dict[str, Any]:
     config = metadata.get("config")
     if not isinstance(config, dict):
         config = metadata.get("Config")
@@ -383,7 +383,8 @@ def verify_service(args: argparse.Namespace) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.required = True
 
     descriptor = subparsers.add_parser("verify-descriptor")
     descriptor.add_argument("--labels-file", required=True)


### PR DESCRIPTION
## 原因

生产服务器运行 Python 3.6.8，旧版 release descriptor verifier 使用了较新的 Python 语法，导致预构建发布在生产变更前失败。GHCR 登录还可能在网络波动时无限等待。

## 改动

- 将 release descriptor verifier 调整为 Python 3.6 兼容实现
- 在 CI 中使用固定 digest 的 Python 3.6.15 容器验证生产接口
- 增加 Python 与 Buildx 版本门禁，并保留离线恢复能力
- 为 GHCR 登录增加 45 秒超时、三次有限重试和分类错误
- 更新 fast-uri 安全覆盖版本与生产 Runbook

## 验证

- pnpm check
- pnpm test:tooling（49 项通过）
- pnpm audit:security
- pnpm canonical:check
- pnpm canonical:verify
- Python 3.6.15 受限容器兼容测试
- 生产机 Python 3.6.8 对真实 release Bundle 的只读校验
- 生产机 Buildx 0.36.1 版本门禁校验
- 差异级 gitleaks 扫描