### PR TITLE
fix(deploy): accept GHCR token files without newline

### DIFF
--- a/tooling/lib/production-deploy.test.mjs
+++ b/tooling/lib/production-deploy.test.mjs
@@ -75,6 +75,12 @@ test('prebuilt images are the default release path and host builds remain resour
   assert.match(source, /GHCR_LOGIN_ATTEMPTS=3/);
   assert.match(source, /GHCR authentication timed out after bounded retries/);
   assert.match(source, /GHCR authentication transport failed after bounded retries/);
+  assert.equal(
+    source.match(/token="\$\(<"\$GHCR_TOKEN_FILE"\)"/g)?.length,
+    2,
+    'both GHCR consumers must accept a token file without a trailing newline',
+  );
+  assert.doesNotMatch(source, /IFS= read -r token <"\$GHCR_TOKEN_FILE"/);
   assert.match(
     source,
     /timeout --foreground --kill-after=10s "\$\{GHCR_LOGIN_TIMEOUT_SECONDS\}s"/,

--- a/tooling/production-deploy.sh
+++ b/tooling/production-deploy.sh
@@ -1452,7 +1452,7 @@ registry_docker() {
 registry_gh() {
   [[ -n "$registry_auth_dir" && -d "$registry_auth_dir" ]] || die 'Temporary GHCR authentication is unavailable.'
   local token
-  IFS= read -r token <"$GHCR_TOKEN_FILE"
+  token="$(<"$GHCR_TOKEN_FILE")"
   [[ -n "$token" && "$token" != *[[:space:]]* ]] || die 'GHCR read token file contains an invalid value.'
   env -i \
     "PATH=$SAFE_PATH" \
@@ -1490,7 +1490,7 @@ login_ghcr() {
   registry_auth_dir="$(mktemp -d "${LOCK_DIR}/registry-auth.XXXXXX")"
   chmod 700 "$registry_auth_dir"
   local token login_error login_status attempt
-  IFS= read -r token <"$GHCR_TOKEN_FILE"
+  token="$(<"$GHCR_TOKEN_FILE")"
   [[ -n "$token" && "$token" != *[[:space:]]* ]] || die 'GHCR read token file contains an invalid value.'
   login_error="$registry_auth_dir/login.err"
   login_status=1


### PR DESCRIPTION
## 原因

生产 Token 文件包含完整的 40 字节 PAT，文件末尾没有换行。Bash `read` 已读取内容后返回 EOF 状态 1，严格模式据此提前退出，使 `repair-identity` 在 GHCR 登录前静默停止。

## 改动

- 两处 GHCR Token 读取改用 Bash 文件读取表达式
- 保留空值和空白字符校验
- 增加回归测试，要求两个 Token 消费路径兼容无尾部换行文件

## 验证

- 先观察回归测试失败，再完成修复
- pnpm test:tooling（49 项通过）
- pnpm check
- pnpm audit:security
- pnpm canonical:verify
- 生产服务器同形态 Token 读取探针通过，仅输出长度和状态
- 差异级 gitleaks 扫描通过