### PR TITLE
修复登录加载期间报名内容被旧草稿覆盖，并补齐 CI 回归

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
           pnpm test:security-config
           pnpm test:checkin-load
           pnpm test:tooling
+          pnpm test:registration-experience
           pnpm test:visual
       - name: Dependency audit
         id: dependency_audit

--- a/apps/web/app/pages/register.vue
+++ b/apps/web/app/pages/register.vue
@@ -324,7 +324,9 @@ function restoreRegistrationDraftForCurrentIdentity() {
     registrationFields.value,
   );
   for (const [key, value] of Object.entries(restored.answers)) {
-    if (preserveCurrentAnswers && (editedAnswerKeys.has(key) || answers[key])) continue;
+    // The form can be edited before the first account/draft lookup finishes.
+    if ((!previous || preserveCurrentAnswers) && editedAnswerKeys.has(key)) continue;
+    if (preserveCurrentAnswers && answers[key]) continue;
     answers[key] = value;
     if (restored.editedKeys.includes(key)) editedAnswerKeys.add(key);
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:security-config": "node tooling/production-config-smoke.mjs",
     "test:checkin-load": "node tooling/checkin-load.mjs",
     "test:visual": "node tooling/visual-smoke.mjs",
+    "test:registration-experience": "node --test tooling/registration-experience-smoke.mjs",
     "test:tokems-admin-skill": "node --test skills/tokems-admin/scripts/lib/*.test.mjs",
     "skill:tokems-contracts": "pnpm --filter @conference/contracts build && pnpm --filter @conference/api exec tsx ../../tooling/tokems-admin-contract-snapshot.mts",
     "skill:tokems-contracts:check": "pnpm --filter @conference/contracts build && pnpm --filter @conference/api exec tsx ../../tooling/tokems-admin-contract-snapshot.mts --check",

--- a/tooling/registration-experience-smoke.mjs
+++ b/tooling/registration-experience-smoke.mjs
@@ -43,11 +43,14 @@ async function fixture(options = {}) {
   const errors = [];
   let signedIn = options.signedIn !== false;
   let eventRequests = 0;
+  let sessionGate;
   page.on('pageerror', (error) => errors.push(error.stack ?? error.message));
   await page.route('**/api/v1/**', async (route) => {
     const path = new URL(route.request().url()).pathname;
-    if (path.endsWith('/customer-auth/session'))
+    if (path.endsWith('/customer-auth/session')) {
+      if (sessionGate) await sessionGate;
       return route.fulfill({ json: signedIn ? session : { authenticated: false } });
+    }
     if (path.endsWith('/customer-auth/otp'))
       return route.fulfill({
         json: {
@@ -145,8 +148,53 @@ async function fixture(options = {}) {
     refreshEvent,
     submit,
     eventRequests: () => eventRequests,
+    setSessionGate: (gate) => {
+      sessionGate = gate;
+    },
   };
 }
+
+test('edits made while the account loads take precedence over an older saved draft', async () => {
+  const f = await fixture();
+  let release;
+  try {
+    await f.open();
+    await f.page.locator('#registration-name').fill('旧草稿姓名');
+    await f.page.locator('#registration-title').fill('旧草稿职位');
+    await f.page.locator('#registration-company').fill('旧草稿公司');
+    await f.page.waitForFunction(() =>
+      Object.entries(localStorage).some(([key, value]) => {
+        if (!key.startsWith('conference.registrationDraft.')) return false;
+        return JSON.parse(value).answers.company === '旧草稿公司';
+      }),
+    );
+    f.setSessionGate(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+    await f.page.reload({ waitUntil: 'domcontentloaded' });
+    await f.page.locator('#registration-name').fill('当前输入姓名');
+    await f.page.locator('#registration-title').fill('临时职位');
+    await f.page.locator('#registration-title').fill('');
+    assert.equal(await f.page.locator('form.flow-card button[type="submit"]').isDisabled(), true);
+    assert.equal(await f.page.locator('#registration-name').inputValue(), '当前输入姓名');
+    release();
+    await f.page.waitForFunction(
+      () => !document.querySelector('form.flow-card button[type="submit"]')?.disabled,
+    );
+    assert.equal(await f.page.locator('#registration-name').inputValue(), '当前输入姓名');
+    assert.equal(await f.page.locator('#registration-title').inputValue(), '');
+    assert.equal(await f.page.locator('#registration-company').inputValue(), '旧草稿公司');
+    await f.submit();
+    assert.equal(f.submissions[0].attendee.name, '当前输入姓名');
+    assert.equal(f.submissions[0].attendee.title, '');
+    assert.deepEqual(f.errors, []);
+  } finally {
+    release?.();
+    await f.context.close();
+  }
+});
 
 test('cleared optional profile fields survive reload and a published form update', async () => {
   const f = await fixture();


### PR DESCRIPTION
账号状态响应较慢时，报名表已允许填写，但首次恢复旧草稿会覆盖用户刚输入或主动清空的内容。此修复让首次恢复优先保留手动编辑，同时继续恢复未编辑字段；切换账号或购票对象时仍清空旧资料。

补充了可控制身份响应时序的浏览器回归，并将完整报名浏览器测试接入 CI。旧代码运行新增测试稳定失败，修复后的正式构建通过全部 6 项浏览器测试；`pnpm check`、`pnpm canonical:check`、51 项工具测试和 31 项数据库专项测试均通过。线上桌面与手机报名页已做只读验收，无真实报名或支付提交。
