### PR TITLE
fix: prevent background Git maintenance during release verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## 本地开发与预览
 
 - 主工作目录的 `main` 是本地集成分支。日常页面调整和连续小迭代默认在这里完成，无需每轮新建分支或工作树；本地提交与远端推送分别按用户授权执行。
+- 已在本地 `main` 完成的提交，远端推送使用 `HEAD:refs/heads/codex/<change-name>`，再通过 PR 合并到远端 `main`。用户授权推送后仍须遵守 PR 流程；禁止直接推送远端 `main` 或使用管理员权限跳过必需检查。
 - 需要并行隔离、较大实验或用户指定时才使用功能分支与独立工作树。完成并验证后及时合并到本地 `main`，再更新共享预览。
 - `http://127.0.0.1:8088/`、Compose 项目 `tokems` 和 `tokems-*:local` 镜像只用于主工作目录的共享预览。其他工作树不得构建、启动或替换这套共享服务。
 - 独立预览必须同时隔离 Compose 项目名、镜像标签、端口和数据卷；仅创建 Git 分支或工作树不能隔离运行环境。临时构建与测试优先使用不接管共享服务的验证方式。
@@ -13,6 +14,7 @@
 
 - 生产发布前必须阅读 `docs/production-deployment-runbook.md`。
 - 唯一上游仓库为 `https://github.com/yaojingang/TokEMS.git`，生产代码只允许来自已合并且 CI 通过的 `origin/main`。
+- 生产目标 SHA 必须等于一个以 `main` 为目标分支的已合并 PR 的 `merge_commit_sha`，并具有该 SHA 的成功主分支 CI 和完整镜像发布。确认提交已在远端 `main` 后，还须核对这三项证据才能给出可发布结论。
 - 生产服务器源码目录为 `/www/wwwroot/TokEMS`。宝塔站点目录 `/www/dk_project/wwwroot/hui.ailingdaoli.com` 只承载站点和反向代理配置，禁止在该目录拉取代码、构建镜像或执行数据库迁移。
 - 生产环境文件固定为 `/etc/tokems/production.env`，目录权限为 `root:root 0700`，文件权限为 `root:root 0600`。生产 Compose 和发布脚本禁止读取 Git 工作区中的实时 `.env`。
 - 服务器分支 `production` 跟踪 `origin/main`。发布前确认工作区干净，并确认服务器 `HEAD` 与 `origin/main` 完全一致。

--- a/docs/production-deployment-runbook.md
+++ b/docs/production-deployment-runbook.md
@@ -128,11 +128,25 @@ pnpm check
 
 ### 6.2 PR 和合并
 
+功能分支上的提交按以下步骤发起 PR：
+
 ```bash
 git push -u origin <feature-branch>
 gh pr create --base main --head <feature-branch>
 gh pr checks <pr-number> --watch
 ```
+
+主工作目录允许在本地 `main` 连续提交。推送前确认 `origin/main..HEAD` 仅包含本轮已完成的提交，再把这些提交推送到远端功能分支。将 `<change-name>` 替换为本次改动的分支名称：
+
+```bash
+git fetch origin main
+git log --oneline origin/main..HEAD
+git push origin HEAD:refs/heads/codex/<change-name>
+gh pr create --base main --head codex/<change-name>
+gh pr checks <pr-number> --watch
+```
+
+本地 `main` 的提交授权与远端主分支的 PR 门禁同时适用。禁止直接推送远端 `main` 或使用管理员权限跳过必需检查。生产脚本要求最终目标 SHA 等于已合并 PR 的 `merge_commit_sha`；仅有远端提交、成功 CI 或已构建镜像均不足以通过此门禁。
 
 合并前确认：
 
@@ -144,7 +158,7 @@ gh pr checks <pr-number> --watch
 - 新迁移、生成文件、文档和测试全部纳入提交。
 - `origin/main` 没有尚未处理的冲突或更新。
 
