### PR TITLE
fix: keep administrator browser sessions for 90 days

### DIFF
--- a/apps/admin/src/lib/api-session.test.ts
+++ b/apps/admin/src/lib/api-session.test.ts
@@ -1,0 +1,55 @@
+import type { LoginResult } from '@conference/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('administrator browser session persistence', () => {
+  const values = new Map<string, string>();
+  const login: LoginResult = {
+    accessToken: 'browser-session-test-token',
+    user: {
+      id: 101,
+      email: null,
+      username: 'session-admin',
+      name: 'Session administrator',
+      role: 'organization_admin',
+    },
+  };
+
+  beforeEach(() => {
+    values.clear();
+    vi.resetModules();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('restores the login when the same browser opens the app again', async () => {
+    const { session } = await import('./api');
+    session.set(login);
+
+    vi.resetModules();
+    const reopened = (await import('./api')).session;
+    expect(reopened.token.value).toBe(login.accessToken);
+    expect(reopened.user.value).toEqual(login.user);
+    expect(reopened.authenticated.value).toBe(true);
+  });
+
+  it('removes the saved login on logout so reopening requires sign-in', async () => {
+    const { session } = await import('./api');
+    session.set(login);
+    expect(values.get('conference.admin.token')).toBe(login.accessToken);
+    session.clear();
+
+    vi.resetModules();
+    const reopened = (await import('./api')).session;
+    expect(reopened.token.value).toBe('');
+    expect(reopened.authenticated.value).toBe(false);
+    expect(values.has('conference.admin.token')).toBe(false);
+    expect(values.has('conference.admin.user')).toBe(false);
+  });
+});

--- a/apps/api/src/modules/auth.module.test.ts
+++ b/apps/api/src/modules/auth.module.test.ts
@@ -1,0 +1,72 @@
+import type { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthGuard } from '../common/auth.guard.js';
+import type { DatabaseService } from '../common/database.service.js';
+import { AuthService } from './auth.module.js';
+
+describe('administrator browser login lifetime', () => {
+  const issuedAt = new Date('2026-09-08T00:00:00Z');
+  const day = 24 * 60 * 60 * 1000;
+  const jwt = new JwtService({
+    secret: 'administrator-session-test-secret',
+    signOptions: { expiresIn: '8h' },
+  });
+  const database = { db: undefined } as unknown as DatabaseService;
+  const auth = new AuthService(jwt, database);
+  const guard = new AuthGuard(jwt, new Reflector(), database);
+
+  function context(accessToken: string) {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ headers: { authorization: `Bearer ${accessToken}` } }),
+      }),
+      getHandler: () => context,
+      getClass: () => AuthService,
+    } as unknown as ExecutionContext;
+  }
+
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('ADMIN_USERNAME', 'session-admin');
+    vi.stubEnv('ADMIN_PASSWORD', 'session-test-password');
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(issuedAt);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it('keeps a login valid after eight hours and until exactly 90 days from sign-in', async () => {
+    const { accessToken } = await auth.login({
+      username: 'session-admin',
+      password: 'session-test-password',
+    });
+    const claims = jwt.decode<{ iat: number; exp: number }>(accessToken);
+    expect(claims.exp - claims.iat).toBe(90 * 24 * 60 * 60);
+
+    vi.setSystemTime(issuedAt.getTime() + day);
+    await expect(guard.canActivate(context(accessToken))).resolves.toBe(true);
+
+    vi.setSystemTime(issuedAt.getTime() + 90 * day - 1000);
+    await expect(guard.canActivate(context(accessToken))).resolves.toBe(true);
+
+    vi.setSystemTime(issuedAt.getTime() + 90 * day);
+    await expect(guard.canActivate(context(accessToken))).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('rejects incorrect passwords', async () => {
+    await expect(
+      auth.login({ username: 'session-admin', password: 'incorrect-password' }),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('preserves the shared lifetime for other tokens', async () => {
+    const token = await jwt.signAsync({ sub: 'unrelated-token' });
+    const claims = jwt.decode<{ iat: number; exp: number }>(token);
+    expect(claims.exp - claims.iat).toBe(8 * 60 * 60);
+  });
+});

--- a/apps/api/src/modules/auth.module.ts
+++ b/apps/api/src/modules/auth.module.ts
@@ -174,18 +174,21 @@ export class AuthService {
         HttpStatus.UNAUTHORIZED,
       );
     }
-    const accessToken = await this.jwt.signAsync({
-      sub: identity.uuid,
-      email: identity.email,
-      username: identity.username,
-      name: identity.name,
-      role: identity.role,
-      organizationId: identity.organizationId,
-      grants: identity.grants,
-      credentialVersion: identity.credentialVersion,
-      membershipId: identity.membershipId,
-      membershipVersion: identity.membershipVersion,
-    });
+    const accessToken = await this.jwt.signAsync(
+      {
+        sub: identity.uuid,
+        email: identity.email,
+        username: identity.username,
+        name: identity.name,
+        role: identity.role,
+        organizationId: identity.organizationId,
+        grants: identity.grants,
+        credentialVersion: identity.credentialVersion,
+        membershipId: identity.membershipId,
+        membershipVersion: identity.membershipVersion,
+      },
+      { expiresIn: '90d' },
+    );
     return {
       accessToken,
       user: {

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,7 @@ OpenAPI JSON：`http://localhost:8088/api/openapi.json`
 ## 通用请求约定
 
 - 后台接口使用 `Authorization: Bearer <token>`。
+- 后台登录凭据自登录成功起固定有效 90 天，并保存在当前浏览器；退出登录会清除本地凭据，凭据或成员授权变更仍会使已有登录失效。已签发的旧凭据保留原有效期，重新登录后生效。
 - 多组织公开读取可传 `X-Organization-Slug`，默认值来自 `PUBLIC_ORGANIZATION_SLUG`。
 - 关键写操作使用 8 到 160 字符的 `Idempotency-Key`。
 - `eventId` 统一为 `101`–`2147483647` 的正整数。首场大会为 `101`，新建成功后全局递增 1，已分配编号不复用。

--- a/docs/generated/project-inventory.json
+++ b/docs/generated/project-inventory.json
@@ -7,5 +7,5 @@
   "databaseTables": 83,
   "apiControllers": 35,
   "apiOperations": 289,
-  "testFiles": 181
+  "testFiles": 183
 }


### PR DESCRIPTION
后台登录原先约 8 小时后过期。本次将管理员登录凭据的有效期设为从登录成功起固定 90 天，同一浏览器重新打开后台时继续使用已保存的登录状态。主动退出会清除本地凭据，现有的凭据和成员授权失效检查继续生效；旧登录凭据需重新登录后获得新有效期。

此次提交仅包含登录修改、回归测试和对应文档。大会内容与规范快照保持远端 main 的现有版本，新增大会内容将后续单独提交。

验证：

- 回归测试覆盖 90 天到期边界、浏览器重新打开、退出清理及其他令牌的有效期。
- 管理员数据库集成测试通过，验证密码和成员授权变更后的登录失效。
- 完整 `pnpm check`、安全依赖审计和浏览器登录/重新打开/退出验证通过。
- 保持仓库推送门禁启用，使用独立工作区及由已提交规范快照恢复的临时数据库完成 `pnpm canonical:check` 和推送校验；主工作区的大会编辑保留原样。
