### PR TITLE
修复生产 V153 模板冲突并保留退款设置

### DIFF
--- a/packages/contracts/src/canonical-homepage.snapshot.json
+++ b/packages/contracts/src/canonical-homepage.snapshot.json
@@ -283,6 +283,11 @@
           }
         ],
         "locale": "zh-CN",
+        "refunds": {
+          "enabled": true,
+          "version": "seven-day-v1",
+          "windowDays": 7
+        },
         "registration": {
           "accountMode": "mobile_otp_required",
           "additionalPurchaseEnabled": false,
@@ -2956,9 +2961,9 @@
   },
   "release": {
     "activationKind": "save",
-    "changeScope": "experience",
-    "changeSummary": "更新首页设置",
-    "id": "c175a2d7-bb8a-4e0a-af97-96d2be67cd81",
+    "changeScope": "event",
+    "changeSummary": "更新大会基本信息",
+    "id": "eb666632-9310-4618-809e-14db4f743029",
     "snapshot": {
       "event": {
         "address": "广东省深圳市南山区（具体酒店待定）",
@@ -3000,6 +3005,11 @@
             }
           ],
           "locale": "zh-CN",
+          "refunds": {
+            "enabled": true,
+            "version": "seven-day-v1",
+            "windowDays": 7
+          },
           "registration": {
             "accountMode": "mobile_otp_required",
             "additionalPurchaseEnabled": false,
@@ -4555,7 +4565,7 @@
     },
     "templateKey": "editorial-blue",
     "templateVersionId": "7917ad7c-304e-43d2-822c-e5d7f86c5b26",
-    "version": 153
+    "version": 154
   },
   "schemaVersion": 1,
   "source": {

--- a/packages/database/src/canonical-seed-routes.integration.test.ts
+++ b/packages/database/src/canonical-seed-routes.integration.test.ts
@@ -75,6 +75,42 @@ describePersistent('canonical seed speaker route retention', () => {
     await new Promise<void>((resolve) => storage.close(() => resolve()));
   });
 
+  it('preserves the independent production V153 when syncing a newer canonical release', async () => {
+    // Production activated refund settings as V153 before the local logo update used V153.
+    await database!.query(
+      `insert into event_releases
+        (event_id, version, template_key, template_version_id, status, snapshot,
+         artifact_key, change_summary, change_scope, activation_kind)
+       select event_id, 153, template_key, template_version_id, status,
+         jsonb_set(snapshot, '{event,settings,refunds}',
+           '{"enabled":true,"version":"seven-day-v1","windowDays":7}'::jsonb),
+         artifact_key, 'Production V153: independent refund settings', 'event', 'save'
+       from event_releases where event_id = $1 and version = $2
+       on conflict (event_id, version) do update set
+         snapshot = excluded.snapshot, change_summary = excluded.change_summary,
+         change_scope = excluded.change_scope`,
+      [DEMO_IDS.event, CANONICAL_HOMEPAGE_SNAPSHOT.release.version],
+    );
+    const historical = await database!.query(
+      'select * from event_releases where event_id = $1 and version = 153',
+      [DEMO_IDS.event],
+    );
+    expect(historical.rows).toHaveLength(1);
+    await seed();
+    const preserved = await database!.query(
+      'select * from event_releases where event_id = $1 and version = 153',
+      [DEMO_IDS.event],
+    );
+    expect(preserved.rows).toEqual(historical.rows);
+    const active = await database!.query(
+      `select r.version from events e join event_releases r
+       on r.id::text = e.settings->>'currentReleaseId' where e.id = $1`,
+      [DEMO_IDS.event],
+    );
+    expect(active.rows[0]?.version).toBe(CANONICAL_HOMEPAGE_SNAPSHOT.release.version);
+    expect(active.rows[0]?.version).toBeGreaterThan(153);
+  }, 60_000);
+
   it('keeps deleted speakers reserved when applying a snapshot of current speakers', async () => {
     await database!.query(
       'insert into speaker_public_routes (organization_id, event_id, speaker_id, public_code) values ($1, $2, $3, $4)',


### PR DESCRIPTION
生产已将七天退款设置发布为 V153，本地 Logo 调整也使用了 V153，导致规范同步触发不可变内容冲突并进入受保护恢复状态。本次生成 V154，保留线上已开启的七天退款设置和本地 Logo 调整，供后续恢复发布使用。

新增 PostgreSQL 回归用例，验证规范同步保留独立的生产 V153，并将当前发布指向新版本。旧快照已复现原始报错；新快照在隔离环境通过 69 项数据库测试、类型检查、格式和 lint 检查。已重新导出规范及前台快照；前台派生快照内容未变，canonical:check 和 canonical:verify 均通过。