-合并后记录目标提交：
+合并后记录目标提交，并确认它与本次 PR 的 `merge_commit_sha` 一致。等待该 SHA 的主分支 CI 和镜像发布工作流全部成功，核对最终 `release-<SHA>` descriptor 后，才进入服务器发布流程：
 
 ```bash
 git fetch origin main

--- a/tooling/lib/release-descriptor.test.mjs
+++ b/tooling/lib/release-descriptor.test.mjs
@@ -42,6 +42,38 @@ function runVerifier(args) {
   return spawnSync('python3', [verifierPath, ...args], { encoding: 'utf8' });
 }
 
+function runVerifierWithGitTrace(args, traceFile) {
+  const script = `
+import importlib.util, os, sys
+spec = importlib.util.spec_from_file_location("release_descriptor", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+trace_file = sys.argv[2]
+original_run = module.subprocess.run
+def traced_run(*args, **kwargs):
+    environment = dict(kwargs.get("env", os.environ))
+    environment["GIT_TRACE2_EVENT"] = trace_file
+    kwargs["env"] = environment
+    return original_run(*args, **kwargs)
+module.subprocess.run = traced_run
+sys.argv = [sys.argv[1]] + sys.argv[3:]
+raise SystemExit(module.main())
+`;
+  return spawnSync('python3', ['-B', '-c', script, verifierPath, traceFile, ...args], {
+    encoding: 'utf8',
+  });
+}
+
+function automaticMaintenance(traceFile) {
+  const events = readFileSync(traceFile, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.ok(events.some((event) => event.event === 'cmd_name' && event.name === 'fetch'));
+  return events.filter(
+    (event) =>
+      event.event === 'child_start' &&
+      event.argv?.some((argument) => argument === 'maintenance' || argument === 'gc'),
+  );
+}
+
 test('release descriptor verifier emits a complete immutable image set', () => {
   const directory = mkdtempSync(resolve(tmpdir(), 'tokems-release-descriptor-'));
   const labelsFile = resolve(directory, 'labels.json');
@@ -201,14 +233,28 @@ test('source bundle verifier accepts the exact release ref and rejects wrong or 
     const created = runGit(['bundle', 'create', bundle, 'refs/heads/tokems-release-source']);
     assert.equal(created.status, 0, created.stderr);
 
-    const accepted = runVerifier([
-      'verify-source-bundle',
-      '--bundle-file',
-      bundle,
-      '--target-sha',
-      targetSha,
-    ]);
+    const controlTrace = resolve(directory, 'control-trace.jsonl');
+    const control = spawnSync(
+      'git',
+      ['-C', repository, 'fetch', bundle, 'refs/heads/tokems-release-source'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, GIT_TRACE2_EVENT: controlTrace },
+      },
+    );
+    assert.equal(control.status, 0, control.stderr);
+    assert.ok(automaticMaintenance(controlTrace).length > 0);
+    const verifyTrace = resolve(directory, 'verify-trace.jsonl');
+    const accepted = runVerifierWithGitTrace(
+      ['verify-source-bundle', '--bundle-file', bundle, '--target-sha', targetSha],
+      verifyTrace,
+    );
     assert.equal(accepted.status, 0, accepted.stderr);
+    assert.deepEqual(
+      automaticMaintenance(verifyTrace),
+      [],
+      'temporary bundle verification must finish without background maintenance',
+    );
 
     const wrongSha = runVerifier([
       'verify-source-bundle',
@@ -285,18 +331,27 @@ test('source bundle importer fast-forwards only origin/main and leaves productio
     ]);
     assert.equal(created.status, 0, created.stderr);
 
-    const imported = runVerifier([
-      'import-source-bundle',
-      '--bundle-file',
-      bundle,
-      '--repository',
-      productionRepository,
-      '--target-sha',
-      targetSha,
-      '--timeout-seconds',
-      '30',
-    ]);
+    const importTrace = resolve(directory, 'import-trace.jsonl');
+    const imported = runVerifierWithGitTrace(
+      [
+        'import-source-bundle',
+        '--bundle-file',
+        bundle,
+        '--repository',
+        productionRepository,
+        '--target-sha',
+        targetSha,
+        '--timeout-seconds',
+        '30',
+      ],
+      importTrace,
+    );
     assert.equal(imported.status, 0, imported.stderr);
+    assert.deepEqual(
+      automaticMaintenance(importTrace),
+      [],
+      'bundle import must finish without background maintenance',
+    );
     assert.equal(
       runGit(productionRepository, ['rev-parse', 'refs/remotes/origin/main']).stdout.trim(),
       targetSha,

--- a/tooling/release-descriptor.py
+++ b/tooling/release-descriptor.py
@@ -235,6 +235,7 @@ def verify_source_bundle(args: argparse.Namespace) -> None:
         run_git(
             "fetch",
             "--quiet",
+            "--no-auto-maintenance",
             "--no-tags",
             "--no-write-fetch-head",
             str(bundle),
@@ -301,6 +302,7 @@ def import_source_bundle(args: argparse.Namespace) -> None:
         run_git(
             "fetch",
             "--quiet",
+            "--no-auto-maintenance",
             "--no-tags",
             "--no-write-fetch-head",
             str(bundle),


### PR DESCRIPTION
完整源码包校验结束后，Git fetch 启动的后台维护进程仍可能写入 objects，导致临时目录清理失败，生产镜像的最终 release descriptor 无法发布。源码包校验和生产导入现在都关闭自动维护，让 Git 操作在受控调用内结束。回归测试读取真实 Git Trace2 子进程记录，覆盖默认行为的正向对照、两个修复路径，以及原有的损坏包和非快进历史拒绝逻辑。

同时明确本地 main 提交后的远端 PR 流程，以及生产目标 SHA、已合并 PR、主分支 CI 和完整镜像发布之间的对应关系。发布版本包含 7912f79 的参会问题排版优化。

验证：
- 两个新增进程生命周期断言在旧实现下失败，修复后通过。
- 源码包和生产部署专项测试共 40 项通过。
- 完整仓库源码包连续三次校验通过。
- 规范快照、文档清单、格式和静态检查通过。
- 独立安全复核未发现新增问题。

合并前等待本 PR 全部必需检查和协作者审批通过；合并后继续核验相同合并 SHA 的主分支 CI、六个服务镜像及最终 release descriptor。
