### PR TITLE
fix: 修复退款设置并更新 SVGO 安全依赖

### DIFF
--- a/apps/admin/src/views/EventRegistrationSettingsView.test.ts
+++ b/apps/admin/src/views/EventRegistrationSettingsView.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ComputedRef, Ref } from 'vue';
+import { WeChatPayConfigurationSchema, type WeChatPayConfiguration } from '@conference/contracts';
 import EventRegistrationSettingsView from './EventRegistrationSettingsView.vue';
 
-const { updateEvent } = vi.hoisted(() => ({ updateEvent: vi.fn() }));
+const { updateEvent, canReadPayment } = vi.hoisted(() => ({
+  updateEvent: vi.fn(),
+  canReadPayment: vi.fn(() => false),
+}));
 vi.mock('../lib/api', () => ({
   conferenceApi: { updateEvent },
-  session: { can: () => false, canAny: () => true },
+  session: { can: canReadPayment, canAny: () => true },
 }));
 vi.mock('vue-router', () => ({ useRoute: () => ({ hash: '' }) }));
 vi.mock('vue', async (original) => ({
@@ -19,6 +23,11 @@ interface RefundSettingsState {
   savedRefundEnabled: Ref<boolean>;
   refundPending: Ref<boolean>;
   refundPolicyDirty: ComputedRef<boolean>;
+  paymentConfiguration: Ref<WeChatPayConfiguration | undefined>;
+  refundPaymentReadiness: ComputedRef<string>;
+  refundPaymentStatus: ComputedRef<string>;
+  refundPaymentDescription: ComputedRef<string>;
+  errorMessage: Ref<string>;
   saveRefundPolicy: () => Promise<void>;
 }
 
@@ -34,6 +43,7 @@ function settingsState() {
 describe('refund settings saving', () => {
   beforeEach(() => {
     updateEvent.mockReset();
+    canReadPayment.mockReturnValue(false);
   });
 
   it.each([false, true])(
@@ -80,4 +90,82 @@ describe('refund settings saving', () => {
     finish();
     await saving;
   });
+
+  function payment(status: WeChatPayConfiguration['status'], refundFunding: 'default' | null) {
+    return WeChatPayConfigurationSchema.parse({
+      status,
+      refundFunding,
+      enabled: true,
+      appId: 'wx-test',
+      mchId: 'test-merchant',
+      merchantCertificateSerial: 'TEST_SERIAL',
+      platformPublicKeyId: 'PUB_KEY_ID_TEST',
+      notifyUrl: 'https://example.test/notify',
+      lastVerifiedAt: null,
+      lastError: null,
+      secretsPresent: {
+        merchantPrivateKey: true,
+        apiV3Key: true,
+        platformPublicKey: true,
+        appSecret: false,
+      },
+    });
+  }
+
+  it.each([
+    ['verified', null, '商户验证已通过，请选择退款出资账户。'],
+    ['configured', 'default', '退款出资账户已设置，请完成商户验证。'],
+    ['error', 'default', '退款出资账户已设置，商户验证失败，请前往支付设置重新验证。'],
+    ['unconfigured', null, '请完成商户配置与验证，并选择退款出资账户。'],
+  ] as const)(
+    'explains and blocks an incomplete configuration (%s, %s)',
+    async (status, funding, description) => {
+      canReadPayment.mockReturnValue(true);
+      const state = settingsState();
+      state.paymentConfiguration.value = payment(status, funding);
+      state.settingsForm.refundEnabled = true;
+      expect(state.refundPaymentReadiness.value).toBe('incomplete');
+      expect(state.refundPaymentDescription.value).toBe(description);
+      await state.saveRefundPolicy();
+      expect(updateEvent).not.toHaveBeenCalled();
+      expect(state.errorMessage.value).toBe(description);
+    },
+  );
+
+  it('saves when both conditions are met without claiming a verified refund transaction', async () => {
+    canReadPayment.mockReturnValue(true);
+    const state = settingsState();
+    state.paymentConfiguration.value = payment('verified', 'default');
+    state.settingsForm.refundEnabled = true;
+    expect(state.refundPaymentStatus.value).toBe('退款开启条件已满足');
+    await state.saveRefundPolicy();
+    expect(updateEvent).toHaveBeenCalledOnce();
+    expect(state.savedRefundEnabled.value).toBe(true);
+  });
+
+  it('allows closing the entry with incomplete payment configuration', async () => {
+    canReadPayment.mockReturnValue(true);
+    const state = settingsState();
+    state.paymentConfiguration.value = payment('configured', null);
+    state.savedRefundEnabled.value = true;
+    await state.saveRefundPolicy();
+    expect(updateEvent).toHaveBeenCalledWith({
+      settings: { refunds: { enabled: false, version: 'seven-day-v1', windowDays: 7 } },
+    });
+  });
+
+  it.each([false, true])(
+    'lets the server validate unavailable payment settings (read access: %s)',
+    async (canRead) => {
+      canReadPayment.mockReturnValue(canRead);
+      const state = settingsState();
+      state.settingsForm.refundEnabled = true;
+      updateEvent.mockRejectedValueOnce(new Error('尚未确认微信退款出资配置'));
+      expect(state.refundPaymentReadiness.value).toBe('unknown');
+      await state.saveRefundPolicy();
+      expect(updateEvent).toHaveBeenCalledOnce();
+      expect(state.savedRefundEnabled.value).toBe(false);
+      expect(state.errorMessage.value).toBe('尚未确认微信退款出资配置');
+    },
+  );
 });

--- a/apps/admin/src/views/EventRegistrationSettingsView.vue
+++ b/apps/admin/src/views/EventRegistrationSettingsView.vue
@@ -101,16 +101,29 @@ const refundPaymentReadiness = computed<'ready' | 'incomplete' | 'unknown'>(() =
     : 'incomplete';
 });
 const refundPaymentStatus = computed(() => {
-  if (refundPaymentReadiness.value === 'ready') return '微信退款配置可用';
+  if (refundPaymentReadiness.value === 'ready') return '退款开启条件已满足';
   if (refundPaymentReadiness.value === 'incomplete') return '微信退款配置待完善';
   return '启用时将校验微信退款配置';
 });
 const refundPaymentDescription = computed(() => {
   if (refundPaymentReadiness.value === 'ready') return '审核通过后，系统会自动提交微信原路退款。';
-  if (refundPaymentReadiness.value === 'incomplete')
-    return '请先完成商户凭据验证，并选择退款出资账户。';
-  return '需要微信商户凭据验证通过，并选择退款出资账户。';
+  if (refundPaymentReadiness.value === 'unknown') return '启用时将由系统校验商户验证状态与退款出资账户。';
+  const configuration = paymentConfiguration.value!;
+  if (configuration.status === 'verified') return '商户验证已通过，请选择退款出资账户。';
+  if (configuration.refundFunding) {
+    return configuration.status === 'error'
+      ? '退款出资账户已设置，商户验证失败，请前往支付设置重新验证。'
+      : '退款出资账户已设置，请完成商户验证。';
+  }
+  return configuration.status === 'error'
+    ? '商户验证失败，请前往支付设置重新验证，并选择退款出资账户。'
+    : '请完成商户配置与验证，并选择退款出资账户。';
 });
+const refundSaveBlockedReason = computed(() =>
+  settingsForm.refundEnabled && refundPaymentReadiness.value === 'incomplete'
+    ? refundPaymentDescription.value
+    : '',
+);
 const canManageTickets = computed(() => session.can('event.inventory.manage'));
 const canReadFlow = computed(() => session.can('event.site.read'));
 const canManageFlow = computed(() => session.can('event.content.manage'));
@@ -266,8 +279,8 @@ async function saveSettings() {
 
 async function saveRefundPolicy() {
   if (refundPending.value || !canManageRefundPolicy.value || !refundPolicyDirty.value) return;
-  if (settingsForm.refundEnabled && refundPaymentReadiness.value === 'incomplete') {
-    errorMessage.value = '请先完成微信退款配置，再开放用户自助退款。';
+  if (refundSaveBlockedReason.value) {
+    errorMessage.value = refundSaveBlockedReason.value;
     return;
   }
   const submittedRefundEnabled = settingsForm.refundEnabled;
@@ -598,7 +611,7 @@ async function saveFlow() {
         <RouterLink
           v-if="canReadPaymentSettings"
           class="button secondary compact"
-          :to="{ name: 'manage-settings-payment' }"
+          :to="{ name: 'manage-settings-payment', hash: '#payment-refund-settings' }"
         >
           前往支付设置
         </RouterLink>
@@ -608,14 +621,23 @@ async function saveFlow() {
         已提交的申请会继续处理；关闭入口不会中止已批准退款。
       </p>
       <div class="event-form-actions">
+        <p
+          v-if="refundSaveBlockedReason"
+          id="refund-save-blocked-reason"
+          class="refund-save-blocked-reason"
+          role="status"
+        >
+          {{ refundSaveBlockedReason }}
+        </p>
         <button
           class="button"
           type="submit"
           :disabled="
             refundPending ||
               !refundPolicyDirty ||
-              (settingsForm.refundEnabled && refundPaymentReadiness === 'incomplete')
+              Boolean(refundSaveBlockedReason)
           "
+          :aria-describedby="refundSaveBlockedReason ? 'refund-save-blocked-reason' : undefined"
         >
           {{ refundPending ? '保存中…' : '保存退款设置' }}
         </button>
@@ -941,7 +963,17 @@ async function saveFlow() {
 }
 
 .refund-settings-form .event-form-actions {
+  flex-wrap: wrap;
+  align-items: center;
   margin-top: 0;
+}
+
+.refund-save-blocked-reason {
+  flex: 1 1 260px;
+  margin: 0;
+  color: var(--gold);
+  font-size: var(--admin-font-caption);
+  line-height: 1.6;
 }
 
 @media (max-width: 640px) {

--- a/apps/admin/src/views/ManagementPaymentSettingsView.test.ts
+++ b/apps/admin/src/views/ManagementPaymentSettingsView.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Ref } from 'vue';
+import { WeChatPayConfigurationSchema, type WeChatPayConfiguration } from '@conference/contracts';
+import ManagementPaymentSettingsView from './ManagementPaymentSettingsView.vue';
+
+const api = vi.hoisted(() => ({
+  getWeChatPayConfiguration: vi.fn(),
+  updateWeChatPayConfiguration: vi.fn(),
+  testWeChatPayConfiguration: vi.fn(),
+  unmatchedRefundNotifications: vi.fn(),
+}));
+vi.mock('../lib/api', () => ({ conferenceApi: api, session: { canAny: () => true } }));
+vi.mock('vue-router', () => ({ useRoute: () => ({ hash: '' }) }));
+vi.mock('vue', async (original) => ({
+  ...(await original<typeof import('vue')>()),
+  onMounted: vi.fn(),
+  useSSRContext: () => ({ modules: new Set() }),
+}));
+vi.mock('../composables/settings-form-state', async () => {
+  const { ref } = await import('vue');
+  return {
+    useSettingsFormScope: () => ({
+      dirty: ref(false),
+      clearDirty: vi.fn(),
+      setBusy: vi.fn(),
+      setResetHandler: vi.fn(),
+    }),
+  };
+});
+
+interface PaymentSettingsState {
+  form: { refundFunding: '' | 'default' | 'available'; apiV3Key: string };
+  configuration: Ref<WeChatPayConfiguration>;
+  message: Ref<string>;
+  errorMessage: Ref<string>;
+  load: () => Promise<void>;
+  save: () => Promise<void>;
+  testConnection: () => Promise<void>;
+}
+
+function configuration(
+  status: WeChatPayConfiguration['status'],
+  refundFunding: 'default' | null = null,
+) {
+  return WeChatPayConfigurationSchema.parse({
+    status,
+    refundFunding,
+    enabled: true,
+    appId: 'wx-test',
+    mchId: 'test-merchant',
+    merchantCertificateSerial: 'TEST_SERIAL',
+    platformPublicKeyId: 'PUB_KEY_ID_TEST',
+    notifyUrl: 'https://example.test/notify',
+    lastVerifiedAt: '2026-09-08T00:00:00Z',
+    lastError: null,
+    secretsPresent: {
+      merchantPrivateKey: true,
+      apiV3Key: true,
+      platformPublicKey: true,
+      appSecret: false,
+    },
+  });
+}
+
+async function settingsState(status: WeChatPayConfiguration['status'] = 'verified') {
+  api.getWeChatPayConfiguration.mockResolvedValue(configuration(status));
+  const setup = ManagementPaymentSettingsView.setup;
+  if (!setup) throw new Error('Payment settings component has no setup function');
+  const state = setup(
+    {},
+    { expose: vi.fn(), attrs: {}, slots: {}, emit: vi.fn() },
+  ) as unknown as PaymentSettingsState;
+  await state.load();
+  return state;
+}
+
+describe('saving WeChat refund funding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.unmatchedRefundNotifications.mockResolvedValue([]);
+    api.testWeChatPayConfiguration.mockRejectedValue(new Error('微信验证接口暂不可用'));
+  });
+
+  it('keeps verified funding saves independent of the WeChat verification endpoint', async () => {
+    const state = await settingsState();
+    state.form.refundFunding = 'default';
+    api.updateWeChatPayConfiguration.mockResolvedValue(configuration('verified', 'default'));
+    await state.save();
+    expect(api.updateWeChatPayConfiguration).toHaveBeenCalledWith(
+      expect.objectContaining({ refundFunding: 'default' }),
+    );
+    expect(api.testWeChatPayConfiguration).not.toHaveBeenCalled();
+    expect(state.configuration.value.status).toBe('verified');
+    expect(state.configuration.value.lastVerifiedAt).toBe('2026-09-08T00:00:00Z');
+    expect(state.message.value).toBe('配置已保存，商户验证保持通过。');
+    expect(state.errorMessage.value).toBe('');
+  });
+
+  it('verifies changed credentials based on the saved server status', async () => {
+    const state = await settingsState();
+    state.form.apiV3Key = 'test-key';
+    api.updateWeChatPayConfiguration.mockResolvedValue(configuration('configured', 'default'));
+    api.testWeChatPayConfiguration.mockResolvedValue({ ok: true, message: '连接验证通过' });
+    api.getWeChatPayConfiguration.mockResolvedValue(configuration('verified', 'default'));
+    await state.save();
+    expect(api.testWeChatPayConfiguration).toHaveBeenCalledOnce();
+    expect(state.configuration.value.status).toBe('verified');
+    expect(state.message.value).toBe('连接验证通过');
+  });
+
+  it('keeps an unverified merchant unverified if the verification request fails', async () => {
+    const state = await settingsState('configured');
+    state.form.refundFunding = 'default';
+    api.updateWeChatPayConfiguration.mockResolvedValue(configuration('configured', 'default'));
+    await state.save();
+    expect(api.testWeChatPayConfiguration).toHaveBeenCalledOnce();
+    expect(state.configuration.value.status).toBe('configured');
+    expect(state.errorMessage.value).toBe('微信验证接口暂不可用');
+  });
+
+  it('allows explicitly revalidating a verified merchant', async () => {
+    const state = await settingsState();
+    await state.testConnection();
+    expect(api.testWeChatPayConfiguration).toHaveBeenCalledOnce();
+    expect(state.errorMessage.value).toBe('微信验证接口暂不可用');
+  });
+});

--- a/apps/admin/src/views/ManagementPaymentSettingsView.vue
+++ b/apps/admin/src/views/ManagementPaymentSettingsView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
 import type { WeChatPayConfiguration } from '@conference/contracts';
 import SaveStatus from '../components/SaveStatus.vue';
 import SettingsFormActions from '../components/SettingsFormActions.vue';
@@ -7,6 +8,7 @@ import { useSettingsFormScope } from '../composables/settings-form-state';
 import { conferenceApi, session } from '../lib/api';
 
 const configuration = ref<WeChatPayConfiguration>();
+const route = useRoute();
 const unmatchedRefunds = ref<
   Awaited<ReturnType<typeof conferenceApi.unmatchedRefundNotifications>>
 >([]);
@@ -141,7 +143,7 @@ async function testConnection() {
 }
 
 /**
- * Persists configuration changes and immediately re-validates the merchant link.
+ * Persists configuration changes and verifies when the server requires it.
  */
 async function save() {
   if (!loaded.value) {
@@ -175,8 +177,12 @@ async function save() {
       ...(form.appSecret.trim() ? { appSecret: form.appSecret.trim() } : {}),
     });
     applyConfiguration(result);
-    message.value = '配置已加密保存，正在验证微信支付连接。';
-    await testConnection();
+    if (result.status === 'verified') {
+      message.value = '配置已保存，商户验证保持通过。';
+    } else {
+      message.value = '配置已加密保存，正在验证微信支付连接。';
+      await testConnection();
+    }
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : '微信支付配置保存失败';
   } finally {
@@ -184,7 +190,14 @@ async function save() {
   }
 }
 
-onMounted(load);
+onMounted(async () => {
+  await load();
+  if (route.hash !== '#payment-refund-settings') return;
+  await nextTick();
+  const refundSettings = document.querySelector<HTMLElement>(route.hash);
+  refundSettings?.scrollIntoView({ block: 'start' });
+  refundSettings?.focus({ preventScroll: true });
+});
 </script>
 
 <template>
@@ -351,7 +364,12 @@ onMounted(load);
         </div>
       </section>
 
-      <section class="settings-form-section" aria-labelledby="payment-refund-heading">
+      <section
+        id="payment-refund-settings"
+        class="settings-form-section"
+        tabindex="-1"
+        aria-labelledby="payment-refund-heading"
+      >
         <div v-if="unmatchedRefunds.length" class="settings-inline-error" role="alert">
           <strong>{{ unmatchedRefunds.length }} 条退款通知需要核验</strong>
           <p v-for="item in unmatchedRefunds" :key="item.id">
@@ -367,11 +385,19 @@ onMounted(load);
         </div>
         <div class="form-field full">
           <label for="wechat-refund-funding">退款出资账户</label>
-          <select id="wechat-refund-funding" v-model="form.refundFunding" :disabled="!canManage">
+          <select
+            id="wechat-refund-funding"
+            v-model="form.refundFunding"
+            :disabled="!canManage"
+            aria-describedby="wechat-refund-funding-help"
+          >
             <option value="" disabled>待财务确认</option>
             <option value="default">默认退款账户（按微信商户配置）</option>
             <option value="available">可用余额（已确认使用旧资金账户）</option>
           </select>
+          <p id="wechat-refund-funding-help">
+            默认退款账户由微信按商户配置处理；可用余额仅适用于已确认的旧资金流商户。请由财务确认后选择。仅修改出资账户时会保留已通过的商户验证，凭据变更需重新验证。
+          </p>
         </div>
         <p v-if="configuration?.refundNotifyUrl">
           退款结果通知地址：{{ configuration.refundNotifyUrl }}
@@ -462,8 +488,14 @@ onMounted(load);
         v-if="canManage"
         :pending="pending"
         :disabled="testing"
-        primary-label="保存并验证"
+        primary-label="保存设置"
       />
     </form>
   </section>
 </template>
+
+<style scoped>
+#payment-refund-settings {
+  scroll-margin-top: 96px;
+}
+</style>

--- a/apps/api/src/common/wechat-pay.service.ts
+++ b/apps/api/src/common/wechat-pay.service.ts
@@ -713,17 +713,21 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
           h5: input.channels?.h5 ?? previousConfig.channels.h5,
         },
       };
-      const preserveVerification =
-        existing?.status === 'verified' &&
+      const keyVersion = integrationEncryptionKeyVersion();
+      const verificationSnapshotUnchanged =
+        existing?.keyVersion === keyVersion &&
         Object.entries(config).every(
           ([key, value]) =>
             key === 'enabled' ||
+            key === 'refundFunding' ||
             JSON.stringify(value) === JSON.stringify(previousConfig[key as keyof PublicConfig]),
         ) &&
         credentials.merchantPrivateKey === previousCredentials?.merchantPrivateKey &&
         credentials.apiV3Key === previousCredentials?.apiV3Key &&
         credentials.platformPublicKey === previousCredentials?.platformPublicKey &&
         credentials.appSecret === previousCredentials?.appSecret;
+      const preserveVerification =
+        existing?.status === 'verified' && verificationSnapshotUnchanged;
       const nextStatus = preserveVerification ? 'verified' : 'configured';
       const lastVerifiedAt = preserveVerification ? existing.lastVerifiedAt : null;
       const encryptedPayload: Record<string, string> = {
@@ -756,13 +760,13 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
       if (credentials.appSecret) {
         encryptedPayload.appSecret = credentials.appSecret;
       }
-      const encryptedCredentials = encryptIntegrationCredentials(
-        organizationId,
-        PROVIDER,
-        encryptedPayload,
-      );
+      // Keep the credential snapshot stable across funding and collection-policy edits.
+      const encryptedCredentials =
+        verificationSnapshotUnchanged && existing?.encryptedCredentials
+          ? existing.encryptedCredentials
+          : encryptIntegrationCredentials(organizationId, PROVIDER, encryptedPayload);
       const now = new Date();
-      await tx
+      const [saved] = await tx
         .insert(organizationIntegrations)
         .values({
           organizationId,
@@ -770,7 +774,7 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
           status: nextStatus,
           config,
           encryptedCredentials,
-          keyVersion: integrationEncryptionKeyVersion(),
+          keyVersion,
           lastVerifiedAt,
           lastError: null,
           updatedBy: actorId,
@@ -779,16 +783,24 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
         .onConflictDoUpdate({
           target: [organizationIntegrations.organizationId, organizationIntegrations.provider],
           set: {
-            status: nextStatus,
+            // Preserve the latest result, including failures, across policy-only saves.
+            status: verificationSnapshotUnchanged
+              ? sql`${organizationIntegrations.status}`
+              : nextStatus,
             config,
             encryptedCredentials,
-            keyVersion: integrationEncryptionKeyVersion(),
-            lastVerifiedAt,
-            lastError: null,
+            keyVersion,
+            lastVerifiedAt: verificationSnapshotUnchanged
+              ? sql`${organizationIntegrations.lastVerifiedAt}`
+              : lastVerifiedAt,
+            lastError: verificationSnapshotUnchanged
+              ? sql`${organizationIntegrations.lastError}`
+              : null,
             updatedBy: actorId,
             updatedAt: now,
           },
-        });
+        })
+        .returning({ status: organizationIntegrations.status });
       await tx.insert(auditLogs).values({
         organizationId,
         actorId,
@@ -796,7 +808,7 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
         resourceType: 'organization_integration',
         resourceId: existing?.id ?? organizationId,
         before: existing ? { status: existing.status, config: safeConfig(existing.config) } : null,
-        after: { status: nextStatus, config },
+        after: { status: saved!.status, config },
         traceId: crypto.randomUUID(),
       });
     });
@@ -1389,6 +1401,25 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
       allowDisabled: true,
     });
     const verifiedAt = new Date();
