### PR TITLE
feat(admin): 增加退款订单数和退款金额统计

### DIFF
--- a/apps/admin/src/composables/dashboard-trend-state.test.ts
+++ b/apps/admin/src/composables/dashboard-trend-state.test.ts
@@ -21,6 +21,8 @@ const dashboardForRange = (from: string, to: string, value = 1): AdminDashboard 
       confirmedAttendees: 1,
       purchasers: 1,
       revenue: 100,
+      refundedOrders: 0,
+      refundedAmount: 0,
       checkedIn: 0,
       conversionRate: 100,
       pendingReview: 0,

--- a/apps/admin/src/views/DashboardView.vue
+++ b/apps/admin/src/views/DashboardView.vue
@@ -28,8 +28,8 @@ const {
   selectTrendPreset,
   applyCustomTrend,
 } = createDashboardTrendState((query) => conferenceApi.getDashboard(query));
-const money = (amount = 0) =>
-  `¥${(amount / 100).toLocaleString('zh-CN', { maximumFractionDigits: 0 })}`;
+const money = (amount = 0, maximumFractionDigits = 0) =>
+  `¥${(amount / 100).toLocaleString('zh-CN', { maximumFractionDigits })}`;
 const trendTotal = computed(() =>
   (dashboard.value?.registrationTrend ?? []).reduce((sum, item) => sum + item.value, 0),
 );
