### PR TITLE
fix: 允许已审阅的多人购票发布配置

### DIFF
--- a/docs/production-deployment-runbook.md
+++ b/docs/production-deployment-runbook.md
@@ -298,7 +298,7 @@ sudo /usr/local/sbin/tokems-deploy deploy \
 
 生产巡检、发布、宝塔面板和故障诊断禁止执行 `docker system df` 及其 `-v` 变体。磁盘门禁使用 `docker info --format '{{.DockerRootDir}}'` 定位 Docker 数据目录，再以 `df -Pk` 或 `df -h` 读取文件系统可用空间；单个镜像证据使用有界的 `docker image inspect`。出现 Docker 异常时先保存 `journalctl -u docker`、内核 OOM 日志、容器状态、进程树和 Docker socket 客户端证据，避免运行全局对象盘点命令。每次发布前同时确认 `pgrep -af 'docker system df'` 没有真实匹配项，并观察 `dockerd` RSS 保持稳定。
 
-标准单命令发布拒绝 `docker-compose.yml` 变化。数据库、缓存、对象存储、卷、端口和服务拓扑变更进入单独评审的基础设施维护窗口。
+标准单命令发布拒绝 `docker-compose.yml` 的基础设施变化。当前只允许一项已评审的应用配置增量：在 API 的环境配置中增加 `BATCH_PURCHASE_CREATION_ENABLED: ${BATCH_PURCHASE_CREATION_ENABLED:-true}`。门禁将目标文件与当前运行提交逐字节比较，除该行在指定位置的增加外，任何其他差异均会阻断发布；开关的默认值变化、删除、其他服务或额外环境项也不在允许范围内。数据库、缓存、对象存储、卷、端口和服务拓扑变更继续进入单独评审的基础设施维护窗口。
 
 每次标准发布都有短暂写冻结窗口：六个候选镜像拉取并验证完成后停止 API 和 Worker，持久化恢复标记，在静止写入状态重新生成最终数据库备份与业务基线，再执行迁移和可选的规范同步。语义验收期间 API 仅允许数据库读取，Worker 暂停消费。只读验收阶段公开浏览恢复；报名、支付回调、后台保存及异步任务会在窗口内失败或重试。脚本在恢复正常 API/Worker、核对持久 ready 身份和数据复验后归档恢复标记并记录成功。选择业务低峰执行，并确认支付渠道具备回调重试。
 

--- a/tooling/lib/production-deploy.test.mjs
+++ b/tooling/lib/production-deploy.test.mjs
@@ -1120,6 +1120,74 @@ for (const verifier of ['canonical_snapshot_files_match', 'verify_homepage_file'
   });
 }
 