+    // A funding edit keeps this proof valid; changed credentials or a newer result invalidate it.
+    const verificationSnapshot = and(
+      eq(organizationIntegrations.id, row.id),
+      eq(organizationIntegrations.organizationId, organizationId),
+      eq(organizationIntegrations.provider, PROVIDER),
+      or(
+        eq(organizationIntegrations.config, row.config),
+        sql`(${organizationIntegrations.config} - 'enabled' - 'refundFunding') =
+          (${JSON.stringify(config)}::jsonb - 'enabled' - 'refundFunding')`,
+      ),
+      row.encryptedCredentials
+        ? eq(organizationIntegrations.encryptedCredentials, row.encryptedCredentials)
+        : isNull(organizationIntegrations.encryptedCredentials),
+      eq(organizationIntegrations.keyVersion, row.keyVersion),
+      or(
+        isNull(organizationIntegrations.lastVerifiedAt),
+        lt(organizationIntegrations.lastVerifiedAt, verifiedAt),
+      ),
+    );
     try {
       const echoMessage = `tokems-${organizationId}-${verifiedAt.getTime()}`;
       const result = await this.request(
@@ -1414,19 +1445,7 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
           updatedBy: actorId,
           updatedAt: verifiedAt,
         })
-        .where(
-          and(
-            eq(organizationIntegrations.id, row.id),
-            eq(organizationIntegrations.organizationId, organizationId),
-            eq(organizationIntegrations.provider, PROVIDER),
-            eq(organizationIntegrations.status, row.status),
-            eq(organizationIntegrations.config, row.config),
-            row.encryptedCredentials
-              ? eq(organizationIntegrations.encryptedCredentials, row.encryptedCredentials)
-              : isNull(organizationIntegrations.encryptedCredentials),
-            eq(organizationIntegrations.keyVersion, row.keyVersion),
-          ),
-        )
+        .where(verificationSnapshot)
         .returning({ id: organizationIntegrations.id });
       if (!verified) {
         throw new DomainError(
@@ -1452,19 +1471,7 @@ export class WeChatPayService implements OnApplicationBootstrap, OnModuleDestroy
           updatedBy: actorId,
           updatedAt: verifiedAt,
         })
