### PR TITLE
fix(deploy): execute canonical exporter from linked package

### DIFF
--- a/tooling/lib/production-deploy.test.mjs
+++ b/tooling/lib/production-deploy.test.mjs
@@ -779,6 +779,16 @@ test('release verifies public recovery projection and the full canonical backend
   assert.match(source, /canonical-homepage\.snapshot\.\$\{evidence_suffix\}\.json/);
   assert.match(source, /export-canonical-homepage\.js --stdout/);
   assert.match(source, /CANONICAL_EXPORT_TRUSTED_COMPOSE_INTERNAL=true/);
+  assert.equal(
+    source.match(
+      /node --preserve-symlinks-main node_modules\/@conference\/database\/dist\/export-canonical-homepage\.js --stdout/g,
+    )?.length,
+    2,
+  );
+  assert.doesNotMatch(
+    source,
+    /\snode node_modules\/@conference\/database\/dist\/export-canonical-homepage\.js --stdout/,
+  );
   assert.match(
     source,
     /verify_canonical_full_snapshot \\\n\s+"\$resolved_full_snapshot" \\\n\s+recovery-resolve/,
@@ -793,12 +803,20 @@ test('automatic canonical sync repairs pre-existing production drift', () => {
     source.indexOf('determine_canonical_sync() {'),
     source.indexOf('\nassert_standard_release_scope() {'),
   );
+  const productionProbe = source.slice(
+    source.indexOf('production_canonical_snapshot_matches_target() {'),
+    source.indexOf('\ndetermine_canonical_sync() {'),
+  );
 
   assert.match(source, /production_canonical_snapshot_matches_target/);
   assert.match(source, /canonical-probe\.compose/);
   assert.match(source, /default_transaction_read_only=on/);
   assert.match(source, /read_only_compose_file="\$previous_read_only_compose_file"/);
   assert.match(source, /unset TOKEMS_READ_ONLY_DATABASE_URL/);
+  assert.match(
+    productionProbe,
+    /node --preserve-symlinks-main node_modules\/@conference\/database\/dist\/export-canonical-homepage\.js --stdout/,
+  );
   assert.match(decision, /production_canonical_snapshot_matches_target/);
   assert.match(decision, /canonical_sync_required='true'/);
   assert.match(decision, /Production canonical snapshot drift detected/);

--- a/tooling/production-deploy.sh
+++ b/tooling/production-deploy.sh
@@ -2238,7 +2238,7 @@ YAML
     -e CANONICAL_API_BASE_URL=http://api:4100/api/v1 \
     -e CANONICAL_EXPORT_TRUSTED_COMPOSE_INTERNAL=true \
     api \
-    node node_modules/@conference/database/dist/export-canonical-homepage.js --stdout \
+    node --preserve-symlinks-main node_modules/@conference/database/dist/export-canonical-homepage.js --stdout \
     >"$canonical_probe_actual_snapshot" 2>/dev/null || export_status=$?
   read_only_compose_file="$previous_read_only_compose_file"
   unset TOKEMS_READ_ONLY_DATABASE_URL
@@ -3522,7 +3522,7 @@ verify_canonical_full_snapshot() {
     -e CANONICAL_API_BASE_URL=http://api:4100/api/v1 \
     -e CANONICAL_EXPORT_TRUSTED_COMPOSE_INTERNAL=true \
     api \
-    node node_modules/@conference/database/dist/export-canonical-homepage.js --stdout \
+    node --preserve-symlinks-main node_modules/@conference/database/dist/export-canonical-homepage.js --stdout \
     >"$actual_snapshot"
   chmod 600 "$actual_snapshot"
   local -a expected_snapshots=("$expected_snapshot")


### PR DESCRIPTION
## 原因

生产 API 镜像通过 pnpm 的链接包路径执行规范导出器。Node 默认解析主模块真实路径，导致 `process.argv[1]` 与 `import.meta.url` 不一致；程序以状态 0 退出且没有输出，部署预检因此无法比较生产规范快照。

## 改动

- 两个容器化规范导出入口增加 `--preserve-symlinks-main`
- 覆盖发布前规范漂移探针与发布后完整规范验收
- 增加回归断言，禁止恢复无标志的链接包入口

## 验证

- 先观察回归测试失败，再完成修复
- 生产健康 API 容器只读探针生成 221,511 字节有效 JSON
- pnpm test:tooling（49 项通过）
- pnpm check
- pnpm audit:security
- pnpm canonical:verify
- Bash 语法与差异级 gitleaks 扫描通过