+test('standard release scope allows only the reviewed API batch switch addition', () => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'tokems-compose-scope-'));
+  const basePath = resolve(directory, 'base.yml');
+  const targetPath = resolve(directory, 'target.yml');
+  const flag = '      BATCH_PURCHASE_CREATION_ENABLED: ${BATCH_PURCHASE_CREATION_ENABLED:-true}\n';
+  const current = readFileSync(resolve(repositoryRoot, 'docker-compose.yml'), 'utf8');
+  assert.equal(current.split(flag).length, 2);
+  const baseline = current.replace(flag, '');
+  const gate = source.slice(
+    source.indexOf('assert_standard_release_scope() {'),
+    source.indexOf('\ncanonical_repair_scope_is_compatible() {'),
+  );
+  function run(base, target, failures = {}) {
+    writeFileSync(basePath, base);
+    writeFileSync(targetPath, target);
+    return spawnSync('bash', ['-c', `
+set -Eeuo pipefail
+release_baseline_sha=baseline
+target_sha=target
+LOCK_DIR="$TEMP_DIR"
+log() { printf '%s\\n' "$*"; }
+die() { printf '%s\\n' "$*" >&2; exit 1; }
+git_as_owner() {
+  case "$1:$2" in
+    diff:--quiet) if [ "\${FAIL_DIFF:-0}" != 0 ]; then return "$FAIL_DIFF"; fi; cmp -s "$BASE" "$TARGET" ;;
+    show:baseline:docker-compose.yml) cat "$BASE"; return "\${FAIL_BASE:-0}" ;;
+    show:target:docker-compose.yml) cat "$TARGET"; return "\${FAIL_TARGET:-0}" ;;
+    *) exit 2 ;;
+  esac
+}
+${gate}
+assert_standard_release_scope
+`], { encoding: 'utf8', env: { ...process.env, BASE: basePath, TARGET: targetPath, TEMP_DIR: directory, ...failures } });
+  }
+  try {
+    for (const [name, base, target, allowed] of [
+      ['unchanged legacy compose', baseline, baseline, true],
+      ['unchanged current compose', current, current, true],
+      ['reviewed API switch', baseline, current, true],
+      ['switch default altered', baseline, current.replace('BATCH_PURCHASE_CREATION_ENABLED:-true', 'BATCH_PURCHASE_CREATION_ENABLED:-false'), false],
+      ['switch under worker', baseline, baseline.replace('  worker:\n', `  worker:\n    environment:\n${flag}`), false],
+      ['switch plus API port change', baseline, current.replace('API_PORT: 4100', 'API_PORT: 4200'), false],
+      ['switch plus volume change', baseline, current.replace('tokems-postgres', 'tokems-postgres-other'), false],
+      ['switch plus another variable', baseline, current.replace(flag, `${flag}      EXTRA_SETTING: true\n`), false],
+      ['switch plus new service', baseline, `${current}\n  unexpected-service:\n    image: example\n`, false],
+      ['switch removal', current, baseline, false],
+      ['unknown baseline layout', baseline.replace('  api:\n', '  different-api:\n'), current, false],
+      ['missing baseline', '', current, false],
+      ['missing target', baseline, '', false],
+    ]) {
+      const result = run(base, target);
+      assert.equal(result.status, allowed ? 0 : 1, `${name}: ${result.stderr}`);
+    }
+    for (const failure of [{ FAIL_DIFF: '128' }, { FAIL_BASE: '128' }, { FAIL_TARGET: '128' }]) {
+      const result = run(baseline, current, failure);
+      assert.equal(result.status, 1, `Git failure with valid output: ${JSON.stringify(failure)}`);
+    }
+    const incomplete = run(
+      baseline.slice(0, baseline.indexOf('\n  worker:\n')),
+      current.slice(0, current.indexOf('\n  worker:\n')),
+      { FAIL_BASE: '128', FAIL_TARGET: '128' },
+    );
+    assert.equal(incomplete.status, 1, 'Partial Git output cannot prove unchanged infrastructure');
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test('production network calls are bounded and infrastructure reconciliation is isolated', () => {
   assert.doesNotMatch(source, /curl\s+-f/);
   assert.match(source, /readonly -a CURL_ARGS=/);

--- a/tooling/production-deploy.sh
+++ b/tooling/production-deploy.sh
@@ -2314,9 +2314,62 @@ determine_canonical_sync() {
 }
 
 assert_standard_release_scope() {
-  if ! git_as_owner diff --quiet "$release_baseline_sha" "$target_sha" -- docker-compose.yml; then
-    die 'docker-compose.yml changed; use the reviewed infrastructure maintenance procedure for this release.'
+  local diff_status=0 scope_status=0 baseline_compose target_compose
+  git_as_owner diff --quiet "$release_baseline_sha" "$target_sha" -- docker-compose.yml || diff_status=$?
+  case "$diff_status" in
+    0) return ;;
+    1) ;;
+    *) die 'Cannot read the Compose release diff.' ;;
+  esac
+
+  baseline_compose="$(mktemp "${LOCK_DIR}/compose-baseline.XXXXXX")" || die 'Cannot prepare Compose scope verification.'
+  target_compose="$(mktemp "${LOCK_DIR}/compose-target.XXXXXX")" || {
+    rm -f -- "$baseline_compose"
+    die 'Cannot prepare Compose scope verification.'
+  }
+  if ! git_as_owner show "${release_baseline_sha}:docker-compose.yml" >"$baseline_compose" \
+    || ! git_as_owner show "${target_sha}:docker-compose.yml" >"$target_compose"; then
+    rm -f -- "$baseline_compose" "$target_compose"
+    die 'Cannot read complete Compose release files.'
   fi
+
+  # Accept the reviewed API switch only when every other Compose byte is unchanged.
+  python3 - "$baseline_compose" "$target_compose" <<'PY' || scope_status=$?
+import re
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8", newline="") as handle:
+        baseline = handle.read()
+    with open(sys.argv[2], encoding="utf-8", newline="") as handle:
+        target = handle.read()
+except (OSError, UnicodeError):
+    raise SystemExit(1)
+
+api_headers = list(re.finditer(r"(?m)^  api:\n", baseline))
+if len(api_headers) != 1:
+    raise SystemExit(1)
+api = api_headers[0]
+next_service = re.search(r"(?m)^  [A-Za-z0-9_-]+:", baseline[api.end():])
+end = api.end() + next_service.start() if next_service else len(baseline)
+body = baseline[api.start():end]
+before = "    environment:\n      <<: *app-environment\n      API_PORT: 4100\n"
+after = (
+    "    environment:\n      <<: *app-environment\n"
+    "      BATCH_PURCHASE_CREATION_ENABLED: ${BATCH_PURCHASE_CREATION_ENABLED:-true}\n"
+    "      API_PORT: 4100\n"
+)
+if body.count(before) != 1:
+    raise SystemExit(1)
+expected = baseline[:api.start()] + body.replace(before, after, 1) + baseline[end:]
+raise SystemExit(0 if target == expected else 1)
+PY
+  rm -f -- "$baseline_compose" "$target_compose"
+  if [[ "$scope_status" == 0 ]]; then
+    log 'Approved API batch purchase switch addition; Compose infrastructure is unchanged.'
+    return
+  fi
+  die 'docker-compose.yml changed; use the reviewed infrastructure maintenance procedure for this release.'
 }
 
 canonical_repair_scope_is_compatible() {


### PR DESCRIPTION
PR #95 增加了 API 的多人购票创建开关。现有部署入口因 Compose 文件存在差异而拒绝从当前生产版本更新，阻塞发生在停服和数据库迁移之前。

本次允许 API 环境块在指定位置增加精确的 `BATCH_PURCHASE_CREATION_ENABLED: ${BATCH_PURCHASE_CREATION_ENABLED:-true}` 一行。比较以当前运行提交为基线，必须完整读取两个 Git 文件并确认读取成功；除此之外的每个字节保持一致。开关默认值、位置、其他环境项、端口、卷和服务改动继续阻断。同步说明了这项发布范围。

验证：

- 原发布文件变更先复现失败，修正后通过。
- 17 个范围与失败读取情景覆盖正常新增、越界变更、非空输出后 Git 失败及部分输出。
- 部署工具测试 39 项通过，1 项 Linux 专属检查在 macOS 跳过；Bash 语法、ESLint、文档清单、规范快照与凭据扫描通过。
- 独立安全复核覆盖基础设施权限范围和 Git 读取失败处理。

本 PR 为服务器发布做准备。生产切换继续要求目标合并提交的主分支 CI、完整镜像发布和服务器预检通过，再由用户在服务器运行稳定部署入口。API 写权限、Worker 就绪、恢复标记和生产业务数据按现有发布流程验收。
