### PR TITLE
fix(ci): skip image publishing for pull request runs

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -21,6 +21,14 @@ env:
 jobs:
   guard:
     name: Verify CI source and release identity
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.status == 'completed' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.repository.full_name == github.repository &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.sha == github.event.workflow_run.head_sha
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:

--- a/tooling/lib/publish-images-workflow.test.mjs
+++ b/tooling/lib/publish-images-workflow.test.mjs
@@ -18,6 +18,17 @@ test('image publication starts only after the official main CI workflow succeeds
   assert.match(source, /workflow_run:/);
   assert.match(source, /workflows: \[tokems-ci\]/);
   assert.match(source, /types: \[completed\]/);
+  for (const eventFilter of [
+    "github.event.workflow_run.event == 'push'",
+    "github.event.workflow_run.head_branch == 'main'",
+    "github.event.workflow_run.status == 'completed'",
+    "github.event.workflow_run.conclusion == 'success'",
+    'github.event.workflow_run.repository.full_name == github.repository',
+    'github.event.workflow_run.head_repository.full_name == github.repository',
+    'github.sha == github.event.workflow_run.head_sha',
+  ]) {
+    assert.ok(source.includes(eventFilter), `missing workflow_run job filter: ${eventFilter}`);
+  }
   for (const gate of [
     "workflow_run.event != 'push'",
     "workflow_run.head_branch != 'main'",


### PR DESCRIPTION
## Summary

- skip the image publication job unless the completed CI run is an official latest `main` push
- keep the existing in-job provenance validation as a second trust boundary
- add a regression test for every job-level workflow source condition

## Root cause

`workflow_run` receives completed PR CI events as well as main push events. The in-job guard rejected PR payloads with a failure, creating a misleading failed image publication run for every pull request.

## Verification

- `node --test tooling/lib/publish-images-workflow.test.mjs` (red before implementation, green after)
- `pnpm test:tooling`
- `pnpm check`
- `pnpm canonical:check`
- commit-scoped gitleaks scan