### PR TITLE
补充报名体验优化和复核修复的生产发布记录

### DIFF
--- a/docs/release-records/2026-09-04-registration-experience.md
+++ b/docs/release-records/2026-09-04-registration-experience.md
@@ -1,0 +1,126 @@
+# 2026-09-04 报名体验优化生产发布记录
+
+> 发布状态：已发布，API 和 Worker 正常写入已恢复，恢复标记已归档。
+>
+> 最终服务器复验：2026-09-04 22:34，Asia/Shanghai。
+>
+> 操作者：Codex，用户已授权上线、修复、PR 合并与主分支同步。
+>
+> 长期规则：`docs/production-deployment-runbook.md`
+
+## 1. 发布目标
+
+- 报名入口缩短为 `https://hui.ailingdaoli.com/register/tokems26`，兼容旧参数链接。
+- 后台邮箱字段可关闭，前台读取已生效的报名表配置；当前邮箱隐藏，职位、所在城市为选填。
+- 表单保留一个默认勾选的报名条款选项，蓝色链接打开居中弹窗，关闭后保留表单内容。
+- 保留生产独立维护的 18 位嘉宾、28 项议程和嘉宾短地址，沿用单一大会通票展示及现有 FAQ。
+- 发布使用全新大会版本 V30、报名表 V8、条款版本 `2026-09-04`。退款流程方案和依赖升级 PR 未纳入本轮。
+
+## 2. GitHub 和构建身份
+
+| 项目                        | 本次值                                                                             |
+| --------------------------- | ---------------------------------------------------------------------------------- |
+| 报名优化 PR                 | [#71](https://github.com/yaojingang/TokEMS/pull/71)                                |
+| 内容保留修复 PR             | [#72](https://github.com/yaojingang/TokEMS/pull/72)                                |
+| 发布时间比较修复 PR         | [#73](https://github.com/yaojingang/TokEMS/pull/73)                                |
+| 最终主分支 CI               | [33881907323，成功](https://github.com/yaojingang/TokEMS/actions/runs/33881907323) |
+| 最终镜像发布                | [33882714376，成功](https://github.com/yaojingang/TokEMS/actions/runs/33882714376) |
+| 目标提交                    | `fe294e213e502bdec455e57723b0d2709fac68f2`                                         |
+| 构建时间                    | `2026-09-04T14:15:58Z`                                                             |
+| 最高迁移                    | `0059_green_rictor.sql`                                                            |
+| 迁移 SHA-256                | `776a677d42968cf0aeafb79ff2920994f2fe32446bf50c1a9d560d7847d14a24`                 |
+| 发布分支                    | `production` 跟踪 `origin/main`，两者 HEAD 一致，服务器工作区干净                  |
+| Release descriptor digest   | `sha256:7e00f327bbff2df407d50901601c3fbac41ca5eac9464497f238b79c9c2c1c88`          |
+| Source Bundle SHA-256       | `5ce083e212ee124b59d8a5c223ed611ee3532369d803f51eef00e5217d17d102`                 |
+| Descriptor verifier SHA-256 | `1975710a912a17a6a8519bc3011d78edb7d19bef78ae332247b662d1e8831568`                 |
+| 目标平台                    | `linux/amd64`                                                                      |
+
+## 3. 发布前检查
+
+- [x] 服务器工作区干净，官方上游和目标提交核对通过。
+- [x] 合并 PR、主分支 CI、六个私有镜像及发布清单均通过证明验证。
+- [x] Compose、Nginx、磁盘、备份容量、当前容器身份和恢复状态检查通过。
+- [x] 新部署脚本从已验证的源码 Bundle 加载；全程使用预构建镜像。
+- [x] 生产环境目录权限 `0700`，环境文件及 GHCR 只读凭据权限 `0600`。
+
+## 4. 备份和回滚点
+
+| 项目                | 本次值                                                             |
+| ------------------- | ------------------------------------------------------------------ |
+| 最终备份目录        | `/www/backup/TokEMS/20260904-222637`                               |
+| 数据库备份          | `/www/backup/TokEMS/20260904-222637/conference.dump`               |
+| dump SHA-256        | `b90130134bbf66ff47ebc2667a73065f8238ded0b2e2c795a1879a64afe27423` |
+| `pg_restore --list` | 已通过                                                             |
+| 镜像回滚标签        | `rollback-20260904-222637`                                         |
+| 发布前运行版本      | `4579248e5eb645df530b999a9c955b6369ba58ca`                         |
+| MinIO 备份          | 本轮未新增对象存储全量备份；嘉宾未新增头像资产                     |
+
+三轮备份和回滚标签均保留。本轮没有覆盖恢复数据库或删除生产卷。
+
+## 5. 数据库和模板
+
+- 无新迁移，最高迁移及哈希保持一致。
+- 常规迁移使用 `SEED_DEMO_DATA=false`；规范同步阶段临时使用 `true`，最终规范组织 / 大会为 `geo-conference` / `tokems26`。
+- `pnpm canonical:check` 及推送门禁通过；部署后的公开首页和完整后台规范与目标一致。
+- 完整快照 SHA-256：`b6eede0924a284d687d8923201dc508a6fc52a578f9c2bc70fb4e598ba75138a`。
+- 前台派生快照 SHA-256：`57464ab82ac2ba7ce876b6233b0956b94b19a6849e1cb4b6a42f06ca1bc02fc4`。
+- 快照脱敏校验通过，管理员身份、密钥、用户资料、交易记录、销量和审计记录未纳入规范快照。
+
+| 数据     | 冻结前 | 只读验收后 | 恢复写入后 |
+| -------- | -----: | ---------: | ---------: |
+| 用户     |     45 |         45 |         45 |
+| 报名     |     37 |         37 |         37 |
+| 订单     |     37 |         37 |         37 |
+| 票       |     25 |         25 |         25 |
+| 发票申请 |      2 |          2 |          2 |
+
+业务主键集合、票种及配额销量校验通过，现有数据完整保留。
+
+## 6. 镜像和容器切换
+
+镜像均来自 `ghcr.io/yaojingang/tokems-production-private`。Web 与 payment-web 共用同一服务镜像。
+
+| 服务              | GHCR digest                                                               | 实际 image ID                                                             | 状态    |
+| ----------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------- |
+| api               | `sha256:194832c7e62665eb9d81afad2ea0aeb1ec53a38e0c9628f80ab1bd82673df631` | `sha256:828f349dfc5de23152721d90c4d49477236b99385de108d0d251f3a34a9e982d` | healthy |
+| worker            | `sha256:bd0e7196b94a1df196d18731913cb2199ecaae92bcd6a8a748b6b5c4f5a9c252` | `sha256:4b871b7125c63311fa47386af1e089f635d95d80f840ac4c653f3e47ab107cb9` | healthy |
+| web               | `sha256:7908e308d72e4f8394f948b92b585bfec4eecce831c0736834e0a1ba3a9198e4` | `sha256:f12c3784965622e4679df1da4368b2a8f2b1e8b3033da8924af7830243dd3ae6` | healthy |
+| payment-web       | `sha256:7908e308d72e4f8394f948b92b585bfec4eecce831c0736834e0a1ba3a9198e4` | `sha256:f12c3784965622e4679df1da4368b2a8f2b1e8b3033da8924af7830243dd3ae6` | healthy |
+| admin             | `sha256:04e50b8caf6db0c92b0fe990d266ca8097ff3e228a249355ab3aa374b9603f78` | `sha256:cf57627ad8fc3962671c87aec0799ba7cf0bc2a8ebe32b782021d3faff1b25e6` | healthy |
+| gateway           | `sha256:34c842315d38a2fdf0ea3ea75492ace2098e0bc4db4e6350f37d8fe70511cc59` | `sha256:c0e5ab20d70c5de3c508fdfa25fad00e40aee84984a50f86f567ca209debf6cc` | healthy |
+| notification-sink | `sha256:ee258a8cf891ebf9ce4f5ad2c1cc8316dfa6482e67572d26c65137ed46d45808` | `sha256:d1e59086f554a7806ccbe982e41d59ea1f96ff5073e4bfed5af94b0837b97ff2` | healthy |
+
+API 和 Worker 已恢复标准启动命令与 `unless-stopped` 策略。独立写入监督机制、Worker 持久 ready 身份和 15 秒稳定性观察通过。`RECOVERY_REQUIRED` 已归档，生产写入正常。
+
+## 7. 验证结果
+
+- [x] 运行容器健康；Gateway、Web、Admin、API、Worker 的构建身份及数据库迁移一致。
+- [x] 服务器本机与公网 HTTP、公开首页及完整规范配置验证通过。
+- [x] 桌面 1440×1000、手机 390×844 的独立浏览器验收通过，未改变用户浏览器视口。
+- [x] 短地址、旧参数链接跳转、邮箱隐藏、选填字段、唯一默认勾选项、蓝色条款链接和居中弹窗符合预期。
+- [x] 弹窗关闭后表单内容保留，无横向溢出、页面 JavaScript 异常或统计脚本请求。
+
+| 公网入口                                              | HTTP 状态 |
+| ----------------------------------------------------- | --------- |
+| [大会首页](https://hui.ailingdaoli.com/)              | 200       |
+| [运营后台](https://admin.hui.ailingdaoli.com/admin/)  | 200       |
+| [独立支付入口](https://www.ailingdaoli.com/pay/hui/)  | 200       |
+| [版本接口](https://hui.ailingdaoli.com/version.json)  | 200       |
+| [健康接口](https://hui.ailingdaoli.com/api/v1/health) | 200       |
+
+页面验收只进行了读取和本地表单输入，没有发送短信、提交报名、创建订单或执行真实支付。持久化和运营流程由通过的 CI 覆盖。截图和 JSON 证据保存于本地 `.codex-artifacts/production-release/2026-09-04-c942cd7/`。
+
+## 8. 异常和处理
+
+1. 首次目标 `c942cd793d76e8a0332b4fba339f5cfae64c9c59` 的 CI 与镜像发布通过，但生产已有独立发布 V22–V28，规范同步因 V22 不可变内容冲突中止。备份为 `/www/backup/TokEMS/20260904-205920`，最终 dump SHA-256 为 `8de6d4e7c8b70ce3b7f5a7f5484421207aced98c7e43285542738d909c42e8d1`。事务回滚，旧应用恢复至保护性只读。PR #72 将线上嘉宾和议程带回本地，生成全新 V30，并修复空白议程字段的导出校验。
+2. 第二次目标 `9623e042136763da84902ec2e2f4079ba4fcd43c` 的 CI 与镜像发布通过，V30 同步成功。验收把生产首次发布报名表的时间与本地时间进行精确比较，触发保护性回滚。备份为 `/www/backup/TokEMS/20260904-214814`，最终 dump SHA-256 为 `b9a2522305a9447e61d6dfd10502ae9d57d2acf1da4d304b7f1c1762b0abba7f`。
+3. 通过只读连接导出完整生产规范，确认唯一差异为 `publicEvent.registrationForm.publishedAt`。PR #73 让跨环境验收忽略该运行时间，实际数据库时间保持原值；字段、版本和条款的负例仍被拒绝。两条新增回归测试修复前失败、修复后通过，31 项部署测试、完整本地检查和生产样本重放全部通过。
+4. 最终按标准 `deploy --sync-canonical --resume-recovery` 完成发布。外部签名核验与镜像下载曾有传输延迟，随后正常完成；未修改服务器 DNS 或网络配置。
+
+两次保护性回滚期间，公开浏览可用，报名、后台保存及异步任务的写入受到冻结保护。最终恢复写入和数据复验通过。
+
+## 9. 剩余风险和后续
+
+- 本次未执行真实付款；支付入口可访问，业务流程通过 CI 验证。
+- 数据库和镜像回滚点保留，后续按既定备份保留策略管理。
+- 本记录随仓库保存；本轮实现与修复代码已合并 GitHub 主分支，本轮修复分支已清理。其他任务中的退款工作流分支与文档保持原状。

--- a/docs/release-records/2026-09-04-registration-review.md
+++ b/docs/release-records/2026-09-04-registration-review.md
@@ -1,0 +1,120 @@
+# 2026-09-04 TokEMS 报名迭代复核修复发布记录
+
+> 发布状态：已发布
+>
+> 验证时间：2026-09-04 23:43，Asia/Shanghai
+>
+> 操作者：Codex，按用户授权执行
+>
+> 长期规则：`docs/production-deployment-runbook.md`
+
+## 1. 发布目标
+
+修复账号状态响应较慢时，旧草稿覆盖报名页当前输入或主动清空内容的问题。首次恢复草稿优先保留手动编辑，未编辑字段继续恢复历史草稿；切换账号、购票对象时继续清空旧资料。
+
+将报名浏览器专项接入 GitHub CI，新增延迟身份响应回归用例。代码改动共 4 个文件，新增 54 行、删除 2 行。
+
+## 2. GitHub 和构建身份
+
+| 项目                        | 本次值                                                                    |
+| --------------------------- | ------------------------------------------------------------------------- |
+| PR                          | https://github.com/yaojingang/TokEMS/pull/74                              |
+| PR CI                       | https://github.com/yaojingang/TokEMS/actions/runs/33886234412 — success   |
+| 主分支 CI                   | https://github.com/yaojingang/TokEMS/actions/runs/33887201538 — success   |
+| 镜像发布工作流              | https://github.com/yaojingang/TokEMS/actions/runs/33887916759 — success   |
+| 目标提交                    | `1afc01d1664406a6e1a08b426258e083a3412ed5`                                |
+| 构建时间                    | `2026-09-04T15:10:14Z`                                                    |
+| 最高迁移                    | `0059_green_rictor.sql`                                                   |
+| 迁移 SHA-256                | `776a677d42968cf0aeafb79ff2920994f2fe32446bf50c1a9d560d7847d14a24`        |
+| 发布分支                    | `origin/main`                                                             |
+| Release descriptor digest   | `sha256:992e8400eef4c58ec42553b41ea382a6c713cc1d814d557664a2ac0cb76d716e` |
+| Source Bundle SHA-256       | `c4092dddd671f6e34694b1b7651607a292dd02a3599bb06d3be70b8d80268e0d`        |
+| Descriptor verifier SHA-256 | `1975710a912a17a6a8519bc3011d78edb7d19bef78ae332247b662d1e8831568`        |
+| 目标平台                    | `linux/amd64`                                                             |
+
+CI 全部通过后，按既有管理员权限压缩合并；GitHub 分支保护保持原配置。本地主分支已同步，本轮临时分支和工作树已清理。
+
+## 3. 发布前检查
+
+- [x] 服务器工作区干净，`production` 跟踪 `origin/main`
+- [x] Compose 与 Nginx 配置通过
+- [x] 预构建模式的磁盘和备份容量满足要求
+- [x] 单一发布进程，未执行主机构建
+- [x] GitHub 必需检查及镜像来源验证成功
+- [x] `pnpm check`、`pnpm canonical:check` 和依赖安全检查通过
+- [x] 新增回归在旧代码失败，正式构建的 6 项报名浏览器测试全部通过
+- [x] 31 项数据库专项及 51 项工具测试通过
+
+## 4. 备份和回滚点
+
+| 项目                | 本次值                                                             |
+| ------------------- | ------------------------------------------------------------------ |
+| 备份目录            | `/www/backup/TokEMS/20260904-233346`                               |
+| 最终数据库 dump     | `/www/backup/TokEMS/20260904-233346/conference.dump`               |
+| dump SHA-256        | `acb47d62f5d69f1d9a78dcaa8cc33acadf7be43e332c87ab2228f037c868c8f6` |
+| `pg_restore --list` | 已验证，内容非空                                                   |
+| 镜像回滚标签        | `rollback-20260904-233346`                                         |
+| 对象存储变更        | 本次无对象存储变更                                                 |
+| 发布前版本          | `fe294e213e502bdec455e57723b0d2709fac68f2`                         |
+
+## 5. 数据库和模板
+
+本次无新迁移，`db-init` 成功；`SEED_DEMO_DATA=false`，未执行规范模板同步。只读规范核验确认 `geo-conference` / `tokems26` 的完整后台设置及公开内容符合目标快照。生产数据主键与销量保护检查通过。
+
+- 完整规范快照 SHA-256：`b6eede0924a284d687d8923201dc508a6fc52a578f9c2bc70fb4e598ba75138a`
+- 前台派生快照 SHA-256：`57464ab82ac2ba7ce876b6233b0956b94b19a6849e1cb4b6a42f06ca1bc02fc4`
+- 规范快照脱敏检查通过。
+
+| 数据表           | 写冻结基线 | 只读验收后 | 恢复写入后 |
+| ---------------- | ---------- | ---------- | ---------- |
+| customer_users   | 45         | 45         | 45         |
+| invoice_requests | 2          | 2          | 2          |
+| orders           | 37         | 37         | 37         |
+| registrations    | 37         | 37         | 37         |
+| tickets          | 25         | 25         | 25         |
+
+## 6. 镜像和容器切换
+
+| 服务              | GHCR digest                                                               | 最终状态 |
+| ----------------- | ------------------------------------------------------------------------- | -------- |
+| api               | `sha256:c0816a62994485152ceba4f53769a4adb04e03d37ce6617bc756eec588969371` | healthy  |
+| worker            | `sha256:326d14fe9e9e3e80adbe942af4462e2de458c5f1cb23374d71edfc9ed0101860` | healthy  |
+| web               | `sha256:528b894955f0ad9b50dac7ea9352afd130424865e30770d2d292af149a81d2e2` | healthy  |
+| admin             | `sha256:7e829433befa36f0771e83cdd13ebc9804f87e446ad8bc1ae51e860592588374` | healthy  |
+| gateway           | `sha256:b17dd24088beb64b1f19c7afd50de6fa00828535979b46bffdf300e2316a7565` | healthy  |
+| notification-sink | `sha256:bf9e1537ce52291dd6e4494b887b501ebb11dae8c8070984742758f8cf20b486` | healthy  |
+
+Web 和 payment-web 使用同一服务镜像。实际容器 image ID：
+
+- `/tokems-notification-sink-1`：`sha256:90682b11697d4b16706d009c5f79e27212f843095a3e12986d2022d12af3d400`
+- `/tokems-api-1`：`sha256:44dcee13f30f453f3c1a5ccafceb931965aa3e9d25303adcae38d60f660d1976`
+- `/tokems-worker-1`：`sha256:70f7e365624e4684cb3a05703dc03eff8abdde600be1fe0e178eaf934c495357`
+- `/tokems-web-1`：`sha256:76d171fcf1f1067edc96bf8fe09bfaa605828d3384831b7fb5259c6188aa4e12`
+- `/tokems-payment-web-1`：`sha256:76d171fcf1f1067edc96bf8fe09bfaa605828d3384831b7fb5259c6188aa4e12`
+- `/tokems-admin-1`：`sha256:200ef53519bd7f16ca8617093351cf31f2b36d743b3618e63f205ca89c46ec7d`
+- `/tokems-gateway-1`：`sha256:8842d0f0e5f9f98ac62340a6e22deb487997f7259de68e9a08235dfb8fc34558`
+
+## 7. 验证结果
+
+- [x] 七个应用容器全部 healthy
+- [x] 服务器源码、远端引用和运行版本均为目标提交
+- [x] API 健康、数据库迁移哈希和全部构建身份一致
+- [x] 服务器本机与公网首页、后台、支付、版本和健康入口通过验证
+- [x] 大会内容、报名表与后台设置符合规范快照
+- [x] 报名、订单、票、发票、用户计数以及库存销量保护检查通过
+- [x] API/Worker 标准启动命令与 `unless-stopped` 策略已恢复
+- [x] 写恢复观察通过，`RECOVERY_REQUIRED` 标记已清除
+
+桌面和手机端最终页面验收结果见本次证据目录中的 `public-acceptance.json`。验收仅访问公开页面并填写未提交的测试内容，未发送短信、创建真实报名或支付。
+
+## 8. 异常和处理
+
+远端镜像验证耗时较长，API 镜像下载触发自动重试，随后全部镜像拉取并验证成功。等待发生于写冻结之前，旧服务持续运行。部署未触发回滚。
+
+新增回归已确认在修复前失败、修复后通过。
+
+## 9. 最终结论
+
+代码复核修复已发布到 `1afc01d1664406a6e1a08b426258e083a3412ed5`。生产业务数据与发布前基线一致，报名和后台写入正常。本次无剩余阻塞项。
+
+本记录保存当次事实，后续操作以当前仓库、CI、服务器健康接口和生产 Runbook 为准。详细证据保存在本地 `.codex-artifacts/production-release/2026-09-04-registration-review/`。


### PR DESCRIPTION
报名体验优化及复核修复已经发布，仓库尚缺少对应的生产发布记录。本 PR 补充两次发布的构建身份、备份与回滚点、模板快照、数据保护结果、容器状态、线上验收和异常处理，便于后续审计与回溯。

记录覆盖：
- PR #71–#73 对应的报名体验优化发布（`fe294e2`）
- PR #74 对应的复核修复发布（`1afc01d`）

验证：
- `pnpm exec prettier --check docs/release-records/2026-09-04-registration-experience.md docs/release-records/2026-09-04-registration-review.md`
- `pnpm docs:check`
- `pnpm canonical:check`
- 推送前规范快照门禁通过