-        .where(
-          and(
-            eq(organizationIntegrations.id, row.id),
-            eq(organizationIntegrations.organizationId, organizationId),
-            eq(organizationIntegrations.provider, PROVIDER),
-            eq(organizationIntegrations.status, row.status),
-            eq(organizationIntegrations.config, row.config),
-            row.encryptedCredentials
-              ? eq(organizationIntegrations.encryptedCredentials, row.encryptedCredentials)
-              : isNull(organizationIntegrations.encryptedCredentials),
-            eq(organizationIntegrations.keyVersion, row.keyVersion),
-          ),
-        );
+        .where(verificationSnapshot);
       return {
         ok: false,
         status: 'error',

--- a/apps/api/src/common/wechat-refund-configuration-race.integration.test.ts
+++ b/apps/api/src/common/wechat-refund-configuration-race.integration.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'node:crypto';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
+  auditLogs,
   customerUsers,
   events,
   orders,
@@ -227,6 +228,477 @@ persistent('WeChat configuration changes and refund creation serialize in Postgr
       policy,
     };
   }
+
+  it.each([
+    [undefined, 'default'],
+    [null, 'default'],
+    ['default', 'available'],
+    ['available', null],
+  ] as const)(
+    'preserves payment verification when refund funding changes from %s to %s',
+    async (previous, next) => {
+      const f = await fixture();
+      const verifiedAt = new Date('2026-09-08T00:00:00Z');
+      await db
+        .update(organizationIntegrations)
+        .set({
+          config: { ...f.config, refundFunding: previous },
+          lastVerifiedAt: verifiedAt,
+        })
+        .where(eq(organizationIntegrations.organizationId, f.organizationId));
+      await f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+        ...f.config,
+        refundFunding: next,
+      });
+      const configuration = await f.gateway.getConfiguration(f.organizationId);
+      expect(configuration.status).toBe('verified');
+      expect(configuration.lastVerifiedAt).toBe(verifiedAt.toISOString());
+      expect(configuration.refundFunding).toBe(next);
+      const required = Reflect.get(f.gateway, 'requiredIntegration').bind(f.gateway);
+      await expect(required(f.organizationId, { requireVerified: true })).resolves.toBeDefined();
+      if (next) {
+        await expect(f.gateway.refundConfiguration(f.organizationId)).resolves.toMatchObject({
+          funding: next,
+        });
+      } else {
+        await expect(f.gateway.refundConfiguration(f.organizationId)).rejects.toMatchObject({
+          code: 'REFUND_NOT_CONFIGURED',
+        });
+      }
+    },
+  );
+
+  it.each(['configured', 'error'] as const)(
+    'keeps a %s merchant unverified after selecting refund funding',
+    async (status) => {
+      const f = await fixture();
+      await db
+        .update(organizationIntegrations)
+        .set({ status })
+        .where(eq(organizationIntegrations.organizationId, f.organizationId));
+      await f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+        ...f.config,
+        refundFunding: 'available',
+      });
+      expect((await f.gateway.getConfiguration(f.organizationId)).status).toBe(status);
+      await expect(f.gateway.refundConfiguration(f.organizationId)).rejects.toMatchObject({
+        code: 'REFUND_NOT_CONFIGURED',
+      });
+      const required = Reflect.get(f.gateway, 'requiredIntegration').bind(f.gateway);
+      await expect(required(f.organizationId, { requireVerified: true })).rejects.toThrow(
+        '尚未验证通过',
+      );
+    },
+  );
+
+  it.each([
+    'appId',
+    'mchId',
+    'merchantCertificateSerial',
+    'platformPublicKeyId',
+    'merchantPrivateKey',
+    'apiV3Key',
+    'platformPublicKey',
+    'appSecret',
+    'channels',
+    'oauthEnabled',
+  ] as const)('still requires verification when funding and %s change together', async (field) => {
+    const f = await fixture();
+    const rotated = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const changes: UpdateWeChatPayConfiguration = {
+      ...f.config,
+      appId: 'wx-changed',
+      mchId: '1900000110',
+      merchantCertificateSerial: 'CHANGED_SERIAL',
+      platformPublicKeyId: 'PUB_KEY_ID_CHANGED',
+      merchantPrivateKey: rotated.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+      apiV3Key: randomBytes(16).toString('hex'),
+      platformPublicKey: rotated.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+      appSecret: 'changed-test-app-secret',
+      channels: { native: true, jsapi: true, h5: false },
+      oauthEnabled: true,
+    };
+    await f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+      ...f.config,
+      refundFunding: 'available',
+      [field]: changes[field],
+    });
+    expect((await f.gateway.getConfiguration(f.organizationId)).status).toBe('configured');
+    const required = Reflect.get(f.gateway, 'requiredIntegration').bind(f.gateway);
+    await expect(required(f.organizationId, { requireVerified: true })).rejects.toThrow(
+      '尚未验证通过',
+    );
+    await expect(f.gateway.refundConfiguration(f.organizationId)).rejects.toMatchObject({
+      code: 'REFUND_NOT_CONFIGURED',
+    });
+  });
+
+  it('keeps queued refund instructions immutable when the funding strategy changes', async () => {
+    const f = await fixture();
+    await f.workflow.createAdmin(f.organizationId, f.orderId, f.actorId, randomUUID(), {
+      amount: 39900,
+      reason: '出资策略验收',
+    });
+    const [before] = await db.select().from(refunds).where(eq(refunds.orderId, f.orderId));
+    expect(before?.requestSnapshot).toMatchObject({
+      amount: { refund: 39900, total: 39900, currency: 'CNY' },
+    });
+    expect(before!.requestSnapshot).not.toHaveProperty('funds_account');
+    await f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+      ...f.config,
+      refundFunding: 'available',
+    });
+    const [after] = await db.select().from(refunds).where(eq(refunds.id, before!.id));
+    expect(after?.requestSnapshot).toEqual(before!.requestSnapshot);
+    expect(after?.outRefundNo).toBe(before!.outRefundNo);
+    await expect(f.gateway.refundConfiguration(f.organizationId)).resolves.toMatchObject({
+      funding: 'available',
+    });
+  });
+
+  it('rejects a stale successful verification after funding and credentials have changed', async () => {
+    const f = await fixture();
+    const inside = latch(),
+      release = latch();
+    Reflect.set(
+      f.gateway,
+      'request',
+      async (_method: string, _url: string, body: { echo_message: string }) => {
+        inside.resolve();
+        await release.promise;
+        return { echo_message: body.echo_message };
+      },
+    );
+    const verifying = f.gateway.testConnection(f.organizationId, f.actorId);
+    try {
+      await inside.promise;
+      await f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+        ...f.config,
+        refundFunding: 'available',
+        apiV3Key: randomBytes(16).toString('hex'),
+      });
+    } finally {
+      release.resolve();
+    }
+    expect(await verifying).toMatchObject({ ok: false });
+    expect((await f.gateway.getConfiguration(f.organizationId)).status).toBe('configured');
+  });
+
+  it.each([
+    ['verified', true],
+    ['verified', false],
+    ['configured', true],
+    ['configured', false],
+    ['error', true],
+    ['error', false],
+  ] as const)(
+    'uses the latest concurrent verification outcome (initial: %s, success: %s)',
+    async (initialStatus, success) => {
+      const f = await fixture();
+      await db
+        .update(organizationIntegrations)
+        .set({ status: initialStatus })
+        .where(eq(organizationIntegrations.organizationId, f.organizationId));
+      const inside = latch(),
+        release = latch();
+      const integration = Reflect.get(f.gateway, 'integration').bind(f.gateway);
+      Reflect.set(f.gateway, 'integration', async (organizationId: string, reader?: unknown) => {
+        const row = await integration(organizationId, reader);
+        if (reader) {
+          inside.resolve();
+          await release.promise;
+        }
+        return row;
+      });
+      Reflect.set(
+        f.gateway,
+        'request',
+        async (_method: string, _url: string, body: { echo_message: string }) => {
+          if (!success) throw new Error('TEST_VERIFY_FAILED');
+          return { echo_message: body.echo_message };
+        },
+      );
+      const saving = f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+        ...f.config,
+        refundFunding: 'available',
+      });
+      let verifiedAt: string | null;
+      try {
+        await inside.promise;
+        expect(await f.gateway.testConnection(f.organizationId, f.actorId)).toMatchObject({
+          ok: success,
+        });
+        const current = await f.gateway.getConfiguration(f.organizationId);
+        expect(current.status).toBe(success ? 'verified' : 'error');
+        verifiedAt = current.lastVerifiedAt;
+      } finally {
+        release.resolve();
+      }
+      const status = success ? 'verified' : 'error';
+      expect(await saving).toMatchObject({ status, lastVerifiedAt: verifiedAt });
+      const [audit] = await db
+        .select()
+        .from(auditLogs)
+        .where(eq(auditLogs.organizationId, f.organizationId));
+      expect(audit?.after).toMatchObject({ status });
+      if (!success) {
+        await expect(f.gateway.refundConfiguration(f.organizationId)).rejects.toMatchObject({
+          code: 'REFUND_NOT_CONFIGURED',
+        });
+      }
+    },
+  );
+
+  it.each([
+    ['verified', true],
+    ['verified', false],
+    ['configured', true],
+    ['configured', false],
+    ['legacy', false],
+  ] as const)(
+    'records a %s merchant verification returning after a funding save (success: %s)',
+    async (status, success) => {
+      const f = await fixture();
+      await db
+        .update(organizationIntegrations)
+        .set({
+          status: status === 'legacy' ? 'verified' : status,
+          ...(status === 'legacy'
+            ? {
+                config: {
+                  ...f.config,
+                  refundFunding: undefined,
+                  channels: undefined,
+                  oauthEnabled: undefined,
+                },
+              }
+            : {}),
+        })
+        .where(eq(organizationIntegrations.organizationId, f.organizationId));
+      const inside = latch(),
+        release = latch();
+      Reflect.set(
+        f.gateway,
+        'request',
+        async (_method: string, _url: string, body: { echo_message: string }) => {
+          inside.resolve();
+          await release.promise;
+          if (!success) throw new Error('TEST_VERIFY_FAILED_AFTER_FUNDING_SAVE');
+          return { echo_message: body.echo_message };
+        },
+      );
+      const verifying = f.gateway.testConnection(f.organizationId, f.actorId);
+      try {
+        await inside.promise;
+        await f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+          ...f.config,
+          refundFunding: 'available',
+        });
+      } finally {
+        release.resolve();
+      }
+      const result = await verifying;
+      expect(result.ok).toBe(success);
+      expect(await f.gateway.getConfiguration(f.organizationId)).toMatchObject({
+        status: success ? 'verified' : 'error',
+        refundFunding: 'available',
+        lastVerifiedAt: result.verifiedAt,
+        lastError: success ? null : 'TEST_VERIFY_FAILED_AFTER_FUNDING_SAVE',
+      });
+      if (!success) {
+        await expect(f.gateway.refundConfiguration(f.organizationId)).rejects.toMatchObject({
+          code: 'REFUND_NOT_CONFIGURED',
+        });
+      }
+    },
+  );
+
+  it.each([true, false])(
+    'keeps a newer verification result after a funding save (older success: %s)',
+    async (success) => {
+      const f = await fixture();
+      const inside = latch(),
+        release = latch();
+      let calls = 0;
+      Reflect.set(
+        f.gateway,
+        'request',
+        async (_method: string, _url: string, body: { echo_message: string }) => {
+          if (++calls === 1) {
+            inside.resolve();
+            await release.promise;
+            if (!success) throw new Error('STALE_VERIFY_FAILED');
+          }
+          return { echo_message: body.echo_message };
+        },
+      );
+      vi.useFakeTimers({ toFake: ['Date'] });
+      const now = Date.now();
+      const older = f.gateway.testConnection(f.organizationId, f.actorId);
+      try {
+        await inside.promise;
+        await f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+          ...f.config,
+          refundFunding: 'available',
+        });
+        vi.setSystemTime(now + 1_000);
+        const latest = await f.gateway.testConnection(f.organizationId, f.actorId);
+        expect(latest.ok).toBe(true);
+        release.resolve();
+        expect(await older).toMatchObject({ ok: false });
+        expect(await f.gateway.getConfiguration(f.organizationId)).toMatchObject({
+          status: 'verified',
+          lastVerifiedAt: latest.verifiedAt,
+          lastError: null,
+          refundFunding: 'available',
+        });
+      } finally {
+        release.resolve();
+        await older;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([
+    [true, false],
+    [false, true],
+    [true, true],
+    [false, false],
+  ])(
+    'records the newer verification after the older result (older: %s, newer: %s)',
+    async (olderSuccess, newerSuccess) => {
+      const f = await fixture();
+      const firstStarted = latch(),
+        secondStarted = latch(),
+        releaseFirst = latch(),
+        releaseSecond = latch();
+      let calls = 0;
+      Reflect.set(
+        f.gateway,
+        'request',
+        async (_method: string, _url: string, body: { echo_message: string }) => {
+          const first = ++calls === 1;
+          (first ? firstStarted : secondStarted).resolve();
+          await (first ? releaseFirst : releaseSecond).promise;
+          if (!(first ? olderSuccess : newerSuccess)) throw new Error('TEST_ORDERED_VERIFY_FAILED');
+          return { echo_message: body.echo_message };
+        },
+      );
+      vi.useFakeTimers({ toFake: ['Date'] });
+      const now = Date.now();
+      const older = f.gateway.testConnection(f.organizationId, f.actorId);
+      let newer: ReturnType<typeof f.gateway.testConnection> | undefined;
+      try {
+        await firstStarted.promise;
+        vi.setSystemTime(now + 1_000);
+        newer = f.gateway.testConnection(f.organizationId, f.actorId);
+        await secondStarted.promise;
+        releaseFirst.resolve();
+        expect(await older).toMatchObject({ ok: olderSuccess });
+        releaseSecond.resolve();
+        const result = await newer;
+        expect(result.ok).toBe(newerSuccess);
+        expect(await f.gateway.getConfiguration(f.organizationId)).toMatchObject({
+          status: newerSuccess ? 'verified' : 'error',
+          lastVerifiedAt: result.verifiedAt,
+          lastError: newerSuccess ? null : 'TEST_ORDERED_VERIFY_FAILED',
+        });
+      } finally {
+        releaseFirst.resolve();
+        releaseSecond.resolve();
+        await Promise.all([older, newer]);
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it('does not restore an older verification after a failed verification and a funding save', async () => {
+    const f = await fixture();
+    await db
+      .update(organizationIntegrations)
+      .set({ status: 'configured' })
+      .where(eq(organizationIntegrations.organizationId, f.organizationId));
+    const inside = latch(),
+      release = latch();
+    let calls = 0;
+    Reflect.set(
+      f.gateway,
+      'request',
+      async (_method: string, _url: string, body: { echo_message: string }) => {
+        if (++calls > 1) throw new Error('NEWER_VERIFY_FAILED');
+        inside.resolve();
+        await release.promise;
+        return { echo_message: body.echo_message };
+      },
+    );
+    const older = f.gateway.testConnection(f.organizationId, f.actorId);
+    try {
+      await inside.promise;
+      const latest = await f.gateway.testConnection(f.organizationId, f.actorId);
+      expect(latest.ok).toBe(false);
+      await f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+        ...f.config,
+        refundFunding: 'available',
+      });
+      release.resolve();
+      expect(await older).toMatchObject({ ok: false });
+      expect(await f.gateway.getConfiguration(f.organizationId)).toMatchObject({
+        status: 'error',
+        lastVerifiedAt: latest.verifiedAt,
+        lastError: 'NEWER_VERIFY_FAILED',
+        refundFunding: 'available',
+      });
+      await expect(f.gateway.refundConfiguration(f.organizationId)).rejects.toMatchObject({
+        code: 'REFUND_NOT_CONFIGURED',
+      });
+    } finally {
+      release.resolve();
+      await older;
+    }
+  });
+
+  it('requires a new verification when a funding save migrates the encryption key version', async () => {
+    const f = await fixture();
+    const previousKey = process.env.INTEGRATION_ENCRYPTION_KEY!;
+    const previousKeys = process.env.INTEGRATION_ENCRYPTION_PREVIOUS_KEYS;
+    const inside = latch(),
+      release = latch();
+    Reflect.set(f.gateway, 'request', async () => {
+      inside.resolve();
+      await release.promise;
+      throw new Error('OLD_ENCRYPTION_SNAPSHOT_VERIFY_FAILED');
+    });
+    const verifying = f.gateway.testConnection(f.organizationId, f.actorId);
+    try {
+      await inside.promise;
+      vi.stubEnv('INTEGRATION_ENCRYPTION_KEY', randomBytes(32).toString('base64'));
+      vi.stubEnv('INTEGRATION_ENCRYPTION_KEY_VERSION', '2');
+      vi.stubEnv('INTEGRATION_ENCRYPTION_PREVIOUS_KEYS', JSON.stringify({ 1: previousKey }));
+      const saved = await f.gateway.updateConfiguration(f.organizationId, f.actorId, {
+        ...f.config,
+        refundFunding: 'available',
+      });
+      release.resolve();
+      expect(await verifying).toMatchObject({ ok: false });
+      expect(saved).toMatchObject({ status: 'configured', refundFunding: 'available' });
+      expect((await f.gateway.getConfiguration(f.organizationId)).status).toBe('configured');
+      const [current] = await db
+        .select()
+        .from(organizationIntegrations)
+        .where(eq(organizationIntegrations.organizationId, f.organizationId));
+      expect(current?.keyVersion).toBe(2);
+      await expect(f.gateway.refundConfiguration(f.organizationId)).rejects.toMatchObject({
+        code: 'REFUND_NOT_CONFIGURED',
+      });
+    } finally {
+      release.resolve();
+      await verifying;
+      vi.stubEnv('INTEGRATION_ENCRYPTION_KEY', previousKey);
+      vi.stubEnv('INTEGRATION_ENCRYPTION_KEY_VERSION', '1');
+      vi.stubEnv('INTEGRATION_ENCRYPTION_PREVIOUS_KEYS', previousKeys);
+    }
+  });
 
   it('preserves verified credentials when disabling new payments and rejects an unverified key change', async () => {
     const f = await fixture();

--- a/docs/generated/project-inventory.json
+++ b/docs/generated/project-inventory.json
@@ -7,5 +7,5 @@
   "databaseTables": 83,
   "apiControllers": 35,
   "apiOperations": 289,
-  "testFiles": 186
+  "testFiles": 187
 }

--- a/packages/security/src/index.test.ts
+++ b/packages/security/src/index.test.ts
@@ -24,8 +24,12 @@ describe('ticket code security contract', () => {
     () => {
       for (let index = 0; index < 100_000; index += 1) {
         const code = createTicketCode();
-        expect(isStrictTicketCode(code)).toBe(true);
-        expect(isReadableTicketCode(code)).toBe(true);
+        if (!isStrictTicketCode(code)) {
+          expect.fail(`Generated ticket code violates the strict contract: ${code}`);
+        }
+        if (!isReadableTicketCode(code)) {
+          expect.fail(`Generated ticket code violates the readable contract: ${code}`);
+        }
       }
     },
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3028,6 +3028,9 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-select@6.0.0:
+    resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
+
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
@@ -3038,6 +3041,10 @@ packages:
 
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  css-what@7.0.0:
+    resolution: {integrity: sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==}
     engines: {node: '>= 6'}
 
   cssesc@3.0.0:
@@ -5270,8 +5277,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svgo@4.0.2:
-    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
+  svgo@4.1.0:
+    resolution: {integrity: sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -8729,6 +8736,14 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-select@6.0.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 7.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
@@ -8740,6 +8755,8 @@ snapshots:
       source-map-js: 1.2.1
 
   css-what@6.2.2: {}
+
+  css-what@7.0.0: {}
 
   cssesc@3.0.0: {}
 
@@ -10661,7 +10678,7 @@ snapshots:
     dependencies:
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
-      svgo: 4.0.2
+      svgo: 4.1.0
 
   postcss-unique-selectors@8.0.1(postcss@8.5.26):
     dependencies:
@@ -11181,12 +11198,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svgo@4.0.2:
+  svgo@4.1.0:
     dependencies:
       commander: 11.1.0
-      css-select: 5.2.2
+      css-select: 6.0.0
       css-tree: 3.2.1
-      css-what: 6.2.2
+      css-what: 7.0.0
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.1


### PR DESCRIPTION
## What changed

商户已通过验证时，退款入口仍会因缺少退款出资账户而无法开启；原提示没有区分具体原因，补选账户还会触发重复商户验证。本次将缺少出资账户、商户验证未通过等阻塞原因分别展示，并提供直达退款账户设置的链接。

- 仅修改退款出资账户或收款开关时，保留当前商户验证状态；保存后仅在服务端要求时重新验证。
- 保存事务保留实时验证结果与错误信息，按验证开始时间处理并发结果，防止迟到结果覆盖新状态。凭据或加密密钥版本变更仍要求重新验证。
- 补充设置界面和并发回归测试，覆盖保存与验证交错、失败结果保留、凭据更新及密钥版本变化。
- 将 Nuxt 构建依赖链中的 SVGO 从 4.0.2 更新至 4.1.0，并更新其所需的选择器依赖，修复阻断 CI 的 [GHSA-w27v-7q3p-w38r](https://github.com/advisories/GHSA-w27v-7q3p-w38r) 和 [GHSA-4vpr-x523-8j87](https://github.com/advisories/GHSA-4vpr-x523-8j87)。锁文件保留其他依赖的版本。
- 优化票码安全抽样测试：保持 10 万个样本、严格格式和历史可读性两项校验，在发现无效票码时立即报告失败，消除 20 万次成功断言的开销，避免 CI 在 20 秒阈值附近超时。

## Verification

- 隔离工作树执行 `env -u DATABASE_URL pnpm check` 通过，涵盖规范文件校验、lint、类型检查、测试、接口契约、构建和生成清单。未变更包复用 Turbo 缓存；数据库集成测试另行验证。
- 使用独立临时 PostgreSQL 执行支付及退款专项：6 个文件、136 项测试通过；本轮 Review 新增 17 项并发回归。
- 设置界面桌面与移动端验证通过，包含阻塞原因、锚点定位、保存账户后保留验证状态及返回开启退款。
- `pnpm canonical:check` 与 Git pre-push 门禁通过；7 个提交文件与最终审查副本的 SHA-256 一致。
- 依赖更新后 `pnpm install --frozen-lockfile` 通过，`pnpm audit --registry=https://registry.npmjs.org` 从 2 条漏洞降至 0 条。
- 票码测试优化后，33 项安全测试通过；分别注入严格格式校验失败和可读性校验失败，优化后的抽样测试均正确失败。本地整组测试从 1.12 秒降至 0.31 秒。
- 安全、组合、级联及滥用路径审查已完成，已确认的问题已修复。

## Risk and rollout

无数据库迁移或接口结构变更。SVGO 升级包含更严格的 XML 校验和选择器更新，现有资源由前端构建与 CI 视觉流程验证。管理员仍需确认并选择退款出资账户后才能开启退款；已创建退款的执行快照保持不变。本 PR 不修改生产支付配置或触发真实退款。生产发布按现有 Runbook 单独执行。

## Checklist

- [x] Tests cover the changed behavior.
- [x] Documentation and examples match the implementation.
- [x] Organization isolation and authorization remain enforced.
- [x] No secrets, private data, or generated local artifacts are included.
- [x] User-facing copy is ready for localization.