@@ -277,6 +277,24 @@ onMounted(async () => {
           <span class="delta neutral">{{
             pendingInvoiceCount === null ? '暂不可用' : '项待处理'
           }}</span>
+        </div>
+      </article>
+      <article class="admin-metric">
+        <span>退款订单数</span>
+        <div class="admin-metric-value">
+          <strong>{{ dashboard.metrics.refundedOrders?.toLocaleString() ?? '—' }}</strong>
+          <span class="delta neutral">已成功退款</span>
+        </div>
+      </article>
+      <article class="admin-metric">
+        <span>退款金额</span>
+        <div class="admin-metric-value">
+          <strong class="metric-money">{{
+            dashboard.metrics.refundedAmount == null
+              ? '—'
+              : money(dashboard.metrics.refundedAmount, 2)
+          }}</strong>
+          <span class="delta neutral">累计已退</span>
         </div>
       </article>
     </section>

--- a/apps/api/src/common/conference.repository.test.ts
+++ b/apps/api/src/common/conference.repository.test.ts
@@ -1062,6 +1062,8 @@ describe('ConferenceRepository in-memory operational loop', () => {
       paidSeats: 6,
       confirmedAttendees: 6,
       purchasers: 6,
+      refundedOrders: 0,
+      refundedAmount: 0,
       conversionRate: 60,
     });
     expect(dashboard.metrics.revenue).toBeGreaterThan(0);

--- a/apps/api/src/common/conference.repository.ts
+++ b/apps/api/src/common/conference.repository.ts
@@ -5464,6 +5464,7 @@ export class ConferenceRepository {
       const paidOrders = orderRows.filter((order) =>
         ['paid', 'partially_refunded'].includes(order.status),
       );
+      const refundedOrders = orderRows.filter((order) => order.status === 'refunded');
       const paidRegistrationIds = new Set(
         paidOrders
           .filter((order) => {
@@ -5500,6 +5501,8 @@ export class ConferenceRepository {
           confirmedAttendees,
           purchasers: purchaserKeys.size,
           revenue: paidOrders.reduce((total, order) => total + order.amount, 0),
+          refundedOrders: refundedOrders.length,
+          refundedAmount: refundedOrders.reduce((total, order) => total + order.amount, 0),
           checkedIn: this.memory.checkins.size,
           conversionRate: registrationRows.length
             ? Number(((paidRegistrationIds.size / registrationRows.length) * 100).toFixed(1))
@@ -5536,27 +5539,28 @@ export class ConferenceRepository {
         HttpStatus.NOT_FOUND,
       );
     }
-    const [[registrationMetric], [orderMetric], [checkinMetric], ticketRows] = await Promise.all([
-      db
-        .select({
-          registrations: count(),
-          activeSubmitted: sql<number>`count(*) filter (where ${registrations.status} in ('pending_review', 'pending_payment', 'confirmed', 'checked_in', 'completed'))::int`,
-          confirmedAttendees: sql<number>`count(*) filter (where ${registrations.status} in ('confirmed', 'checked_in', 'completed'))::int`,
-          pendingReview: sql<number>`count(*) filter (where ${registrations.status} = 'pending_review')::int`,
-        })
-        .from(registrations)
-        .where(
-          and(
-            eq(registrations.organizationId, organizationId),
-            eq(registrations.eventId, eventId),
-            isNull(registrations.supersededAt),
+    const [[registrationMetric], [orderMetric], [refundMetric], [checkinMetric], ticketRows] =
+      await Promise.all([
+        db
+          .select({
+            registrations: count(),
+            activeSubmitted: sql<number>`count(*) filter (where ${registrations.status} in ('pending_review', 'pending_payment', 'confirmed', 'checked_in', 'completed'))::int`,
+            confirmedAttendees: sql<number>`count(*) filter (where ${registrations.status} in ('confirmed', 'checked_in', 'completed'))::int`,
+            pendingReview: sql<number>`count(*) filter (where ${registrations.status} = 'pending_review')::int`,
+          })
+          .from(registrations)
+          .where(
+            and(
+              eq(registrations.organizationId, organizationId),
+              eq(registrations.eventId, eventId),
+              isNull(registrations.supersededAt),
+            ),
           ),
-        ),
-      db
-        .select({
-          paidOrders: sql<number>`count(*) filter (where ${orders.status} in ('paid', 'partially_refunded'))::int`,
-          paidSeats: sql<number>`count(*) filter (where ${orders.status} in ('paid', 'partially_refunded') and ${registrations.status} <> 'cancelled' and ${registrations.supersededAt} is null)::int`,
-          purchasers: sql<number>`count(distinct case
+        db
+          .select({
+            paidOrders: sql<number>`count(*) filter (where ${orders.status} in ('paid', 'partially_refunded'))::int`,
+            paidSeats: sql<number>`count(*) filter (where ${orders.status} in ('paid', 'partially_refunded') and ${registrations.status} <> 'cancelled' and ${registrations.supersededAt} is null)::int`,
+            purchasers: sql<number>`count(distinct case
               when ${orders.status} in ('paid', 'partially_refunded') then coalesce(
                 case when ${orders.purchaserCustomerUserId} is not null then 'customer:' || ${orders.purchaserCustomerUserId}::text end,
                 case when nullif(${orders.purchaserSnapshot}->>'customerUserId', '') is not null then 'customer:' || (${orders.purchaserSnapshot}->>'customerUserId') end,
@@ -5566,7 +5570,7 @@ export class ConferenceRepository {
                 'order:' || ${orders.id}::text
               )
           end)::int`,
-          revenue: sql<number>`coalesce(sum(
+            revenue: sql<number>`coalesce(sum(
               case when ${orders.status} in ('paid', 'partially_refunded', 'refunded')
                 then greatest(
                   ${orders.amount} - coalesce((
@@ -5580,20 +5584,33 @@ export class ConferenceRepository {
                 else 0
               end
           ), 0)::int`,
-        })
-        .from(orders)
-        .innerJoin(registrations, eq(registrations.id, orders.registrationId))
-        .where(and(eq(orders.organizationId, organizationId), eq(orders.eventId, eventId))),
-      db
-        .select({ value: count() })
-        .from(checkinRecords)
-        .where(and(eq(checkinRecords.eventId, eventId), eq(checkinRecords.result, 'accepted'))),
-      db
-        .select()
-        .from(ticketTypes)
-        .where(eq(ticketTypes.eventId, eventId))
-        .orderBy(asc(ticketTypes.price)),
-    ]);
+          })
+          .from(orders)
+          .innerJoin(registrations, eq(registrations.id, orders.registrationId))
+          .where(and(eq(orders.organizationId, organizationId), eq(orders.eventId, eventId))),
+        db
+          .select({
+            refundedOrders: sql<number>`count(distinct ${refunds.orderId})::int`,
+            refundedAmount: sql<number>`coalesce(sum(${refunds.amount}), 0)::int`,
+          })
+          .from(refunds)
+          .where(
+            and(
+              eq(refunds.organizationId, organizationId),
+              eq(refunds.eventId, eventId),
+              eq(refunds.status, 'succeeded'),
+            ),
+          ),
+        db
+          .select({ value: count() })
+          .from(checkinRecords)
+          .where(and(eq(checkinRecords.eventId, eventId), eq(checkinRecords.result, 'accepted'))),
+        db
+          .select()
+          .from(ticketTypes)
+          .where(eq(ticketTypes.eventId, eventId))
+          .orderBy(asc(ticketTypes.price)),
+      ]);
     const registrationTotal = Number(registrationMetric?.registrations ?? 0);
     const activeSubmitted = Number(registrationMetric?.activeSubmitted ?? 0);
     const paidSeats = Number(orderMetric?.paidSeats ?? 0);
@@ -5609,6 +5626,8 @@ export class ConferenceRepository {
         confirmedAttendees: Number(registrationMetric?.confirmedAttendees ?? 0),
         purchasers: Number(orderMetric?.purchasers ?? 0),
         revenue: Number(orderMetric?.revenue ?? 0),
+        refundedOrders: Number(refundMetric?.refundedOrders ?? 0),
+        refundedAmount: Number(refundMetric?.refundedAmount ?? 0),
         checkedIn: Number(checkinMetric?.value ?? 0),
         conversionRate: activeSubmitted
           ? Number(((paidSeats / activeSubmitted) * 100).toFixed(1))

--- a/apps/api/src/common/dashboard-metrics.integration.test.ts
+++ b/apps/api/src/common/dashboard-metrics.integration.test.ts
@@ -23,6 +23,7 @@ describePersistent('PostgreSQL dashboard metric semantics', () => {
   const purchaserTwo = randomUUID();
   const ticketTypeId = randomUUID();
   let eventId = 0;
+  let emptyEventId = 0;
 
   beforeAll(async () => {
     const db = database.db!;
@@ -49,8 +50,13 @@ describePersistent('PostgreSQL dashboard metric semantics', () => {
         address: '深圳测试地址',
         settings: {},
       })
-      .returning({ id: events.id });
+      .returning();
     eventId = event!.id;
+    const [emptyEvent] = await db
+      .insert(events)
+      .values({ ...event!, id: undefined, slug: `${event!.slug}-empty` })
+      .returning({ id: events.id });
+    emptyEventId = emptyEvent!.id;
     await db.insert(ticketTypes).values({
       id: ticketTypeId,
       organizationId,
@@ -136,10 +142,21 @@ describePersistent('PostgreSQL dashboard metric semantics', () => {
         eventId,
         orderId: orderIds[1]!,
         refundNo: `METRIC-REFUND-1-${randomUUID().slice(0, 8)}`,
-        amount: 10_000,
+        amount: 6_001,
         currency: 'CNY',
         status: 'succeeded',
         reason: '部分退款测试',
+        idempotencyKey: randomUUID(),
+      },
+      {
+        organizationId,
+        eventId,
+        orderId: orderIds[1]!,
+        refundNo: `METRIC-REFUND-REPEAT-${randomUUID().slice(0, 8)}`,
+        amount: 4_000,
+        currency: 'CNY',
+        status: 'succeeded',
+        reason: '同一订单再次部分退款',
         idempotencyKey: randomUUID(),
       },
       {
@@ -165,6 +182,19 @@ describePersistent('PostgreSQL dashboard metric semantics', () => {
         idempotencyKey: randomUUID(),
       },
     ]);
+    await db.insert(refunds).values(
+      ['pending', 'processing', 'failed', 'closed'].map((status) => ({
+        organizationId,
+        eventId,
+        orderId: orderIds[0]!,
+        refundNo: `METRIC-${status}-${randomUUID().slice(0, 8)}`,
+        amount: 8_888,
+        currency: 'CNY',
+        status,
+        reason: '未成功的退款应排除',
+        idempotencyKey: randomUUID(),
+      })),
+    );
   });
 
   afterAll(async () => {
@@ -182,10 +212,30 @@ describePersistent('PostgreSQL dashboard metric semantics', () => {
       paidSeats: 2,
       confirmedAttendees: 4,
       purchasers: 2,
-      revenue: 104_700,
+      revenue: 104_699,
+      refundedOrders: 3,
+      refundedAmount: 54_901,
       checkedIn: 0,
       conversionRate: 40,
       pendingReview: 1,
     });
+  });
+
+  it('returns zero refund metrics for another event with no refunds', async () => {
+    const dashboard = await repository.getDashboard(emptyEventId, organizationId);
+
+    expect(dashboard.metrics.refundedOrders).toBe(0);
+    expect(dashboard.metrics.refundedAmount).toBe(0);
+  });
+
+  it('keeps cumulative refunds independent of the registration trend date range', async () => {
+    const dashboard = await repository.getDashboard(eventId, organizationId, {
+      from: '2020-01-01',
+      to: '2020-01-02',
+    });
+
+    expect(dashboard.metrics.refundedOrders).toBe(3);
+    expect(dashboard.metrics.refundedAmount).toBe(54_901);
+    expect(dashboard.registrationTrend.every((day) => day.value === 0)).toBe(true);
   });
 });

--- a/packages/contracts/src/admin-dashboard-metrics.test.ts
+++ b/packages/contracts/src/admin-dashboard-metrics.test.ts
@@ -14,6 +14,8 @@ describe('admin dashboard metric contract', () => {
         confirmedAttendees: 4,
         purchasers: 2,
         revenue: 59_800,
+        refundedOrders: 2,
+        refundedAmount: 10_001,
         checkedIn: 1,
         conversionRate: 25,
         pendingReview: 2,
@@ -28,6 +30,8 @@ describe('admin dashboard metric contract', () => {
       confirmedAttendees: 4,
       purchasers: 2,
       revenue: 59_800,
+      refundedOrders: 2,
+      refundedAmount: 10_001,
     });
   });
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1567,6 +1567,8 @@ export const AdminDashboardSchema = z.object({
     confirmedAttendees: z.number().int(),
     purchasers: z.number().int(),
     revenue: z.number().int(),
+    refundedOrders: z.number().int().nonnegative(),
+    refundedAmount: z.number().int().nonnegative(),
     checkedIn: z.number().int(),
     conversionRate: z.number(),
     pendingReview: z.number().int(),


### PR DESCRIPTION
大会后台数据概览的第二行增加“退款订单数”和“退款金额”。仅累计当前组织、当前大会的成功退款，订单按订单 ID 去重，金额包含部分退款并保留分位精度。

已通过独立环境中的前后端构建、类型检查、代码检查、退款统计数据库测试，以及桌面和 375px 窄屏验证；覆盖重复退款、未成功退款、无退款大会、趋势日期切换和含分金额。规范快照检查通过。
